### PR TITLE
[fix] 프론트 SSR fetch 의 4xx/5xx silent fallback 패턴 정리

### DIFF
--- a/apps/web/pages/index.jsx
+++ b/apps/web/pages/index.jsx
@@ -31,13 +31,19 @@ export default function Home({ projects }) {
 export async function getServerSideProps() {
 	try {
 		const res = await fetch(`${API_BASE_URL}/api/projects`);
-		if (!res.ok) {
+		if (res.status === 404) {
+			// 프로젝트 목록 API 가 404 를 반환하는 건 비정상이지만, 배포 순서 이슈 등으로
+			// 일시적으로 발생할 수 있으므로 홈이 하드 크래시되지 않도록 빈 배열로 fallback
 			return { props: { projects: [] } };
+		}
+		if (!res.ok) {
+			// 5xx 등 비정상 응답은 시스템 장애이므로 감추지 않고 Next.js 에러 페이지로 드러낸다
+			throw new Error(`[home] projects API returned ${res.status}`);
 		}
 		const body = await res.json();
 		return { props: { projects: body?.data ?? [] } };
 	} catch (err) {
 		console.error('[home] fetch projects failed', err);
-		return { props: { projects: [] } };
+		throw err;
 	}
 }

--- a/apps/web/pages/projects/[url].jsx
+++ b/apps/web/pages/projects/[url].jsx
@@ -142,10 +142,12 @@ export async function getServerSideProps({ query }) {
 	try {
 		const res = await fetch(`${API_BASE_URL}/api/projects/${url}`);
 		if (res.status === 404) {
+			// 존재하지 않는 슬러그는 Next.js 404 로 응답
 			return { notFound: true };
 		}
 		if (!res.ok) {
-			return { notFound: true };
+			// 5xx 등 비정상 응답은 404 로 위장하지 않고 Next.js 에러 페이지로 드러낸다
+			throw new Error(`[project detail] API returned ${res.status}`);
 		}
 		const body = await res.json();
 		const project = body?.data;
@@ -153,6 +155,7 @@ export async function getServerSideProps({ query }) {
 			return { notFound: true };
 		}
 
+		// Related projects 는 보조 섹션이므로 실패해도 메인 페이지 렌더를 막지 않는다
 		let relatedProjects = [];
 		try {
 			const category = encodeURIComponent(project.category);
@@ -172,7 +175,7 @@ export async function getServerSideProps({ query }) {
 		return { props: { project, relatedProjects } };
 	} catch (err) {
 		console.error('[project detail] fetch failed', err);
-		return { notFound: true };
+		throw err;
 	}
 }
 

--- a/apps/web/pages/projects/index.jsx
+++ b/apps/web/pages/projects/index.jsx
@@ -17,14 +17,19 @@ function ProjectsIndex({ projects }) {
 export async function getServerSideProps() {
 	try {
 		const res = await fetch(`${API_BASE_URL}/api/projects`);
-		if (!res.ok) {
+		if (res.status === 404) {
+			// 목록 API 가 404 를 돌려주는 건 비정상이지만, 방어적으로 빈 배열 fallback
 			return { props: { projects: [] } };
+		}
+		if (!res.ok) {
+			// 5xx 등 비정상 응답은 시스템 장애이므로 감추지 않고 Next.js 에러 페이지로 드러낸다
+			throw new Error(`[projects] API returned ${res.status}`);
 		}
 		const body = await res.json();
 		return { props: { projects: body?.data ?? [] } };
 	} catch (err) {
 		console.error('[projects] fetch failed', err);
-		return { props: { projects: [] } };
+		throw err;
 	}
 }
 


### PR DESCRIPTION
## 요약

- 홈 / 프로젝트 목록 / 프로젝트 상세 세 페이지의 `getServerSideProps` 에서 API 장애(5xx) 또는 네트워크 오류를 조용히 빈 상태로 덮는 패턴을 걷어낸다.
- 404 는 "데이터가 없는 합법적 상태" 로 유지하고, 그 외 비정상 응답은 throw 로 드러내 Next.js 에러 페이지로 연결한다.
- About 페이지에서 먼저 적용했던 원칙(PR #16, 커밋 `95dec36`)을 나머지 SSR 경로에 동일하게 확장한다.

## 변경 내용

- 커밋 `997914f fix(web): 홈 페이지 SSR 에서 5xx 를 드러내고 silent 빈 배열 fallback 제거`
  - `apps/web/pages/index.jsx`
  - 404 → 빈 배열 fallback (방어적)
  - 5xx / 네트워크 오류 → throw
- 커밋 `0500754 fix(web): 프로젝트 목록 SSR 에서 5xx 를 드러내고 silent 빈 배열 fallback 제거`
  - `apps/web/pages/projects/index.jsx`
  - 홈과 동일 정책
- 커밋 `5e8fe09 fix(web): 프로젝트 상세 SSR 에서 5xx 를 404 로 위장하지 않도록 수정`
  - `apps/web/pages/projects/[url].jsx`
  - 404 슬러그는 `notFound: true` 유지
  - 5xx / outer catch → throw
  - Related Projects 블록은 보조 섹션이라 기존 silent fallback 유지 (주석 보강)

## 변경 이유

- 기존 구현은 백엔드 장애와 "아직 데이터가 없는 상태" 를 구분하지 않고 모두 빈 응답으로 처리해, 사용자는 "원래 이런 페이지" 로 오해하고 운영자는 장애를 늦게 인지할 수 있었다.
- About 리뷰에서 같은 문제가 지적되어 원칙이 확정됐고, 남은 3개 경로에 같은 기준을 적용해 프로젝트 전체 SSR 오류 처리 정책을 통일한다.

## 영향 범위

- [x] `apps/web`
- [ ] `apps/api`
- [ ] `packages`
- [ ] `repo`

## 스크린샷 / 데모

없음 (정상 동작 시 UI 변화 없음). 장애 시에만 Next.js 기본 500 에러 페이지가 노출.

## 테스트 / 확인

`apps/web` 에는 현재 단위 테스트 인프라가 없어, 테스트 코드 추가 대신 로컬에서 4가지 시나리오를 수동 검증했다.

| 시나리오 | `/` | `/projects` | `/projects/:slug` |
|---|---|---|---|
| happy (api 정상) | **200** | **200** | **200** |
| 존재하지 않는 슬러그 | — | — | **404** |
| api 중단 (`docker compose stop api`) | **500** | **500** | **500** |
| api 복구 후 | **200** | **200** | **200** |

- 이전 동작: 5xx 에도 `/` 와 `/projects` 는 빈 화면(HTTP 200), `/projects/:slug` 는 404 로 위장됨.
- 수정 후: 5xx 가 Next.js 에러 페이지로 연결되어 가시화됨.

## 리뷰 포인트

- 목록형 페이지에서 404 를 방어적으로 빈 배열로 fallback 하는 게 맞는지 확인. 응답 스펙상 목록 API 는 항상 200 + 빈 배열을 돌려주지만, 라우팅 실수나 배포 과도기에 404 가 나올 수 있어 크래시 방지 목적으로 유지함.
- Related Projects 블록의 silent fallback 유지 의도(보조 섹션이라 메인 페이지 렌더를 막지 않음) 가 납득되는지 확인.
- apps/web 테스트 인프라 도입은 별도 이슈 범위로 분리 제안. 이번 PR 에서는 인프라 작업을 포함하지 않았음.

## 참고 사항

- apps/web 전용 변경이라 백엔드/시드/스키마는 손대지 않았음.
- 리뷰어가 언급했던 About 의 같은 패턴은 PR #16 의 `95dec36` 커밋에서 이미 반영되어 dev 에 머지된 상태.

Closes #17