### PR TITLE
[chore] Self-hosted runner CD 파이프라인 구성

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: [self-hosted, portfolio]
@@ -18,4 +22,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Deploy
+        env:
+          DEPLOY_SHA: ${{ github.event.workflow_run.head_sha }}
         run: bash scripts/deploy.sh

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,13 +1,17 @@
 name: CD
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
     branches:
       - main
+    types:
+      - completed
 
 jobs:
   deploy:
     runs-on: [self-hosted, portfolio]
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,17 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, portfolio]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy
+        run: bash scripts/deploy.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,11 +2,20 @@
 set -euo pipefail
 
 PROJECT_DIR="/home/lagoon3/.openclaw/workspace/Portfolio-Project"
+DEPLOY_SHA="${DEPLOY_SHA:-}"
 
 cd "$PROJECT_DIR"
 
-echo "=== Pulling latest changes ==="
-git pull origin main
+echo "=== Fetching latest changes ==="
+git fetch origin main
+
+if [ -n "$DEPLOY_SHA" ]; then
+  echo "=== Checking out exact SHA: $DEPLOY_SHA ==="
+  git checkout "$DEPLOY_SHA"
+else
+  echo "=== Resetting to origin/main ==="
+  git reset --hard origin/main
+fi
 
 echo "=== Building and restarting containers ==="
 docker compose build --no-cache

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="/home/lagoon3/.openclaw/workspace/Portfolio-Project"
+
+cd "$PROJECT_DIR"
+
+echo "=== Pulling latest changes ==="
+git pull origin main
+
+echo "=== Building and restarting containers ==="
+docker compose build --no-cache
+docker compose up -d
+
+echo "=== Cleaning up dangling images ==="
+docker image prune -f
+
+echo "=== Deploy complete ==="
+docker compose ps


### PR DESCRIPTION
## 요약

- GitHub Actions self-hosted runner를 서버에 설치하고 CD 파이프라인 구성
- main 브랜치에 push 시 CI 통과 후 자동으로 서버에 배포

## 변경 내용

- `.github/workflows/cd.yml`: CI 성공 시 self-hosted runner에서 배포 실행 (`workflow_run` 트리거)
- `scripts/deploy.sh`: git pull → docker compose build → up -d → image prune

## 변경 이유

- 수동 배포 대신 main 머지 시 자동 배포로 전환
- CI 실패 시 배포가 진행되지 않도록 안전장치 포함

## 영향 범위

- [ ] `apps/web`
- [ ] `apps/api`
- [ ] `packages`
- [x] `repo` (루트 설정, 워크스페이스, 공통 설정)

## 스크린샷 / 데모

없음

## 테스트 / 확인

- [x] `npm run build` 또는 관련 빌드 확인
- [x] `npm run lint` 또는 관련 정적 검사 확인
- [x] Self-hosted runner 서버에서 정상 실행 확인 (Listening for Jobs)

## 리뷰 포인트

- `cd.yml` — `workflow_run` 트리거로 CI 성공 시에만 배포
- `scripts/deploy.sh` — 배포 순서 및 cleanup 로직
- Runner는 서버 재부팅 시 수동 시작 필요 (systemd 등록은 sudo 필요로 보류)

## 참고 사항

- Self-hosted runner label: `self-hosted`, `portfolio`
- Runner 경로: `/home/lagoon3/actions-runner`
- 서버 재부팅 시 runner 수동 시작: `cd ~/actions-runner && nohup ./run.sh &`

🤖 Generated with [Claude Code](https://claude.com/claude-code)