### PR TITLE
[fix] 프론트엔드 리팩토링 및 버그 수정

### DIFF
--- a/apps/web/components/HireMeModal.jsx
+++ b/apps/web/components/HireMeModal.jsx
@@ -88,38 +88,21 @@ function HireMeModal({ onClose, onRequest }) {
 								</div>
 
 								<div className="mt-6 pb-4 sm:pb-1">
-									<span
+									<Button
+										title="Send Request"
 										onClick={onRequest}
-										type="submit"
-										className="px-4
-											sm:px-6
-											py-2
-											sm:py-2.5
-											text-white
-											bg-indigo-500
-											hover:bg-indigo-600
-											rounded-md
-											focus:ring-1 focus:ring-indigo-900 duration-500"
-										aria-label="Submit Request"
-									>
-										<Button title="Send Request" />
-									</span>
+										ariaLabel="Submit Request"
+									/>
 								</div>
 							</form>
 						</div>
 						<div className="modal-footer mt-2 sm:mt-0 py-5 px-8 border0-t text-right">
-							<span
+							<Button
+								title="Close"
+								variant="secondary"
 								onClick={onClose}
-								type="button"
-								className="px-4
-									sm:px-6
-									py-2 bg-gray-600 text-primary-light hover:bg-ternary-dark dark:bg-gray-200 dark:text-secondary-dark dark:hover:bg-primary-light
-									rounded-md
-									focus:ring-1 focus:ring-indigo-900 duration-500"
-								aria-label="Close Modal"
-							>
-								<Button title="Close" />
-							</span>
+								ariaLabel="Close Modal"
+							/>
 						</div>
 					</div>
 				</div>

--- a/apps/web/components/HireMeModal.jsx
+++ b/apps/web/components/HireMeModal.jsx
@@ -1,6 +1,7 @@
 import { motion } from 'framer-motion';
 import { FiX } from 'react-icons/fi';
 import Button from './reusable/Button';
+import FormInput from './reusable/FormInput';
 
 const selectOptions = [
 	'Web Application',
@@ -42,34 +43,25 @@ function HireMeModal({ onClose, onRequest }) {
 								}}
 								className="max-w-xl m-4 text-left"
 							>
-								<div className="">
-									<input
-										className="w-full px-5 py-2 border dark:border-secondary-dark rounded-md text-md bg-secondary-light dark:bg-ternary-dark text-primary-dark dark:text-ternary-light"
-										id="name"
-										name="name"
-										type="text"
-										required
-										placeholder="Name"
-										aria-label="Name"
-									/>
-								</div>
-								<div className="mt-6">
-									<input
-										className="w-full px-5 py-2 border dark:border-secondary-dark rounded-md text-md bg-secondary-light dark:bg-ternary-dark text-primary-dark dark:text-ternary-light"
-										id="email"
-										name="email"
-										type="text"
-										required
-										placeholder="Email"
-										aria-label="Email"
-									/>
-								</div>
-								<div className="mt-6">
+								<FormInput
+									inputType="text"
+									inputId="name"
+									inputName="name"
+									placeholderText="Name"
+									ariaLabelName="Name"
+								/>
+								<FormInput
+									inputType="email"
+									inputId="email"
+									inputName="email"
+									placeholderText="Email"
+									ariaLabelName="Email"
+								/>
+								<div className="font-general-regular mb-4">
 									<select
-										className="w-full px-5 py-2 border dark:border-secondary-dark rounded-md text-md bg-secondary-light dark:bg-ternary-dark text-primary-dark dark:text-ternary-light"
+										className="w-full px-5 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-ternary-dark rounded-md shadow-sm text-md"
 										id="subject"
 										name="subject"
-										type="text"
 										required
 										aria-label="Project Category"
 									>
@@ -83,10 +75,9 @@ function HireMeModal({ onClose, onRequest }) {
 										))}
 									</select>
 								</div>
-
-								<div className="mt-6">
+								<div className="font-general-regular mb-4">
 									<textarea
-										className="w-full px-5 py-2 border dark:border-secondary-dark rounded-md text-md bg-secondary-light dark:bg-ternary-dark text-primary-dark dark:text-ternary-light"
+										className="w-full px-5 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-ternary-dark rounded-md shadow-sm text-md"
 										id="message"
 										name="message"
 										cols="14"

--- a/apps/web/components/HireMeModal.jsx
+++ b/apps/web/components/HireMeModal.jsx
@@ -40,6 +40,7 @@ function HireMeModal({ onClose, onRequest }) {
 							<form
 								onSubmit={(e) => {
 									e.preventDefault();
+									onRequest();
 								}}
 								className="max-w-xl m-4 text-left"
 							>
@@ -90,7 +91,7 @@ function HireMeModal({ onClose, onRequest }) {
 								<div className="mt-6 pb-4 sm:pb-1">
 									<Button
 										title="Send Request"
-										onClick={onRequest}
+										type="submit"
 										ariaLabel="Submit Request"
 									/>
 								</div>

--- a/apps/web/components/about/AboutClientSingle.jsx
+++ b/apps/web/components/about/AboutClientSingle.jsx
@@ -6,9 +6,10 @@ function AboutClientSingle({ title, image }) {
 			<Image
 				src={image}
 				alt={title}
-				layout="responsive"
 				width={100}
 				height={50}
+				sizes="100vw"
+				style={{ width: '100%', height: 'auto' }}
 			/>
 		</div>
 	);

--- a/apps/web/components/about/AboutClients.jsx
+++ b/apps/web/components/about/AboutClients.jsx
@@ -1,17 +1,14 @@
-import { useState } from 'react';
-import { clientsData } from '../../data/clientsData';
-import { clientsHeading } from '../../data/clientsData';
+import { clientsData, clientsHeading } from '../../data/clientsData';
 import AboutClientSingle from './AboutClientSingle';
 
 function AboutClients() {
-	const [clients, setClients] = useState(clientsData);
 	return (
 		<div className="mt-10 sm:mt-20">
 			<p className="font-general-medium text-2xl sm:text-3xl  text-center text-primary-dark dark:text-primary-light">
 				{clientsHeading}
 			</p>
 			<div className="grid grid-cols-2 sm:grid-cols-4 mt-10 sm:mt-14 gap-2">
-				{clients.map((client) => (
+				{clientsData.map((client) => (
 					<AboutClientSingle
 						title={client.title}
 						image={client.img}

--- a/apps/web/components/about/AboutMeBio.jsx
+++ b/apps/web/components/about/AboutMeBio.jsx
@@ -1,9 +1,7 @@
 import Image from 'next/image';
-import { useState } from 'react';
 import { aboutMeData } from '../../data/aboutMeData';
 
 function AboutMeBio() {
-	const [aboutMe, setAboutMe] = useState(aboutMeData);
 	return (
 		<div className="block sm:flex sm:gap-10 mt-10 sm:mt-20">
 			<div className="w-full sm:w-1/4 mb-7 sm:mb-0">
@@ -17,7 +15,7 @@ function AboutMeBio() {
 			</div>
 
 			<div className="font-general-regular w-full sm:w-3/4 text-left">
-				{aboutMe.map((bio) => (
+				{aboutMeData.map((bio) => (
 					<p
 						className="mb-4 text-ternary-dark dark:text-ternary-light text-lg"
 						key={bio.id}

--- a/apps/web/components/contact/ContactForm.jsx
+++ b/apps/web/components/contact/ContactForm.jsx
@@ -114,18 +114,14 @@ function ContactForm() {
 					</div>
 
 					<div className="mt-6">
-						<span className="font-general-medium  px-7 py-4 text-white text-center font-medium tracking-wider bg-indigo-500 hover:bg-indigo-600 focus:ring-1 focus:ring-indigo-900 rounded-lg mt-6 duration-500">
-							<Button
-								title={
-									status.state === 'loading'
-										? 'Sending...'
-										: 'Send Message'
-								}
-								type="submit"
-								aria-label="Send Message"
-								disabled={status.state === 'loading'}
-							/>
-						</span>
+						<Button
+							title={status.state === 'loading' ? 'Sending...' : 'Send Message'}
+							type="submit"
+							size="lg"
+							ariaLabel="Send Message"
+							disabled={status.state === 'loading'}
+							className="tracking-wider rounded-lg"
+						/>
 					</div>
 
 					{status.state === 'success' && (

--- a/apps/web/components/contact/ContactForm.jsx
+++ b/apps/web/components/contact/ContactForm.jsx
@@ -93,9 +93,9 @@ function ContactForm() {
 						onChange={handleChange}
 					/>
 
-					<div className="mt-6">
+					<div className="font-general-regular mb-4">
 						<label
-							className="block text-lg text-primary-dark dark:text-primary-light mb-2"
+							className="block text-lg text-primary-dark dark:text-primary-light mb-1"
 							htmlFor="message"
 						>
 							Message

--- a/apps/web/components/contact/ContactForm.jsx
+++ b/apps/web/components/contact/ContactForm.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import Button from '../reusable/Button';
 import FormInput from '../reusable/FormInput';
 
-// API 요청은 Next.js rewrites를 통해 같은 origin으로 프록시됨
+// API requests are proxied to the same origin via Next.js rewrites
 const API_BASE_URL = '';
 
 function ContactForm() {
@@ -32,18 +32,18 @@ function ContactForm() {
 				const data = await res.json().catch(() => ({}));
 				const msg = Array.isArray(data?.message)
 					? data.message.join(', ')
-					: data?.message || '메시지 전송에 실패했습니다.';
+					: data?.message || 'Failed to send message.';
 				throw new Error(msg);
 			}
 			setStatus({
 				state: 'success',
-				message: '메시지가 성공적으로 전송되었습니다.',
+				message: 'Your message has been sent successfully.',
 			});
 			setForm({ name: '', email: '', subject: '', message: '' });
 		} catch (err) {
 			setStatus({
 				state: 'error',
-				message: err.message || '메시지 전송에 실패했습니다.',
+				message: err.message || 'Failed to send message.',
 			});
 		}
 	};
@@ -146,10 +146,10 @@ function ContactForm() {
 							</svg>
 							<div className="font-general-medium">
 								<p className="text-green-800 dark:text-green-200 text-base">
-									메시지가 성공적으로 전송되었습니다
+									Your message has been sent successfully
 								</p>
 								<p className="text-green-700 dark:text-green-300/80 text-sm mt-0.5">
-									빠른 시일 내에 답변드리겠습니다. 감사합니다!
+									We&apos;ll get back to you shortly. Thank you!
 								</p>
 							</div>
 						</div>
@@ -176,7 +176,7 @@ function ContactForm() {
 							</svg>
 							<div className="font-general-medium">
 								<p className="text-red-800 dark:text-red-200 text-base">
-									전송에 실패했습니다
+									Failed to send
 								</p>
 								<p className="text-red-700 dark:text-red-300/80 text-sm mt-0.5">
 									{status.message}

--- a/apps/web/components/projects/ProjectSingle.jsx
+++ b/apps/web/components/projects/ProjectSingle.jsx
@@ -2,9 +2,7 @@ import { motion } from 'framer-motion';
 import Image from 'next/image';
 import Link from 'next/link';
 
-const imageStyle = { maxWidth: '100%', height: 'auto' };
-
-const ProjectSingle = (props) => {
+const ProjectSingle = ({ url, img, title, category }) => {
 	return (
 		<motion.div
 			initial={false}
@@ -17,16 +15,16 @@ const ProjectSingle = (props) => {
 		>
 			<Link
 				href="/projects/[url]"
-				as={'/projects/' + props.url}
-				aria-label="Single Project"
+				as={`/projects/${url}`}
+				aria-label={title}
 				passHref
 			>
 				<div className="rounded-xl shadow-lg hover:shadow-xl cursor-pointer mb-10 sm:mb-0 bg-secondary-light dark:bg-ternary-dark">
 					<div>
 						<Image
-							src={props.img}
+							src={img}
 							className="rounded-t-xl border-none"
-							alt="Single Project"
+							alt={title}
 							sizes="100vw"
 							style={{ width: '100%', height: 'auto' }}
 							width={100}
@@ -35,11 +33,13 @@ const ProjectSingle = (props) => {
 					</div>
 					<div className="text-center px-4 py-6">
 						<p className="font-general-medium text-xl md:text-2xl text-ternary-dark dark:text-ternary-light mb-2">
-							{props.title}
+							{title}
 						</p>
-						<span className="text-lg text-ternary-dark dark:text-ternary-light">
-							{props.category}
-						</span>
+						{category && (
+							<span className="text-lg text-ternary-dark dark:text-ternary-light">
+								{category}
+							</span>
+						)}
 					</div>
 				</div>
 			</Link>

--- a/apps/web/components/projects/ProjectsGrid.jsx
+++ b/apps/web/components/projects/ProjectsGrid.jsx
@@ -78,7 +78,7 @@ function ProjectsGrid({ projects = [] }) {
 								setSearchProject(e.target.value);
 							}}
 							className="
-                                ont-general-medium 
+                                font-general-medium
                                 pl-3
                                 pr-1
                                 sm:px-4

--- a/apps/web/components/projects/ProjectsGrid.jsx
+++ b/apps/web/components/projects/ProjectsGrid.jsx
@@ -109,11 +109,11 @@ function ProjectsGrid({ projects = [] }) {
 
 			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 mt-6 sm:gap-5">
 				{selectProject
-					? selectProjectsByCategory.map((project, index) => {
-							return <ProjectSingle key={index} {...project} />;
-					  })
-					: projects.map((project, index) => (
-							<ProjectSingle key={index} {...project} />
+					? selectProjectsByCategory.map((project) => (
+							<ProjectSingle key={project.id ?? project.url} {...project} />
+					  ))
+					: projects.map((project) => (
+							<ProjectSingle key={project.id ?? project.url} {...project} />
 					  ))}
 			</div>
 		</section>

--- a/apps/web/components/projects/RelatedProjects.jsx
+++ b/apps/web/components/projects/RelatedProjects.jsx
@@ -1,5 +1,4 @@
-import Image from 'next/image';
-import Link from 'next/link';
+import ProjectSingle from './ProjectSingle';
 
 function RelatedProjects({ projects = [] }) {
 	if (projects.length === 0) return null;
@@ -12,30 +11,7 @@ function RelatedProjects({ projects = [] }) {
 
 			<div className="grid grid-cols-1 sm:grid-cols-4 gap-10">
 				{projects.map((project) => (
-					<Link
-						key={project.id}
-						href="/projects/[url]"
-						as={`/projects/${project.url}`}
-						aria-label={project.title}
-						passHref
-					>
-						<div className="rounded-xl shadow-lg hover:shadow-xl cursor-pointer bg-secondary-light dark:bg-ternary-dark">
-							<Image
-								src={project.img}
-								className="rounded-t-xl"
-								width={400}
-								height={400}
-								sizes="100vw"
-								style={{ width: '100%', height: 'auto' }}
-								alt={project.title}
-							/>
-							<div className="text-center px-4 py-4">
-								<p className="font-general-medium text-lg text-ternary-dark dark:text-ternary-light">
-									{project.title}
-								</p>
-							</div>
-						</div>
-					</Link>
+					<ProjectSingle key={project.id} {...project} />
 				))}
 			</div>
 		</div>

--- a/apps/web/components/reusable/Button.jsx
+++ b/apps/web/components/reusable/Button.jsx
@@ -1,5 +1,39 @@
-function Button({ title }) {
-	return <button>{title}</button>;
+const baseStyles =
+	'font-general-medium rounded-md duration-500 focus:ring-1 focus:ring-indigo-900';
+
+const variants = {
+	primary:
+		'text-white bg-indigo-500 hover:bg-indigo-600',
+	secondary:
+		'bg-gray-600 text-primary-light hover:bg-ternary-dark dark:bg-gray-200 dark:text-secondary-dark dark:hover:bg-primary-light',
+};
+
+const sizes = {
+	md: 'px-4 sm:px-6 py-2 sm:py-2.5',
+	lg: 'px-7 py-4',
+};
+
+function Button({
+	title,
+	variant = 'primary',
+	size = 'md',
+	type = 'button',
+	onClick,
+	disabled,
+	className = '',
+	ariaLabel,
+}) {
+	return (
+		<button
+			type={type}
+			onClick={onClick}
+			disabled={disabled}
+			aria-label={ariaLabel}
+			className={`${baseStyles} ${variants[variant]} ${sizes[size]} ${className} ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+		>
+			{title}
+		</button>
+	);
 }
 
 export default Button;

--- a/apps/web/components/reusable/FormInput.jsx
+++ b/apps/web/components/reusable/FormInput.jsx
@@ -11,12 +11,14 @@ const FormInput = ({
 }) => {
 	return (
 		<div className="font-general-regular mb-4">
-			<label
-				className="block text-lg text-primary-dark dark:text-primary-light mb-1"
-				htmlFor={labelFor}
-			>
-				{inputLabel}
-			</label>
+			{inputLabel && (
+				<label
+					className="block text-lg text-primary-dark dark:text-primary-light mb-1"
+					htmlFor={labelFor}
+				>
+					{inputLabel}
+				</label>
+			)}
 			<input
 				className="w-full px-5 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-ternary-dark rounded-md shadow-sm text-md"
 				type={inputType}

--- a/apps/web/components/shared/AppBanner.jsx
+++ b/apps/web/components/shared/AppBanner.jsx
@@ -3,49 +3,35 @@ import Image from 'next/image';
 import { FiArrowDownCircle } from 'react-icons/fi';
 import useThemeSwitcher from '../../hooks/useThemeSwitcher';
 
+const fade = (delay = 0.2) => ({
+	initial: false,
+	animate: { opacity: 1 },
+	transition: { ease: 'easeInOut', duration: 0.9, delay },
+});
+
 function AppBanner() {
 	const [activeTheme, , mounted] = useThemeSwitcher();
 
 	return (
 		<motion.section
-			initial={false}
-			animate={{ opacity: 1 }}
-			transition={{ ease: 'easeInOut', duration: 0.9, delay: 0.2 }}
+			{...fade(0.2)}
 			className="flex flex-col sm:justify-between items-center sm:flex-row mt-5 md:mt-2"
 		>
 			<div className="w-full md:w-1/3 text-left">
 				<motion.h1
-					initial={false}
-					animate={{ opacity: 1 }}
-					transition={{
-						ease: 'easeInOut',
-						duration: 0.9,
-						delay: 0.1,
-					}}
+					{...fade(0.1)}
 					className="font-general-semibold text-2xl lg:text-3xl xl:text-4xl text-center sm:text-left text-ternary-dark dark:text-primary-light uppercase"
 				>
 					Hi, Iam Stoman
 				</motion.h1>
 				<motion.p
-					initial={false}
-					animate={{ opacity: 1 }}
-					transition={{
-						ease: 'easeInOut',
-						duration: 0.9,
-						delay: 0.2,
-					}}
+					{...fade(0.2)}
 					className="font-general-medium mt-4 text-lg md:text-xl lg:text-2xl xl:text-3xl text-center sm:text-left leading-normal text-gray-500 dark:text-gray-200"
 				>
 					A Full-Stack Developer & Design Enthusiast
 				</motion.p>
 				<motion.div
-					initial={false}
-					animate={{ opacity: 1 }}
-					transition={{
-						ease: 'easeInOut',
-						duration: 0.9,
-						delay: 0.3,
-					}}
+					{...fade(0.3)}
 					className="flex justify-center sm:block"
 				>
 					<a
@@ -62,9 +48,8 @@ function AppBanner() {
 				</motion.div>
 			</div>
 			<motion.div
-				initial={false}
+				{...fade(0.2)}
 				animate={{ opacity: 1, y: 0 }}
-				transition={{ ease: 'easeInOut', duration: 0.9, delay: 0.2 }}
 				className="w-full sm:w-2/3 text-right float-right mt-8 sm:mt-0"
 			>
 				<img

--- a/apps/web/components/shared/AppBanner.jsx
+++ b/apps/web/components/shared/AppBanner.jsx
@@ -52,13 +52,18 @@ function AppBanner() {
 				animate={{ opacity: 1, y: 0 }}
 				className="w-full sm:w-2/3 text-right float-right mt-8 sm:mt-0"
 			>
-				<img
+				<Image
 					src={
 						mounted && activeTheme === 'dark'
 							? '/images/developer.svg'
 							: '/images/developer-dark.svg'
 					}
 					alt="Developer"
+					width={600}
+					height={600}
+					sizes="100vw"
+					style={{ width: '100%', height: 'auto' }}
+					priority
 				/>
 			</motion.div>
 		</motion.section>

--- a/apps/web/components/shared/AppBanner.jsx
+++ b/apps/web/components/shared/AppBanner.jsx
@@ -40,7 +40,7 @@ function AppBanner() {
 						className="font-general-medium flex justify-center items-center w-36 sm:w-48 mt-12 mb-6 sm:mb-0 text-lg border border-indigo-200 dark:border-ternary-dark py-2.5 sm:py-3 shadow-lg rounded-lg bg-indigo-50 focus:ring-1 focus:ring-indigo-900 hover:bg-indigo-500 text-gray-500 hover:text-white duration-500"
 						aria-label="Download Resume"
 					>
-						<FiArrowDownCircle className="ml-0 sm:ml-1 mr-2 sm:mr-3 h-5 w-5 sn:w-6 sm:h-6 duration-100"></FiArrowDownCircle>
+						<FiArrowDownCircle className="ml-0 sm:ml-1 mr-2 sm:mr-3 h-5 w-5 sm:w-6 sm:h-6 duration-100"></FiArrowDownCircle>
 						<span className="text-sm sm:text-lg duration-100">
 							Download CV
 						</span>

--- a/apps/web/components/shared/AppFooter.jsx
+++ b/apps/web/components/shared/AppFooter.jsx
@@ -48,7 +48,7 @@ function AppFooter() {
 						{socialLinks.map((link) => (
 							<a
 								href={link.url}
-								target="__blank"
+								target="_blank"
 								key={link.id}
 								className="text-gray-400 hover:text-indigo-500 dark:hover:text-indigo-400 cursor-pointer rounded-lg bg-gray-50 dark:bg-ternary-dark hover:bg-gray-100 shadow-sm p-4 duration-300"
 							>

--- a/apps/web/components/shared/AppFooter.jsx
+++ b/apps/web/components/shared/AppFooter.jsx
@@ -49,6 +49,7 @@ function AppFooter() {
 							<a
 								href={link.url}
 								target="_blank"
+								rel="noopener noreferrer"
 								key={link.id}
 								className="text-gray-400 hover:text-indigo-500 dark:hover:text-indigo-400 cursor-pointer rounded-lg bg-gray-50 dark:bg-ternary-dark hover:bg-gray-100 shadow-sm p-4 duration-300"
 							>

--- a/apps/web/components/shared/AppFooterCopyright.jsx
+++ b/apps/web/components/shared/AppFooterCopyright.jsx
@@ -6,6 +6,7 @@ function AppFooterCopyright() {
 				<a
 					href="https://github.com/realstoman/nextjs-tailwindcss-portfolio"
 					target="_blank"
+					rel="noopener noreferrer"
 					className="hover:underline hover:text-indigo-600 dark:hover:text-indigo-300 ml-1 duration-500"
 				>
 					Next.js & Tailwind CSS Portfolio
@@ -14,6 +15,7 @@ function AppFooterCopyright() {
 				<a
 					href="https://stoman.me"
 					target="_blank"
+					rel="noopener noreferrer"
 					className="text-secondary-dark dark:text-secondary-light font-medium uppercase hover:underline hover:text-indigo-600 dark:hover:text-indigo-300 ml-1 duration-500"
 				>
 					Stoman

--- a/apps/web/components/shared/AppFooterCopyright.jsx
+++ b/apps/web/components/shared/AppFooterCopyright.jsx
@@ -5,7 +5,7 @@ function AppFooterCopyright() {
 				&copy; {new Date().getFullYear()}
 				<a
 					href="https://github.com/realstoman/nextjs-tailwindcss-portfolio"
-					target="__blank"
+					target="_blank"
 					className="hover:underline hover:text-indigo-600 dark:hover:text-indigo-300 ml-1 duration-500"
 				>
 					Next.js & Tailwind CSS Portfolio
@@ -13,7 +13,7 @@ function AppFooterCopyright() {
 				.{' '}
 				<a
 					href="https://stoman.me"
-					target="__blank"
+					target="_blank"
 					className="text-secondary-dark dark:text-secondary-light font-medium uppercase hover:underline hover:text-indigo-600 dark:hover:text-indigo-300 ml-1 duration-500"
 				>
 					Stoman

--- a/apps/web/components/shared/AppHeader.jsx
+++ b/apps/web/components/shared/AppHeader.jsx
@@ -65,21 +65,20 @@ function AppHeader() {
 						</Link>
 					</div>
 
-					{/* Theme switcher small screen */}
-					<div
-						onClick={() => setTheme(activeTheme)}
-						aria-label="Theme Switcher"
-						className="block sm:hidden ml-0 bg-primary-light dark:bg-ternary-dark p-3 shadow-sm rounded-xl cursor-pointer"
-					>
-						{mounted && activeTheme === 'dark' ? (
-							<FiMoon className="text-ternary-dark hover:text-gray-400 dark:text-ternary-light dark:hover:text-primary-light text-xl" />
-						) : (
-							<FiSun className="text-gray-200 hover:text-gray-50 text-xl" />
-						)}
-					</div>
-
-					{/* Small screen hamburger menu */}
-					<div className="sm:hidden">
+					{/* Theme switcher + hamburger menu small screen */}
+					<div className="flex items-center gap-3 sm:hidden">
+						<div
+							onClick={() => setTheme(activeTheme)}
+							aria-label="Theme Switcher"
+							className="bg-primary-light dark:bg-ternary-dark p-3 shadow-sm rounded-xl cursor-pointer"
+						>
+							{mounted && activeTheme === 'dark' ? (
+								<FiMoon className="text-ternary-dark hover:text-gray-400 dark:text-ternary-light dark:hover:text-primary-light text-xl" />
+							) : (
+								<FiSun className="text-gray-200 hover:text-gray-50 text-xl" />
+							)}
+						</div>
+						<div>
 						<button
 							onClick={toggleMenu}
 							type="button"
@@ -98,6 +97,7 @@ function AppHeader() {
 								)}
 							</svg>
 						</button>
+					</div>
 					</div>
 				</div>
 

--- a/apps/web/components/shared/AppHeader.jsx
+++ b/apps/web/components/shared/AppHeader.jsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { motion } from 'framer-motion';
 import { FiSun, FiMoon, FiX, FiMenu } from 'react-icons/fi';
 import HireMeModal from '../HireMeModal';
+import Button from '../reusable/Button';
 import logoLight from '../../public/images/logo-light.svg';
 import logoDark from '../../public/images/logo-dark.svg';
 import useThemeSwitcher from '../../hooks/useThemeSwitcher';
@@ -118,13 +119,12 @@ function AppHeader() {
 						</Link>
 					</div>
 					<div className="border-t-2 pt-3 sm:pt-0 sm:border-t-0 border-primary-light dark:border-secondary-dark">
-						<button
+						<Button
+							title="Hire Me"
 							onClick={showHireMeModal}
-							className="font-general-medium sm:hidden block text-left text-md bg-indigo-500 hover:bg-indigo-600 text-white shadow-sm rounded-sm px-4 py-2 mt-2 duration-300 w-24"
-							aria-label="Hire Me Button"
-						>
-							Hire Me
-						</button>
+							ariaLabel="Hire Me Button"
+							className="sm:hidden block text-left text-md shadow-sm rounded-sm mt-2 w-24"
+						/>
 					</div>
 				</div>
 
@@ -154,13 +154,12 @@ function AppHeader() {
 				{/* Header right section buttons */}
 				<div className="hidden sm:flex justify-between items-center flex-col md:flex-row">
 					<div className="hidden md:flex">
-						<button
+						<Button
+							title="Hire Me"
 							onClick={showHireMeModal}
-							className="text-md font-general-medium bg-indigo-500 hover:bg-indigo-600 text-white shadow-sm rounded-md px-5 py-2.5 duration-300"
-							aria-label="Hire Me Button"
-						>
-							Hire Me
-						</button>
+							ariaLabel="Hire Me Button"
+							className="text-md shadow-sm"
+						/>
 					</div>
 
 					{/* Theme switcher large screen */}

--- a/apps/web/components/shared/AppHeader.jsx
+++ b/apps/web/components/shared/AppHeader.jsx
@@ -9,6 +9,12 @@ import logoLight from '../../public/images/logo-light.svg';
 import logoDark from '../../public/images/logo-dark.svg';
 import useThemeSwitcher from '../../hooks/useThemeSwitcher';
 
+const navLinks = [
+	{ href: '/projects', label: 'Projects' },
+	{ href: '/about', label: 'About Me' },
+	{ href: '/contact', label: 'Contact' },
+];
+
 function AppHeader() {
 	const [showMenu, setShowMenu] = useState(false);
 	const [showModal, setShowModal] = useState(false);
@@ -103,21 +109,16 @@ function AppHeader() {
 							: 'hidden'
 					}
 				>
-					<div className="block text-left text-lg text-primary-dark dark:text-ternary-light hover:text-secondary-dark dark:hover:text-secondary-light  sm:mx-4 mb-2 sm:py-2">
-						<Link href="/projects" aria-label="Projects">
-							Projects
-						</Link>
-					</div>
-					<div className="block text-left text-lg text-primary-dark dark:text-ternary-light hover:text-secondary-dark dark:hover:text-secondary-light  sm:mx-4 mb-2 sm:py-2 border-t-2 pt-3 sm:pt-2 sm:border-t-0 border-primary-light dark:border-secondary-dark">
-						<Link href="/about" aria-label="About Me">
-							About Me
-						</Link>
-					</div>
-					<div className="block text-left text-lg text-primary-dark dark:text-ternary-light hover:text-secondary-dark dark:hover:text-secondary-light  sm:mx-4 mb-2 sm:py-2 border-t-2 pt-3 sm:pt-2 sm:border-t-0 border-primary-light dark:border-secondary-dark">
-						<Link href="/contact" aria-label="Contact">
-							Contact
-						</Link>
-					</div>
+					{navLinks.map((link, i) => (
+						<div
+							key={link.href}
+							className={`block text-left text-lg text-primary-dark dark:text-ternary-light hover:text-secondary-dark dark:hover:text-secondary-light sm:mx-4 mb-2 sm:py-2${i > 0 ? ' border-t-2 pt-3 sm:pt-2 sm:border-t-0 border-primary-light dark:border-secondary-dark' : ''}`}
+						>
+							<Link href={link.href} aria-label={link.label}>
+								{link.label}
+							</Link>
+						</div>
+					))}
 					<div className="border-t-2 pt-3 sm:pt-0 sm:border-t-0 border-primary-light dark:border-secondary-dark">
 						<Button
 							title="Hire Me"
@@ -130,25 +131,16 @@ function AppHeader() {
 
 				{/* Header links large screen */}
 				<div className="font-general-medium hidden m-0 sm:ml-4 mt-5 sm:mt-3 sm:flex p-5 sm:p-0 justify-center items-center shadow-lg sm:shadow-none">
-					<div
-						className="block text-left text-lg font-medium text-primary-dark dark:text-ternary-light hover:text-secondary-dark dark:hover:text-secondary-light  sm:mx-4 mb-2 sm:py-2"
-						aria-label="Projects"
-					>
-						<Link href="/projects">Projects</Link>
-					</div>
-					<div
-						className="block text-left text-lg font-medium text-primary-dark dark:text-ternary-light hover:text-secondary-dark dark:hover:text-secondary-light  sm:mx-4 mb-2 sm:py-2"
-						aria-label="About Me"
-					>
-						<Link href="/about">About Me</Link>
-					</div>
-
-					<div
-						className="block text-left text-lg font-medium text-primary-dark dark:text-ternary-light hover:text-secondary-dark dark:hover:text-secondary-light  sm:mx-4 mb-2 sm:py-2"
-						aria-label="Contact"
-					>
-						<Link href="/contact">Contact</Link>
-					</div>
+					{navLinks.map((link) => (
+						<div
+							key={link.href}
+							className="block text-left text-lg font-medium text-primary-dark dark:text-ternary-light hover:text-secondary-dark dark:hover:text-secondary-light sm:mx-4 mb-2 sm:py-2"
+						>
+							<Link href={link.href} aria-label={link.label}>
+								{link.label}
+							</Link>
+						</div>
+					))}
 				</div>
 
 				{/* Header right section buttons */}

--- a/apps/web/components/shared/AppHeader.jsx
+++ b/apps/web/components/shared/AppHeader.jsx
@@ -175,7 +175,6 @@ function AppHeader() {
 						onRequest={showHireMeModal}
 					/>
 				) : null}
-				{showModal ? showHireMeModal : null}
 			</div>
 		</motion.nav>
 	);

--- a/apps/web/components/shared/AppHeader.jsx
+++ b/apps/web/components/shared/AppHeader.jsx
@@ -30,14 +30,14 @@ function AppHeader() {
 
 	function showHireMeModal() {
 		if (!showModal) {
-			document
-				.getElementsByTagName('html')[0]
-				.classList.add('overflow-y-hidden');
+			if (typeof document !== 'undefined') {
+				document.documentElement.classList.add('overflow-y-hidden');
+			}
 			setShowModal(true);
 		} else {
-			document
-				.getElementsByTagName('html')[0]
-				.classList.remove('overflow-y-hidden');
+			if (typeof document !== 'undefined') {
+				document.documentElement.classList.remove('overflow-y-hidden');
+			}
 			setShowModal(false);
 		}
 	}

--- a/apps/web/hooks/useScrollToTop.jsx
+++ b/apps/web/hooks/useScrollToTop.jsx
@@ -28,17 +28,8 @@ function useScrollToTop() {
 	return (
 		<>
 			<FiChevronUp
-				className="scrollToTop"
+				className={`scrollToTop fixed right-12 bottom-12 h-10 w-10 p-2 rounded-full cursor-pointer bg-indigo-500 text-white shadow-lg hover:bg-indigo-600 duration-300 ${showScroll ? 'flex' : 'hidden'}`}
 				onClick={backToTop}
-				style={{
-					height: 40,
-					width: 40,
-					padding: 7,
-					borderRadius: 50,
-					right: 50,
-					bottom: 50,
-					display: showScroll ? 'flex' : 'none',
-				}}
 			/>
 		</>
 	);

--- a/apps/web/pages/about.jsx
+++ b/apps/web/pages/about.jsx
@@ -4,7 +4,7 @@ import AboutCounter from '../components/about/AboutCounter';
 import AboutMeBio from '../components/about/AboutMeBio';
 import PagesMetaHead from '../components/PagesMetaHead';
 
-function about() {
+function About() {
 	return (
 		<div>
 			<PagesMetaHead title="About Me" />
@@ -39,4 +39,4 @@ function about() {
 	);
 }
 
-export default about;
+export default About;

--- a/apps/web/pages/contact.jsx
+++ b/apps/web/pages/contact.jsx
@@ -3,7 +3,7 @@ import ContactDetails from '../components/contact/ContactDetails';
 import ContactForm from '../components/contact/ContactForm';
 import PagesMetaHead from '../components/PagesMetaHead';
 
-function contact() {
+function Contact() {
 	return (
 		<div>
 			<PagesMetaHead title="Contact" />
@@ -26,4 +26,4 @@ function contact() {
 	);
 }
 
-export default contact;
+export default Contact;

--- a/apps/web/pages/index.jsx
+++ b/apps/web/pages/index.jsx
@@ -1,7 +1,6 @@
 import Link from 'next/link';
 import PagesMetaHead from '../components/PagesMetaHead';
 import ProjectsGrid from '../components/projects/ProjectsGrid';
-import Button from '../components/reusable/Button';
 import AppBanner from '../components/shared/AppBanner';
 
 const API_BASE_URL =
@@ -17,12 +16,12 @@ export default function Home({ projects }) {
 			<ProjectsGrid projects={projects} />
 
 			<div className="mt-10 sm:mt-15 flex justify-center">
-				<Link href="/projects" aria-label="More Projects" passHref>
-					<Button
-						title="More Projects"
-						size="lg"
-						className="text-lg sm:text-xl shadow-lg hover:shadow-xl rounded-lg"
-					/>
+				<Link
+					href="/projects"
+					aria-label="More Projects"
+					className="font-general-medium px-7 py-4 text-lg sm:text-xl text-white bg-indigo-500 hover:bg-indigo-600 focus:ring-1 focus:ring-indigo-900 rounded-lg shadow-lg hover:shadow-xl duration-500"
+				>
+					More Projects
 				</Link>
 			</div>
 		</div>

--- a/apps/web/pages/index.jsx
+++ b/apps/web/pages/index.jsx
@@ -17,11 +17,13 @@ export default function Home({ projects }) {
 			<ProjectsGrid projects={projects} />
 
 			<div className="mt-10 sm:mt-15 flex justify-center">
-				<div className="font-general-medium flex items-center px-6 py-3 rounded-lg shadow-lg hover:shadow-xl bg-indigo-500 hover:bg-indigo-600 focus:ring-1 focus:ring-indigo-900 text-white text-lg sm:text-xl duration-300">
-					<Link href="/projects" aria-label="More Projects" passHref>
-						<Button title="More Projects" />
-					</Link>
-				</div>
+				<Link href="/projects" aria-label="More Projects" passHref>
+					<Button
+						title="More Projects"
+						size="lg"
+						className="text-lg sm:text-xl shadow-lg hover:shadow-xl rounded-lg"
+					/>
+				</Link>
 			</div>
 		</div>
 	);

--- a/apps/web/pages/projects/[url].jsx
+++ b/apps/web/pages/projects/[url].jsx
@@ -69,18 +69,19 @@ function ProjectSingle(props) {
 											key={info.id}
 										>
 											<span>{info.title}: </span>
-											<a
-												href="https://stoman.me"
-												className={
-													info.title === 'Website' ||
-													info.title === 'Phone'
-														? 'hover:underline hover:text-indigo-500 dark:hover:text-indigo-400 cursor-pointer duration-300'
-														: ''
-												}
-												aria-label="Project Website and Phone"
-											>
-												{info.details}
-											</a>
+											{info.title === 'Website' ? (
+												<a
+													href={info.details}
+													target="_blank"
+													rel="noopener noreferrer"
+													className="hover:underline hover:text-indigo-500 dark:hover:text-indigo-400 cursor-pointer duration-300"
+													aria-label={`${info.title}: ${info.details}`}
+												>
+													{info.details}
+												</a>
+											) : (
+												<span>{info.details}</span>
+											)}
 										</li>
 									);
 								}

--- a/apps/web/pages/projects/[url].jsx
+++ b/apps/web/pages/projects/[url].jsx
@@ -41,7 +41,6 @@ function ProjectSingle(props) {
 								src={project.img}
 								className="rounded-xl cursor-pointer shadow-lg sm:shadow-none"
 								alt={project.title}
-								key={project.id}
 								sizes="100vw"
 								style={{ width: '100%', height: 'auto' }}
 								width={100}


### PR DESCRIPTION
## 요약

- 재사용 컴포넌트(Button, FormInput) 활용도를 높이고, 중복 코드를 정리
- CRITICAL/HIGH/MEDIUM 등급의 버그 및 안티패턴 총 17건 수정
- 모든 변경사항은 빌드 통과 확인 후 개별 커밋

## 변경 내용

### 리팩토링 (7건)
- **Button**: variant/size/onClick/disabled 등 props 지원, 모든 사용처에서 `<span>` wrapper 제거
- **FormInput**: label 선택적 렌더링 지원, HireMeModal에 적용
- **RelatedProjects**: 카드 직접 구현 → ProjectSingle 컴포넌트 재사용
- **useScrollToTop**: 인라인 스타일 → Tailwind 클래스 전환
- **ContactForm**: textarea 레이아웃을 FormInput 패턴에 맞춰 통일
- **AppBanner**: framer-motion 반복 props를 fade 헬퍼 함수로 추출
- **AppHeader**: 네비게이션 링크를 navLinks 배열 기반 map으로 정리

### 버그 수정 (12건)
- **CRITICAL**: CompanyInfo 하드코딩 링크(`stoman.me`) 제거, AppHeader 함수 렌더링 버그, Image 중복 key
- **HIGH**: AppHeader SSR document 가드, ProjectsGrid key를 index→id, AboutMeBio/AboutClients 불필요 useState 제거
- **MEDIUM**: CSS 오타 3건(font, sm, _blank), about/contact PascalCase, AppBanner img→Image, deprecated layout prop 제거, ContactForm 한국어→영문 통일

## 변경 이유

- 재사용 컴포넌트가 있지만 활용되지 않아 동일 스타일이 여러 곳에 하드코딩
- SSR 환경에서 document 직접 접근, 필터링 시 index key 문제 등 런타임 버그 존재
- Next.js 13 deprecated API 사용, 오타 등 품질 이슈 정리

## 영향 범위

- [x] `apps/web`
- [ ] `apps/api`
- [ ] `packages`
- [ ] `repo` (루트 설정, 워크스페이스, 공통 설정)

## 스크린샷 / 데모

없음

## 테스트 / 확인

- [x] `npm run build` 또는 관련 빌드 확인
- [x] `npm run lint` 또는 관련 정적 검사 확인
- [x] 주요 변경 화면/기능을 로컬에서 확인

## 리뷰 포인트

- `components/reusable/Button.jsx` — variant/size 체계가 프로젝트에 적합한지
- `components/shared/AppHeader.jsx` — SSR 가드 방식, navLinks 배열 구조
- `pages/projects/[url].jsx` — CompanyInfo 링크 조건 분기 로직

## 참고 사항

- LOW 등급(데드코드 제거, useScrollToTop 네이밍 등)은 후속 작업으로 보류
- 검색 기능(ProjectsGrid 검색 input)은 별도 이슈로 관리

🤖 Generated with [Claude Code](https://claude.com/claude-code)