### PR TITLE
[feat] 어드민 Projects CRUD (이미지 업로드 제외) (Phase 2a)

### DIFF
--- a/apps/api/src/modules/projects/admin-projects.controller.spec.ts
+++ b/apps/api/src/modules/projects/admin-projects.controller.spec.ts
@@ -1,0 +1,88 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminProjectsController } from './admin-projects.controller';
+import { AdminProjectsService } from './admin-projects.service';
+import { UpsertProjectDto } from './dto/upsert-project.dto';
+
+const baseDto = (): UpsertProjectDto =>
+  ({
+    title: 'T',
+    url: 't',
+    category: 'Web Application',
+    thumbnailImg: '/img.jpg',
+    headerPublishDate: '2026',
+    headerTags: 'UI',
+    clientHeading: 'Client',
+    objectivesHeading: 'Goal',
+    objectivesDetails: 'details',
+    projectDetailsHeading: 'Challenge',
+    images: [],
+    companyInfo: [],
+    technologies: [],
+    details: [],
+  }) as UpsertProjectDto;
+
+describe('AdminProjectsController', () => {
+  let controller: AdminProjectsController;
+  let service: jest.Mocked<AdminProjectsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminProjectsController],
+      providers: [
+        {
+          provide: AdminProjectsService,
+          useValue: {
+            getById: jest.fn(),
+            create: jest.fn(),
+            update: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(AdminProjectsController);
+    service = module.get(AdminProjectsService);
+  });
+
+  it('getById: service.getById 결과를 위임한다', async () => {
+    const detail = { id: 1 } as never;
+    service.getById.mockResolvedValue(detail);
+
+    const result = await controller.getById(1);
+
+    expect(service.getById).toHaveBeenCalledWith(1);
+    expect(result).toBe(detail);
+  });
+
+  it('create: service.create 결과를 위임한다', async () => {
+    const dto = baseDto();
+    const detail = { id: 9 } as never;
+    service.create.mockResolvedValue(detail);
+
+    const result = await controller.create(dto);
+
+    expect(service.create).toHaveBeenCalledWith(dto);
+    expect(result).toBe(detail);
+  });
+
+  it('update: service.update(id, dto) 결과를 위임한다', async () => {
+    const dto = baseDto();
+    const detail = { id: 3 } as never;
+    service.update.mockResolvedValue(detail);
+
+    const result = await controller.update(3, dto);
+
+    expect(service.update).toHaveBeenCalledWith(3, dto);
+    expect(result).toBe(detail);
+  });
+
+  it('remove: service.remove(id) 를 호출하고 void 를 반환한다', async () => {
+    service.remove.mockResolvedValue(undefined);
+
+    const result = await controller.remove(7);
+
+    expect(service.remove).toHaveBeenCalledWith(7);
+    expect(result).toBeUndefined();
+  });
+});

--- a/apps/api/src/modules/projects/admin-projects.controller.ts
+++ b/apps/api/src/modules/projects/admin-projects.controller.ts
@@ -1,0 +1,61 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { UpsertProjectDto } from './dto/upsert-project.dto';
+import { ProjectDetailDto } from './dto/project-detail.dto';
+import { AdminProjectsService } from './admin-projects.service';
+
+@ApiTags('Admin · Projects')
+@Controller('api/admin/projects')
+@UseGuards(JwtAuthGuard)
+export class AdminProjectsController {
+  constructor(private readonly adminProjectsService: AdminProjectsService) {}
+
+  @Get(':id')
+  @ApiOperation({ summary: 'id 기반 단건 조회 (편집 프리필 용)' })
+  @ApiResponse({ status: 200, type: ProjectDetailDto })
+  @ApiResponse({ status: 404 })
+  async getById(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<ProjectDetailDto> {
+    return this.adminProjectsService.getById(id);
+  }
+
+  @Post()
+  @ApiOperation({ summary: '프로젝트 생성' })
+  @ApiResponse({ status: 201, type: ProjectDetailDto })
+  async create(@Body() dto: UpsertProjectDto): Promise<ProjectDetailDto> {
+    return this.adminProjectsService.create(dto);
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: '프로젝트 수정 (관계 자식 전체 교체)' })
+  @ApiResponse({ status: 200, type: ProjectDetailDto })
+  @ApiResponse({ status: 404 })
+  async update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpsertProjectDto,
+  ): Promise<ProjectDetailDto> {
+    return this.adminProjectsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(204)
+  @ApiOperation({ summary: '프로젝트 삭제 (연관 row CASCADE)' })
+  @ApiResponse({ status: 204 })
+  @ApiResponse({ status: 404 })
+  async remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
+    await this.adminProjectsService.remove(id);
+  }
+}

--- a/apps/api/src/modules/projects/admin-projects.service.spec.ts
+++ b/apps/api/src/modules/projects/admin-projects.service.spec.ts
@@ -1,0 +1,199 @@
+import {
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { AdminProjectsService } from './admin-projects.service';
+import { UpsertProjectDto } from './dto/upsert-project.dto';
+import { Project } from './entities/project.entity';
+
+type DSMock = jest.Mocked<
+  Pick<DataSource, 'transaction'>
+>;
+
+const baseDto = (overrides: Partial<UpsertProjectDto> = {}): UpsertProjectDto =>
+  ({
+    title: 'T',
+    url: 'new-slug',
+    category: 'Web Application',
+    thumbnailImg: '/img.jpg',
+    headerPublishDate: '2026',
+    headerTags: 'UI',
+    clientHeading: 'Client',
+    objectivesHeading: 'Goal',
+    objectivesDetails: 'details',
+    projectDetailsHeading: 'Challenge',
+    images: [{ title: 'A', img: '/a.jpg' }],
+    companyInfo: [{ title: 'Name', details: 'ACME' }],
+    technologies: [{ title: 'Stack', techs: ['Node'] }],
+    details: [{ details: '## 본문' }],
+    ...overrides,
+  }) as UpsertProjectDto;
+
+const baseProject = (overrides: Partial<Project> = {}): Project =>
+  ({
+    id: 1,
+    url: 'existing',
+    title: 'Existing',
+    category: 'Web Application',
+    thumbnailImg: '/x.jpg',
+    headerPublishDate: '2026',
+    headerTags: 'UI',
+    clientHeading: 'Client',
+    objectivesHeading: 'Goal',
+    objectivesDetails: 'd',
+    projectDetailsHeading: 'Challenge',
+    socialSharingHeading: 'Share',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    images: [],
+    companyInfo: [],
+    technologies: [],
+    details: [],
+    ...overrides,
+  }) as Project;
+
+describe('AdminProjectsService', () => {
+  let service: AdminProjectsService;
+  let projectRepo: jest.Mocked<Repository<Project>>;
+  let dataSource: DSMock;
+  let txManager: { save: jest.Mock; delete: jest.Mock; find: jest.Mock };
+
+  beforeEach(async () => {
+    txManager = { save: jest.fn(), delete: jest.fn(), find: jest.fn() };
+
+    dataSource = {
+      transaction: jest
+        .fn()
+        .mockImplementation(async (cb: (m: typeof txManager) => unknown) =>
+          cb(txManager),
+        ),
+    } as unknown as DSMock;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminProjectsService,
+        {
+          provide: getRepositoryToken(Project),
+          useValue: {
+            findOne: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+        { provide: DataSource, useValue: dataSource },
+      ],
+    }).compile();
+
+    service = module.get(AdminProjectsService);
+    projectRepo = module.get(getRepositoryToken(Project));
+  });
+
+  describe('getById', () => {
+    it('존재하면 DTO 반환', async () => {
+      projectRepo.findOne.mockResolvedValue(baseProject({ id: 1, url: 'demo' }));
+      const dto = await service.getById(1);
+      expect(dto.url).toBe('demo');
+    });
+
+    it('없으면 NotFoundException', async () => {
+      projectRepo.findOne.mockResolvedValue(null);
+      await expect(service.getById(99)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('create', () => {
+    it('slug 이미 사용 중이면 ConflictException', async () => {
+      projectRepo.findOne.mockResolvedValueOnce(baseProject({ url: 'new-slug' }));
+      await expect(service.create(baseDto())).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+      expect(dataSource.transaction).not.toHaveBeenCalled();
+    });
+
+    it('성공하면 transaction 안에서 save 후 relations 로드해 DTO 반환', async () => {
+      projectRepo.findOne
+        .mockResolvedValueOnce(null) // assertUrlAvailable
+        .mockResolvedValueOnce(baseProject({ id: 10, url: 'new-slug', title: 'T' })); // findOneWithRelations
+
+      txManager.save.mockImplementation(async (_entity, project) => ({
+        ...project,
+        id: 10,
+      }));
+
+      const dto = await service.create(baseDto());
+
+      expect(dataSource.transaction).toHaveBeenCalledTimes(1);
+      expect(txManager.save).toHaveBeenCalledTimes(1);
+      expect(dto.url).toBe('new-slug');
+      expect(dto.id).toBe(10);
+    });
+  });
+
+  describe('update', () => {
+    it('대상 없으면 NotFoundException', async () => {
+      projectRepo.findOne.mockResolvedValue(null);
+      await expect(service.update(99, baseDto())).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('slug 변경 시 다른 프로젝트에서 사용 중이면 ConflictException', async () => {
+      projectRepo.findOne
+        .mockResolvedValueOnce(baseProject({ id: 5, url: 'current' })) // exists
+        .mockResolvedValueOnce(baseProject({ id: 7, url: 'new-slug' })); // collision
+
+      await expect(
+        service.update(5, baseDto({ url: 'new-slug' })),
+      ).rejects.toBeInstanceOf(ConflictException);
+      expect(dataSource.transaction).not.toHaveBeenCalled();
+    });
+
+    it('정상 경로: 자식 관계 전부 삭제 후 재저장', async () => {
+      projectRepo.findOne
+        .mockResolvedValueOnce(baseProject({ id: 5, url: 'new-slug' })) // exists (same url → assertUrlAvailable 생략)
+        .mockResolvedValueOnce(baseProject({ id: 5, url: 'new-slug' })); // findOneWithRelations
+
+      txManager.find.mockResolvedValue([{ id: 1 }, { id: 2 }]);
+
+      await service.update(5, baseDto({ url: 'new-slug' }));
+
+      // 자식 삭제 순서 확인
+      const deleteCalls = txManager.delete.mock.calls.map((c) => c[0].name ?? c[0]);
+      expect(deleteCalls).toContain('ProjectTechnologyItem');
+      expect(deleteCalls).toContain('ProjectTechnology');
+      expect(deleteCalls).toContain('ProjectImage');
+      expect(deleteCalls).toContain('ProjectCompanyInfo');
+      expect(deleteCalls).toContain('ProjectDetail');
+      // 최종 save 호출
+      expect(txManager.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('TechnologyItem 은 tech 그룹이 없으면 삭제 건너뛴다', async () => {
+      projectRepo.findOne
+        .mockResolvedValueOnce(baseProject({ id: 5, url: 'new-slug' }))
+        .mockResolvedValueOnce(baseProject({ id: 5, url: 'new-slug' }));
+      txManager.find.mockResolvedValue([]);
+
+      await service.update(5, baseDto({ url: 'new-slug' }));
+
+      const deleteCalls = txManager.delete.mock.calls.map((c) => c[0].name ?? c[0]);
+      expect(deleteCalls).not.toContain('ProjectTechnologyItem');
+    });
+  });
+
+  describe('remove', () => {
+    it('affected=0 이면 NotFoundException', async () => {
+      projectRepo.delete.mockResolvedValue({ affected: 0, raw: {} } as never);
+      await expect(service.remove(10)).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('성공 시 void', async () => {
+      projectRepo.delete.mockResolvedValue({ affected: 1, raw: {} } as never);
+      await expect(service.remove(10)).resolves.toBeUndefined();
+      expect(projectRepo.delete).toHaveBeenCalledWith(10);
+    });
+  });
+});

--- a/apps/api/src/modules/projects/admin-projects.service.ts
+++ b/apps/api/src/modules/projects/admin-projects.service.ts
@@ -1,0 +1,157 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, In, Repository } from 'typeorm';
+import { Project } from './entities/project.entity';
+import { ProjectCompanyInfo } from './entities/project-company-info.entity';
+import { ProjectDetail } from './entities/project-detail.entity';
+import { ProjectImage } from './entities/project-image.entity';
+import { ProjectTechnology } from './entities/project-technology.entity';
+import { ProjectTechnologyItem } from './entities/project-technology-item.entity';
+import { UpsertProjectDto } from './dto/upsert-project.dto';
+import { ProjectDetailDto } from './dto/project-detail.dto';
+import { toProjectDetailDto } from './mappers/project-detail.mapper';
+
+@Injectable()
+export class AdminProjectsService {
+  constructor(
+    @InjectRepository(Project)
+    private readonly projectRepo: Repository<Project>,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  async getById(id: number): Promise<ProjectDetailDto> {
+    const project = await this.findOneWithRelations(id);
+    if (!project) {
+      throw new NotFoundException(`Project not found: id=${id}`);
+    }
+    return toProjectDetailDto(project);
+  }
+
+  async create(dto: UpsertProjectDto): Promise<ProjectDetailDto> {
+    await this.assertUrlAvailable(dto.url);
+    const saved = await this.dataSource.transaction(async (manager) => {
+      const entity = buildProject(dto);
+      return manager.save(Project, entity);
+    });
+    const loaded = await this.findOneWithRelations(saved.id);
+    return toProjectDetailDto(loaded!);
+  }
+
+  async update(id: number, dto: UpsertProjectDto): Promise<ProjectDetailDto> {
+    const exists = await this.projectRepo.findOne({ where: { id } });
+    if (!exists) {
+      throw new NotFoundException(`Project not found: id=${id}`);
+    }
+    if (dto.url !== exists.url) {
+      await this.assertUrlAvailable(dto.url, id);
+    }
+
+    await this.dataSource.transaction(async (manager) => {
+      // 자식 관계를 전부 비우고 재삽입. 이미지 섬네일 하나 바꾸더라도 일관되게 덮어쓴다.
+      const techs = await manager.find(ProjectTechnology, {
+        where: { projectId: id },
+        select: { id: true },
+      });
+      const techIds = techs.map((t) => t.id);
+      if (techIds.length > 0) {
+        await manager.delete(ProjectTechnologyItem, {
+          technologyId: In(techIds),
+        });
+      }
+      await manager.delete(ProjectTechnology, { projectId: id });
+      await manager.delete(ProjectImage, { projectId: id });
+      await manager.delete(ProjectCompanyInfo, { projectId: id });
+      await manager.delete(ProjectDetail, { projectId: id });
+
+      const updated = buildProject(dto);
+      updated.id = id;
+      await manager.save(Project, updated);
+    });
+
+    const loaded = await this.findOneWithRelations(id);
+    return toProjectDetailDto(loaded!);
+  }
+
+  async remove(id: number): Promise<void> {
+    const result = await this.projectRepo.delete(id);
+    if (!result.affected) {
+      throw new NotFoundException(`Project not found: id=${id}`);
+    }
+  }
+
+  private findOneWithRelations(id: number): Promise<Project | null> {
+    return this.projectRepo.findOne({
+      where: { id },
+      relations: {
+        images: true,
+        companyInfo: true,
+        technologies: { items: true },
+        details: true,
+      },
+    });
+  }
+
+  private async assertUrlAvailable(url: string, excludingId?: number): Promise<void> {
+    const found = await this.projectRepo.findOne({ where: { url } });
+    if (found && found.id !== excludingId) {
+      throw new ConflictException(`url slug already in use: ${url}`);
+    }
+  }
+}
+
+function buildProject(dto: UpsertProjectDto): Project {
+  const project = new Project();
+  project.url = dto.url;
+  project.title = dto.title;
+  project.category = dto.category;
+  project.thumbnailImg = dto.thumbnailImg;
+  project.headerPublishDate = dto.headerPublishDate;
+  project.headerTags = dto.headerTags;
+  project.clientHeading = dto.clientHeading;
+  project.objectivesHeading = dto.objectivesHeading;
+  project.objectivesDetails = dto.objectivesDetails;
+  project.projectDetailsHeading = dto.projectDetailsHeading;
+  project.socialSharingHeading = dto.socialSharingHeading ?? '';
+
+  project.images = dto.images.map((img, idx) => {
+    const e = new ProjectImage();
+    e.title = img.title;
+    e.img = img.img;
+    e.sortOrder = idx;
+    return e;
+  });
+
+  project.companyInfo = dto.companyInfo.map((info, idx) => {
+    const e = new ProjectCompanyInfo();
+    e.title = info.title;
+    e.details = info.details;
+    e.sortOrder = idx;
+    return e;
+  });
+
+  project.technologies = dto.technologies.map((tech, idx) => {
+    const e = new ProjectTechnology();
+    e.title = tech.title;
+    e.sortOrder = idx;
+    e.items = tech.techs.map((name, j) => {
+      const item = new ProjectTechnologyItem();
+      item.name = name;
+      item.sortOrder = j;
+      return item;
+    });
+    return e;
+  });
+
+  project.details = dto.details.map((detail, idx) => {
+    const e = new ProjectDetail();
+    e.details = detail.details;
+    e.sortOrder = idx;
+    return e;
+  });
+
+  return project;
+}

--- a/apps/api/src/modules/projects/dto/upsert-project.dto.spec.ts
+++ b/apps/api/src/modules/projects/dto/upsert-project.dto.spec.ts
@@ -1,0 +1,61 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { UpsertProjectDto } from './upsert-project.dto';
+
+const validPayload = (overrides: Partial<UpsertProjectDto> = {}) => ({
+  title: 'Demo',
+  url: 'demo',
+  category: 'Web Application',
+  thumbnailImg: '/img.jpg',
+  headerPublishDate: '2026.01',
+  headerTags: 'Web',
+  clientHeading: 'About Project',
+  objectivesHeading: 'Objective',
+  objectivesDetails: 'details',
+  projectDetailsHeading: 'Challenge',
+  images: [{ title: 'a', img: '/a.jpg' }],
+  companyInfo: [{ title: 'Role', details: 'Backend' }],
+  technologies: [{ title: 'Tools', techs: ['Node.js'] }],
+  details: [{ details: '## 본문' }],
+  ...overrides,
+});
+
+describe('UpsertProjectDto', () => {
+  it('정상 payload 는 검증 오류가 없다', async () => {
+    const dto = plainToInstance(UpsertProjectDto, validPayload());
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('technologies 가 빈 배열이면 ArrayMinSize 위반', async () => {
+    const dto = plainToInstance(
+      UpsertProjectDto,
+      validPayload({ technologies: [] }),
+    );
+    const errors = await validate(dto);
+    const tech = errors.find((e) => e.property === 'technologies');
+    expect(tech?.constraints).toHaveProperty('arrayMinSize');
+  });
+
+  it('techs 항목 길이가 100 을 넘으면 검증 실패', async () => {
+    const longTech = 'a'.repeat(101);
+    const dto = plainToInstance(
+      UpsertProjectDto,
+      validPayload({
+        technologies: [{ title: 'Tools', techs: [longTech] }],
+      }),
+    );
+    const errors = await validate(dto);
+    // 상위 technologies 에러에서 nested TechnologyGroup 의 techs 제약 위반을 찾는다
+    const tech = errors.find((e) => e.property === 'technologies');
+    const flatten = JSON.stringify(tech?.children ?? tech);
+    expect(flatten).toContain('maxLength');
+  });
+
+  it('기본 필수 필드가 비어있으면 검증 실패', async () => {
+    const dto = plainToInstance(UpsertProjectDto, validPayload({ title: '' }));
+    const errors = await validate(dto);
+    const title = errors.find((e) => e.property === 'title');
+    expect(title?.constraints).toHaveProperty('isNotEmpty');
+  });
+});

--- a/apps/api/src/modules/projects/dto/upsert-project.dto.ts
+++ b/apps/api/src/modules/projects/dto/upsert-project.dto.ts
@@ -2,6 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   ArrayMaxSize,
+  ArrayMinSize,
   IsArray,
   IsNotEmpty,
   IsOptional,
@@ -50,6 +51,7 @@ export class UpsertTechnologyGroupDto {
   @ArrayMaxSize(100)
   @IsString({ each: true })
   @IsNotEmpty({ each: true })
+  @MaxLength(100, { each: true })
   techs!: string[];
 }
 
@@ -138,8 +140,9 @@ export class UpsertProjectDto {
   @Type(() => UpsertCompanyInfoDto)
   companyInfo!: UpsertCompanyInfoDto[];
 
-  @ApiProperty({ type: [UpsertTechnologyGroupDto] })
+  @ApiProperty({ type: [UpsertTechnologyGroupDto], minItems: 1 })
   @IsArray()
+  @ArrayMinSize(1)
   @ValidateNested({ each: true })
   @Type(() => UpsertTechnologyGroupDto)
   technologies!: UpsertTechnologyGroupDto[];

--- a/apps/api/src/modules/projects/dto/upsert-project.dto.ts
+++ b/apps/api/src/modules/projects/dto/upsert-project.dto.ts
@@ -1,0 +1,152 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
+
+export class UpsertImageDto {
+  @ApiProperty({ maxLength: 200 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  title!: string;
+
+  @ApiProperty({ maxLength: 500 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(500)
+  img!: string;
+}
+
+export class UpsertCompanyInfoDto {
+  @ApiProperty({ maxLength: 100 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  title!: string;
+
+  @ApiProperty({ maxLength: 500 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(500)
+  details!: string;
+}
+
+export class UpsertTechnologyGroupDto {
+  @ApiProperty({ maxLength: 200 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  title!: string;
+
+  @ApiProperty({ type: [String] })
+  @IsArray()
+  @ArrayMaxSize(100)
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  techs!: string[];
+}
+
+export class UpsertProjectDetailDto {
+  @ApiProperty({ description: '마크다운 허용' })
+  @IsString()
+  @IsNotEmpty()
+  details!: string;
+}
+
+export class UpsertProjectDto {
+  @ApiProperty({ maxLength: 200 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  title!: string;
+
+  @ApiProperty({ maxLength: 200, description: 'URL slug' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  url!: string;
+
+  @ApiProperty({ maxLength: 100 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  category!: string;
+
+  @ApiProperty({ maxLength: 500 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(500)
+  thumbnailImg!: string;
+
+  @ApiProperty({ maxLength: 100 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  headerPublishDate!: string;
+
+  @ApiProperty({ maxLength: 200 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  headerTags!: string;
+
+  @ApiProperty({ maxLength: 200 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  clientHeading!: string;
+
+  @ApiProperty({ maxLength: 200 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  objectivesHeading!: string;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  objectivesDetails!: string;
+
+  @ApiProperty({ maxLength: 200 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  projectDetailsHeading!: string;
+
+  @ApiProperty({ maxLength: 200, required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  socialSharingHeading?: string;
+
+  @ApiProperty({ type: [UpsertImageDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => UpsertImageDto)
+  images!: UpsertImageDto[];
+
+  @ApiProperty({ type: [UpsertCompanyInfoDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => UpsertCompanyInfoDto)
+  companyInfo!: UpsertCompanyInfoDto[];
+
+  @ApiProperty({ type: [UpsertTechnologyGroupDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => UpsertTechnologyGroupDto)
+  technologies!: UpsertTechnologyGroupDto[];
+
+  @ApiProperty({ type: [UpsertProjectDetailDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => UpsertProjectDetailDto)
+  details!: UpsertProjectDetailDto[];
+}

--- a/apps/api/src/modules/projects/projects.module.ts
+++ b/apps/api/src/modules/projects/projects.module.ts
@@ -3,6 +3,8 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ProjectsController } from './projects.controller';
 import { ProjectsService } from './projects.service';
 import { ProjectsRepository } from './projects.repository';
+import { AdminProjectsController } from './admin-projects.controller';
+import { AdminProjectsService } from './admin-projects.service';
 import { Project } from './entities/project.entity';
 import { ProjectImage } from './entities/project-image.entity';
 import { ProjectCompanyInfo } from './entities/project-company-info.entity';
@@ -21,7 +23,7 @@ import { ProjectDetail } from './entities/project-detail.entity';
       ProjectDetail,
     ]),
   ],
-  controllers: [ProjectsController],
-  providers: [ProjectsService, ProjectsRepository],
+  controllers: [ProjectsController, AdminProjectsController],
+  providers: [ProjectsService, ProjectsRepository, AdminProjectsService],
 })
 export class ProjectsModule {}

--- a/apps/web/components/admin/AdminFormSection.jsx
+++ b/apps/web/components/admin/AdminFormSection.jsx
@@ -1,0 +1,23 @@
+// 어드민 폼의 섹션 단위 래퍼. 제목/설명/본문을 일관된 간격으로 묶는다.
+function AdminFormSection({ title, description, action, children }) {
+	return (
+		<section className="mb-8 rounded-xl border border-gray-200 dark:border-secondary-dark bg-secondary-light dark:bg-secondary-dark p-5 sm:p-6">
+			<header className="flex items-start justify-between gap-3 mb-4">
+				<div>
+					<h2 className="font-general-medium text-xl text-primary-dark dark:text-primary-light">
+						{title}
+					</h2>
+					{description && (
+						<p className="font-general-regular text-sm text-ternary-dark dark:text-ternary-light mt-1">
+							{description}
+						</p>
+					)}
+				</div>
+				{action && <div className="shrink-0">{action}</div>}
+			</header>
+			<div>{children}</div>
+		</section>
+	);
+}
+
+export default AdminFormSection;

--- a/apps/web/components/admin/AdminTable.jsx
+++ b/apps/web/components/admin/AdminTable.jsx
@@ -1,0 +1,63 @@
+// 어드민 목록 테이블 공용 컴포넌트.
+// columns: [{ key, label, render?: (row) => node, className?: string }]
+// rows:    [row]
+// actions: (row) => node  (optional, 우측 액션 열)
+// emptyMessage: 빈 상태 문구
+function AdminTable({ columns, rows, actions, emptyMessage = '데이터가 없습니다.' }) {
+	const showActions = typeof actions === 'function';
+
+	if (!rows || rows.length === 0) {
+		return (
+			<div className="font-general-regular text-ternary-dark dark:text-ternary-light rounded-xl border border-gray-200 dark:border-secondary-dark p-6 text-center">
+				{emptyMessage}
+			</div>
+		);
+	}
+
+	return (
+		<div className="overflow-x-auto rounded-xl border border-gray-200 dark:border-secondary-dark">
+			<table className="min-w-full font-general-regular">
+				<thead className="bg-ternary-light dark:bg-ternary-dark text-primary-dark dark:text-primary-light">
+					<tr>
+						{columns.map((col) => (
+							<th
+								key={col.key}
+								className={`px-4 py-3 text-left text-sm font-general-medium ${col.className ?? ''}`}
+							>
+								{col.label}
+							</th>
+						))}
+						{showActions && (
+							<th className="px-4 py-3 text-right text-sm font-general-medium">
+								Actions
+							</th>
+						)}
+					</tr>
+				</thead>
+				<tbody className="bg-secondary-light dark:bg-secondary-dark divide-y divide-gray-200 dark:divide-ternary-dark">
+					{rows.map((row, idx) => (
+						<tr key={row.id ?? idx}>
+							{columns.map((col) => (
+								<td
+									key={col.key}
+									className={`px-4 py-3 text-ternary-dark dark:text-ternary-light text-sm ${col.className ?? ''}`}
+								>
+									{col.render ? col.render(row) : row[col.key]}
+								</td>
+							))}
+							{showActions && (
+								<td className="px-4 py-3 text-right">
+									<div className="flex justify-end gap-2">
+										{actions(row)}
+									</div>
+								</td>
+							)}
+						</tr>
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+}
+
+export default AdminTable;

--- a/apps/web/components/admin/DynamicList.jsx
+++ b/apps/web/components/admin/DynamicList.jsx
@@ -1,0 +1,99 @@
+import { FiArrowDown, FiArrowUp, FiPlus, FiTrash2 } from 'react-icons/fi';
+
+// 어드민 폼의 N 행 컨트롤. 값 추가/삭제/상/하 이동을 공용화한다.
+// props:
+//   items: 배열
+//   onChange: (nextItems) => void
+//   renderItem: (item, index, onItemChange) => node  — onItemChange(partial)
+//   emptyItem: () => newItem  (추가 버튼 눌렀을 때 생성)
+//   addLabel: 버튼 라벨 (기본 '추가')
+//   minLength: 최소 개수 (기본 0)
+function DynamicList({
+	items,
+	onChange,
+	renderItem,
+	emptyItem,
+	addLabel = '추가',
+	minLength = 0,
+}) {
+	function update(index, partial) {
+		const next = items.map((it, i) =>
+			i === index ? { ...it, ...partial } : it,
+		);
+		onChange(next);
+	}
+
+	function add() {
+		onChange([...items, emptyItem()]);
+	}
+
+	function remove(index) {
+		if (items.length <= minLength) return;
+		onChange(items.filter((_, i) => i !== index));
+	}
+
+	function move(index, delta) {
+		const target = index + delta;
+		if (target < 0 || target >= items.length) return;
+		const next = [...items];
+		[next[index], next[target]] = [next[target], next[index]];
+		onChange(next);
+	}
+
+	return (
+		<div className="flex flex-col gap-3">
+			{items.map((item, i) => (
+				<div
+					key={item._key ?? i}
+					className="rounded-lg border border-gray-200 dark:border-ternary-dark bg-primary-light dark:bg-ternary-dark p-3 sm:p-4"
+				>
+					<div className="flex justify-between items-start gap-2 mb-2">
+						<span className="font-general-medium text-xs text-ternary-dark dark:text-ternary-light">
+							#{i + 1}
+						</span>
+						<div className="flex gap-1">
+							<button
+								type="button"
+								onClick={() => move(i, -1)}
+								disabled={i === 0}
+								aria-label="Move up"
+								className="p-1.5 rounded hover:bg-ternary-light dark:hover:bg-secondary-dark disabled:opacity-30 disabled:cursor-not-allowed"
+							>
+								<FiArrowUp className="w-4 h-4" />
+							</button>
+							<button
+								type="button"
+								onClick={() => move(i, 1)}
+								disabled={i === items.length - 1}
+								aria-label="Move down"
+								className="p-1.5 rounded hover:bg-ternary-light dark:hover:bg-secondary-dark disabled:opacity-30 disabled:cursor-not-allowed"
+							>
+								<FiArrowDown className="w-4 h-4" />
+							</button>
+							<button
+								type="button"
+								onClick={() => remove(i)}
+								disabled={items.length <= minLength}
+								aria-label="Remove"
+								className="p-1.5 rounded text-red-500 hover:bg-red-50 dark:hover:bg-secondary-dark disabled:opacity-30 disabled:cursor-not-allowed"
+							>
+								<FiTrash2 className="w-4 h-4" />
+							</button>
+						</div>
+					</div>
+					<div>{renderItem(item, i, (partial) => update(i, partial))}</div>
+				</div>
+			))}
+			<button
+				type="button"
+				onClick={add}
+				className="flex items-center justify-center gap-1.5 font-general-medium text-sm text-indigo-600 dark:text-indigo-400 border border-dashed border-indigo-300 dark:border-indigo-700 rounded-lg py-2.5 hover:bg-indigo-50 dark:hover:bg-secondary-dark duration-300"
+			>
+				<FiPlus className="w-4 h-4" />
+				{addLabel}
+			</button>
+		</div>
+	);
+}
+
+export default DynamicList;

--- a/apps/web/components/admin/ProjectForm.jsx
+++ b/apps/web/components/admin/ProjectForm.jsx
@@ -1,0 +1,356 @@
+import { useState } from 'react';
+import Button from '../reusable/Button';
+import FormInput from '../reusable/FormInput';
+import AdminFormSection from './AdminFormSection';
+import DynamicList from './DynamicList';
+
+const DEFAULT_VALUES = {
+	title: '',
+	url: '',
+	category: '',
+	thumbnailImg: '',
+	headerPublishDate: '',
+	headerTags: '',
+	clientHeading: 'About Project',
+	objectivesHeading: 'Objective',
+	objectivesDetails: '',
+	projectDetailsHeading: 'Challenge',
+	socialSharingHeading: '',
+	images: [],
+	companyInfo: [],
+	technologies: [],
+	details: [],
+};
+
+function toFormState(initial) {
+	const merged = { ...DEFAULT_VALUES, ...(initial ?? {}) };
+	return {
+		...merged,
+		images: (merged.images ?? []).map((img, i) => ({
+			_key: `img-${i}-${Math.random()}`,
+			title: img.title ?? '',
+			img: img.img ?? '',
+		})),
+		companyInfo: (merged.companyInfo ?? []).map((info, i) => ({
+			_key: `ci-${i}-${Math.random()}`,
+			title: info.title ?? '',
+			details: info.details ?? '',
+		})),
+		technologies: (merged.technologies ?? []).map((tech, i) => ({
+			_key: `tech-${i}-${Math.random()}`,
+			title: tech.title ?? '',
+			techs: (tech.techs ?? []).join(', '),
+		})),
+		details: (merged.details ?? []).map((d, i) => ({
+			_key: `d-${i}-${Math.random()}`,
+			details: d.details ?? '',
+		})),
+	};
+}
+
+function toSubmitPayload(form) {
+	return {
+		title: form.title.trim(),
+		url: form.url.trim(),
+		category: form.category.trim(),
+		thumbnailImg: form.thumbnailImg.trim(),
+		headerPublishDate: form.headerPublishDate.trim(),
+		headerTags: form.headerTags.trim(),
+		clientHeading: form.clientHeading.trim(),
+		objectivesHeading: form.objectivesHeading.trim(),
+		objectivesDetails: form.objectivesDetails.trim(),
+		projectDetailsHeading: form.projectDetailsHeading.trim(),
+		socialSharingHeading: form.socialSharingHeading.trim() || undefined,
+		images: form.images.map((img) => ({ title: img.title, img: img.img })),
+		companyInfo: form.companyInfo.map((info) => ({
+			title: info.title,
+			details: info.details,
+		})),
+		technologies: form.technologies.map((tech) => ({
+			title: tech.title,
+			techs: tech.techs
+				.split(',')
+				.map((s) => s.trim())
+				.filter(Boolean),
+		})),
+		details: form.details.map((d) => ({ details: d.details })),
+	};
+}
+
+function ProjectForm({ initialValue, submitLabel = '저장', onSubmit }) {
+	const [form, setForm] = useState(() => toFormState(initialValue));
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState('');
+
+	function set(name, value) {
+		setForm((prev) => ({ ...prev, [name]: value }));
+	}
+
+	async function handleSubmit(event) {
+		event.preventDefault();
+		if (submitting) return;
+		setError('');
+		setSubmitting(true);
+		try {
+			await onSubmit(toSubmitPayload(form));
+		} catch (err) {
+			console.error('[admin project form] submit failed', err);
+			setError(err?.message ?? '저장에 실패했습니다.');
+		} finally {
+			setSubmitting(false);
+		}
+	}
+
+	return (
+		<form onSubmit={handleSubmit}>
+			<AdminFormSection title="기본 정보" description="프로젝트 목록·헤더에 노출되는 핵심 필드입니다.">
+				<FormInput
+					inputLabel="제목"
+					labelFor="title"
+					inputType="text"
+					inputId="title"
+					inputName="title"
+					ariaLabelName="Title"
+					placeholderText="프로젝트 제목"
+					value={form.title}
+					onChange={(e) => set('title', e.target.value)}
+				/>
+				<FormInput
+					inputLabel="URL slug (예: my-project)"
+					labelFor="url"
+					inputType="text"
+					inputId="url"
+					inputName="url"
+					ariaLabelName="URL slug"
+					placeholderText="my-project"
+					value={form.url}
+					onChange={(e) => set('url', e.target.value)}
+				/>
+				<FormInput
+					inputLabel="카테고리"
+					labelFor="category"
+					inputType="text"
+					inputId="category"
+					inputName="category"
+					ariaLabelName="Category"
+					placeholderText="Web Application / Backend / ..."
+					value={form.category}
+					onChange={(e) => set('category', e.target.value)}
+				/>
+				<FormInput
+					inputLabel="썸네일 이미지 경로"
+					labelFor="thumbnailImg"
+					inputType="text"
+					inputId="thumbnailImg"
+					inputName="thumbnailImg"
+					ariaLabelName="Thumbnail image path"
+					placeholderText="/images/project.jpg"
+					value={form.thumbnailImg}
+					onChange={(e) => set('thumbnailImg', e.target.value)}
+				/>
+				<FormInput
+					inputLabel="게시일 표기"
+					labelFor="headerPublishDate"
+					inputType="text"
+					inputId="headerPublishDate"
+					inputName="headerPublishDate"
+					ariaLabelName="Publish date"
+					placeholderText="2026.01 – 2026.03"
+					value={form.headerPublishDate}
+					onChange={(e) => set('headerPublishDate', e.target.value)}
+				/>
+				<FormInput
+					inputLabel="헤더 태그"
+					labelFor="headerTags"
+					inputType="text"
+					inputId="headerTags"
+					inputName="headerTags"
+					ariaLabelName="Header tags"
+					placeholderText="Backend / Realtime"
+					value={form.headerTags}
+					onChange={(e) => set('headerTags', e.target.value)}
+				/>
+			</AdminFormSection>
+
+			<AdminFormSection title="Objective" description="프로젝트 상세의 목표 영역 문구.">
+				<FormInput
+					inputLabel="Objective heading"
+					labelFor="objectivesHeading"
+					inputType="text"
+					inputId="objectivesHeading"
+					inputName="objectivesHeading"
+					ariaLabelName="Objectives heading"
+					placeholderText="Objective"
+					value={form.objectivesHeading}
+					onChange={(e) => set('objectivesHeading', e.target.value)}
+				/>
+				<label
+					className="block text-lg text-primary-dark dark:text-primary-light mb-1 font-general-regular"
+					htmlFor="objectivesDetails"
+				>
+					Objective details
+				</label>
+				<textarea
+					id="objectivesDetails"
+					name="objectivesDetails"
+					rows={4}
+					placeholder="한 줄 소개"
+					aria-label="Objective details"
+					className="w-full px-5 py-2 mb-4 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-ternary-dark rounded-md shadow-sm text-md font-general-regular"
+					value={form.objectivesDetails}
+					onChange={(e) => set('objectivesDetails', e.target.value)}
+					required
+				/>
+			</AdminFormSection>
+
+			<AdminFormSection title="About Project 영역" description="Projects 상세의 좌측 메타 블록.">
+				<FormInput
+					inputLabel="About heading"
+					labelFor="clientHeading"
+					inputType="text"
+					inputId="clientHeading"
+					inputName="clientHeading"
+					ariaLabelName="Client heading"
+					placeholderText="About Project"
+					value={form.clientHeading}
+					onChange={(e) => set('clientHeading', e.target.value)}
+				/>
+				<DynamicList
+					items={form.companyInfo}
+					onChange={(next) => set('companyInfo', next)}
+					emptyItem={() => ({ _key: `ci-${Date.now()}`, title: '', details: '' })}
+					addLabel="About 항목 추가"
+					renderItem={(item, _idx, onItemChange) => (
+						<div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+							<input
+								className="px-3 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-secondary-dark rounded-md text-sm font-general-regular sm:col-span-1"
+								placeholder="항목 이름 (예: Services)"
+								aria-label="Company info title"
+								value={item.title}
+								onChange={(e) => onItemChange({ title: e.target.value })}
+								required
+							/>
+							<input
+								className="px-3 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-secondary-dark rounded-md text-sm font-general-regular sm:col-span-2"
+								placeholder="값 (URL 은 자동으로 링크 렌더링)"
+								aria-label="Company info details"
+								value={item.details}
+								onChange={(e) => onItemChange({ details: e.target.value })}
+								required
+							/>
+						</div>
+					)}
+				/>
+			</AdminFormSection>
+
+			<AdminFormSection title="기술 스택" description="한 줄에 콤마(,) 로 구분해서 입력합니다.">
+				<DynamicList
+					items={form.technologies}
+					onChange={(next) => set('technologies', next)}
+					emptyItem={() => ({
+						_key: `tech-${Date.now()}`,
+						title: 'Tools & Technologies',
+						techs: '',
+					})}
+					addLabel="기술 그룹 추가"
+					renderItem={(item, _idx, onItemChange) => (
+						<div className="flex flex-col gap-2">
+							<input
+								className="px-3 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-secondary-dark rounded-md text-sm font-general-regular"
+								placeholder="그룹 제목 (예: Tools & Technologies)"
+								aria-label="Technology group title"
+								value={item.title}
+								onChange={(e) => onItemChange({ title: e.target.value })}
+								required
+							/>
+							<input
+								className="px-3 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-secondary-dark rounded-md text-sm font-general-regular"
+								placeholder="콤마로 구분 (Node.js, NestJS, MySQL)"
+								aria-label="Technologies comma separated"
+								value={item.techs}
+								onChange={(e) => onItemChange({ techs: e.target.value })}
+							/>
+						</div>
+					)}
+				/>
+			</AdminFormSection>
+
+			<AdminFormSection title="Challenge 섹션" description="각 블록은 마크다운을 지원합니다.">
+				<FormInput
+					inputLabel="Challenge heading"
+					labelFor="projectDetailsHeading"
+					inputType="text"
+					inputId="projectDetailsHeading"
+					inputName="projectDetailsHeading"
+					ariaLabelName="Project details heading"
+					placeholderText="Challenge"
+					value={form.projectDetailsHeading}
+					onChange={(e) => set('projectDetailsHeading', e.target.value)}
+				/>
+				<DynamicList
+					items={form.details}
+					onChange={(next) => set('details', next)}
+					emptyItem={() => ({ _key: `d-${Date.now()}`, details: '' })}
+					addLabel="Challenge 단락 추가"
+					renderItem={(item, _idx, onItemChange) => (
+						<textarea
+							className="w-full px-3 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-secondary-dark rounded-md text-sm font-mono"
+							rows={8}
+							placeholder="## 섹션 제목&#10;본문 (마크다운 가능)"
+							aria-label="Challenge markdown block"
+							value={item.details}
+							onChange={(e) => onItemChange({ details: e.target.value })}
+							required
+						/>
+					)}
+				/>
+			</AdminFormSection>
+
+			<AdminFormSection title="갤러리 이미지" description="프로젝트 상세 상단의 이미지 배열. URL 을 직접 입력합니다 (Phase 2b 에서 업로더로 교체).">
+				<DynamicList
+					items={form.images}
+					onChange={(next) => set('images', next)}
+					emptyItem={() => ({ _key: `img-${Date.now()}`, title: '', img: '' })}
+					addLabel="이미지 추가"
+					renderItem={(item, _idx, onItemChange) => (
+						<div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+							<input
+								className="px-3 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-secondary-dark rounded-md text-sm font-general-regular sm:col-span-1"
+								placeholder="alt 텍스트"
+								aria-label="Image alt"
+								value={item.title}
+								onChange={(e) => onItemChange({ title: e.target.value })}
+								required
+							/>
+							<input
+								className="px-3 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-secondary-dark rounded-md text-sm font-general-regular sm:col-span-2"
+								placeholder="/images/... 또는 https://..."
+								aria-label="Image path"
+								value={item.img}
+								onChange={(e) => onItemChange({ img: e.target.value })}
+								required
+							/>
+						</div>
+					)}
+				/>
+			</AdminFormSection>
+
+			{error && (
+				<p className="font-general-regular text-sm text-red-500 dark:text-red-400 mb-3" role="alert">
+					{error}
+				</p>
+			)}
+			<div className="flex justify-end gap-2">
+				<Button
+					title={submitting ? '저장 중…' : submitLabel}
+					type="submit"
+					variant="primary"
+					disabled={submitting}
+					ariaLabel="Save project"
+				/>
+			</div>
+		</form>
+	);
+}
+
+export default ProjectForm;

--- a/apps/web/components/admin/ProjectForm.jsx
+++ b/apps/web/components/admin/ProjectForm.jsx
@@ -18,7 +18,8 @@ const DEFAULT_VALUES = {
 	socialSharingHeading: '',
 	images: [],
 	companyInfo: [],
-	technologies: [],
+	// 공개 상세 페이지가 Technologies[0] 을 직접 참조하므로 최소 1 그룹을 기본으로 유지한다.
+	technologies: [{ title: 'Tools & Technologies', techs: [] }],
 	details: [],
 };
 
@@ -243,7 +244,7 @@ function ProjectForm({ initialValue, submitLabel = '저장', onSubmit }) {
 				/>
 			</AdminFormSection>
 
-			<AdminFormSection title="기술 스택" description="한 줄에 콤마(,) 로 구분해서 입력합니다.">
+			<AdminFormSection title="기술 스택" description="한 줄에 콤마(,) 로 구분해서 입력합니다. 최소 1그룹이 필요합니다.">
 				<DynamicList
 					items={form.technologies}
 					onChange={(next) => set('technologies', next)}
@@ -253,6 +254,7 @@ function ProjectForm({ initialValue, submitLabel = '저장', onSubmit }) {
 						techs: '',
 					})}
 					addLabel="기술 그룹 추가"
+					minLength={1}
 					renderItem={(item, _idx, onItemChange) => (
 						<div className="flex flex-col gap-2">
 							<input

--- a/apps/web/lib/admin/api.js
+++ b/apps/web/lib/admin/api.js
@@ -1,0 +1,45 @@
+// 어드민 API 호출용 fetch 래퍼.
+// - credentials: 'include' 로 admin_token 쿠키가 자동으로 붙음
+// - JSON 요청/응답을 표준화
+// - 401 일 때는 /admin/login 으로 튕겨주는 AuthError 를 던져 호출 측에서 일관 처리하도록
+export class AdminApiError extends Error {
+	constructor(message, { status, payload } = {}) {
+		super(message);
+		this.name = 'AdminApiError';
+		this.status = status;
+		this.payload = payload;
+	}
+}
+
+export async function fetchAdmin(path, { method = 'GET', body, signal } = {}) {
+	const init = {
+		method,
+		credentials: 'include',
+		signal,
+		headers: {},
+	};
+	if (body !== undefined) {
+		init.body = JSON.stringify(body);
+		init.headers['Content-Type'] = 'application/json';
+	}
+
+	const res = await fetch(path, init);
+
+	let payload;
+	const contentType = res.headers.get('content-type') ?? '';
+	if (contentType.includes('application/json')) {
+		payload = await res.json().catch(() => null);
+	}
+
+	if (res.status === 204) {
+		return null;
+	}
+	if (!res.ok) {
+		const message =
+			payload?.error?.message ??
+			payload?.message ??
+			`request failed: ${res.status}`;
+		throw new AdminApiError(message, { status: res.status, payload });
+	}
+	return payload?.data ?? payload ?? null;
+}

--- a/apps/web/pages/admin/projects/[id]/edit.jsx
+++ b/apps/web/pages/admin/projects/[id]/edit.jsx
@@ -1,0 +1,86 @@
+import { useRouter } from 'next/router';
+import AdminLayout from '../../../../components/admin/AdminLayout';
+import ProjectForm from '../../../../components/admin/ProjectForm';
+import { AdminApiError, fetchAdmin } from '../../../../lib/admin/api';
+import { requireAuth } from '../../../../lib/admin/requireAuth';
+
+function toFormInitial(project) {
+	const info = project.ProjectInfo ?? {};
+	return {
+		title: project.title,
+		url: project.url,
+		category: project.category,
+		thumbnailImg: project.img,
+		headerPublishDate: project.ProjectHeader?.publishDate ?? '',
+		headerTags: project.ProjectHeader?.tags ?? '',
+		clientHeading: info.ClientHeading ?? '',
+		objectivesHeading: info.ObjectivesHeading ?? '',
+		objectivesDetails: info.ObjectivesDetails ?? '',
+		projectDetailsHeading: info.ProjectDetailsHeading ?? 'Challenge',
+		socialSharingHeading: info.SocialSharingHeading ?? '',
+		images: (project.ProjectImages ?? []).map((img) => ({
+			title: img.title,
+			img: img.img,
+		})),
+		companyInfo: (info.CompanyInfo ?? []).map((c) => ({
+			title: c.title,
+			details: c.details,
+		})),
+		technologies: (info.Technologies ?? []).map((t) => ({
+			title: t.title,
+			techs: t.techs ?? [],
+		})),
+		details: (info.ProjectDetails ?? []).map((d) => ({ details: d.details })),
+	};
+}
+
+function AdminProjectsEdit({ project }) {
+	const router = useRouter();
+
+	async function handleSubmit(payload) {
+		try {
+			const updated = await fetchAdmin(`/api/admin/projects/${project.id}`, {
+				method: 'PUT',
+				body: payload,
+			});
+			// slug 이 바뀌었을 수 있지만 편집 라우트는 id 기반이므로 URL 유지
+			router.replace(`/admin/projects/${updated.id}/edit`);
+		} catch (err) {
+			if (err instanceof AdminApiError && err.status === 401) {
+				router.replace('/admin/login');
+				return;
+			}
+			throw err;
+		}
+	}
+
+	return (
+		<AdminLayout title={`Edit · ${project.title}`}>
+			<ProjectForm
+				initialValue={toFormInitial(project)}
+				submitLabel="저장"
+				onSubmit={handleSubmit}
+			/>
+		</AdminLayout>
+	);
+}
+
+const API_BASE_URL = process.env.API_INTERNAL_URL || 'http://localhost:7341';
+
+export const getServerSideProps = requireAuth(async (ctx) => {
+	const id = ctx.params?.id;
+	const cookieHeader = ctx.req?.headers?.cookie ?? '';
+	const res = await fetch(`${API_BASE_URL}/api/admin/projects/${id}`, {
+		headers: cookieHeader ? { cookie: cookieHeader } : undefined,
+	});
+	if (res.status === 404) {
+		return { notFound: true };
+	}
+	if (!res.ok) {
+		throw new Error(`[admin projects edit] API returned ${res.status}`);
+	}
+	const body = await res.json();
+	return { props: { project: body?.data } };
+});
+
+export default AdminProjectsEdit;

--- a/apps/web/pages/admin/projects/index.jsx
+++ b/apps/web/pages/admin/projects/index.jsx
@@ -1,0 +1,120 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useCallback, useState } from 'react';
+import { FiEdit2, FiPlus, FiTrash2 } from 'react-icons/fi';
+import AdminLayout from '../../../components/admin/AdminLayout';
+import AdminTable from '../../../components/admin/AdminTable';
+import { AdminApiError, fetchAdmin } from '../../../lib/admin/api';
+import { requireAuth } from '../../../lib/admin/requireAuth';
+
+function AdminProjectsList({ initialProjects }) {
+	const router = useRouter();
+	const [projects, setProjects] = useState(initialProjects);
+	const [pendingId, setPendingId] = useState(null);
+	const [error, setError] = useState('');
+
+	const handleDelete = useCallback(
+		async (project) => {
+			const confirmed = window.confirm(
+				`'${project.title}' 프로젝트를 삭제할까요? 연관 이미지·상세·기술 목록도 함께 제거됩니다.`,
+			);
+			if (!confirmed) return;
+			setError('');
+			setPendingId(project.id);
+			try {
+				await fetchAdmin(`/api/admin/projects/${project.id}`, { method: 'DELETE' });
+				setProjects((prev) => prev.filter((p) => p.id !== project.id));
+			} catch (err) {
+				if (err instanceof AdminApiError && err.status === 401) {
+					router.replace('/admin/login');
+					return;
+				}
+				setError(err?.message ?? '삭제에 실패했습니다.');
+			} finally {
+				setPendingId(null);
+			}
+		},
+		[router],
+	);
+
+	return (
+		<AdminLayout title="Projects">
+			<div className="flex items-center justify-between mb-5">
+				<p className="font-general-regular text-ternary-dark dark:text-ternary-light">
+					총 {projects.length}개 프로젝트
+				</p>
+				<Link
+					href="/admin/projects/new"
+					className="inline-flex items-center gap-2 font-general-medium text-sm text-white bg-indigo-500 hover:bg-indigo-600 rounded-md px-4 py-2 duration-300"
+				>
+					<FiPlus className="w-4 h-4" />
+					새 프로젝트
+				</Link>
+			</div>
+			{error && (
+				<p className="font-general-regular text-sm text-red-500 dark:text-red-400 mb-3" role="alert">
+					{error}
+				</p>
+			)}
+			<AdminTable
+				columns={[
+					{ key: 'title', label: '제목' },
+					{
+						key: 'url',
+						label: 'URL',
+						render: (row) => (
+							<Link
+								href={`/projects/${row.url}`}
+								className="text-indigo-600 dark:text-indigo-400 hover:underline"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								{row.url}
+							</Link>
+						),
+					},
+					{ key: 'category', label: '카테고리' },
+				]}
+				rows={projects}
+				actions={(row) => (
+					<>
+						<Link
+							href={`/admin/projects/${row.id}/edit`}
+							className="inline-flex items-center gap-1 text-indigo-600 dark:text-indigo-400 hover:underline text-sm"
+						>
+							<FiEdit2 className="w-4 h-4" />
+							편집
+						</Link>
+						<button
+							type="button"
+							onClick={() => handleDelete(row)}
+							disabled={pendingId === row.id}
+							className="inline-flex items-center gap-1 text-red-600 dark:text-red-400 hover:underline text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							<FiTrash2 className="w-4 h-4" />
+							{pendingId === row.id ? '삭제 중…' : '삭제'}
+						</button>
+					</>
+				)}
+				emptyMessage="등록된 프로젝트가 없습니다. 새 프로젝트를 만들어보세요."
+			/>
+		</AdminLayout>
+	);
+}
+
+const API_BASE_URL = process.env.API_INTERNAL_URL || 'http://localhost:7341';
+
+export const getServerSideProps = requireAuth(async (ctx) => {
+	// 목록은 공개 엔드포인트 재사용 (관리자 전용 목록이 따로 필요 없음)
+	const cookieHeader = ctx.req?.headers?.cookie ?? '';
+	const res = await fetch(`${API_BASE_URL}/api/projects`, {
+		headers: cookieHeader ? { cookie: cookieHeader } : undefined,
+	});
+	if (!res.ok) {
+		throw new Error(`[admin projects] list API returned ${res.status}`);
+	}
+	const body = await res.json();
+	return { props: { initialProjects: body?.data ?? [] } };
+});
+
+export default AdminProjectsList;

--- a/apps/web/pages/admin/projects/new.jsx
+++ b/apps/web/pages/admin/projects/new.jsx
@@ -1,0 +1,35 @@
+import { useRouter } from 'next/router';
+import AdminLayout from '../../../components/admin/AdminLayout';
+import ProjectForm from '../../../components/admin/ProjectForm';
+import { AdminApiError, fetchAdmin } from '../../../lib/admin/api';
+import { requireAuth } from '../../../lib/admin/requireAuth';
+
+function AdminProjectsNew() {
+	const router = useRouter();
+
+	async function handleSubmit(payload) {
+		try {
+			const created = await fetchAdmin('/api/admin/projects', {
+				method: 'POST',
+				body: payload,
+			});
+			router.replace(`/admin/projects/${created.id}/edit`);
+		} catch (err) {
+			if (err instanceof AdminApiError && err.status === 401) {
+				router.replace('/admin/login');
+				return;
+			}
+			throw err;
+		}
+	}
+
+	return (
+		<AdminLayout title="New Project">
+			<ProjectForm submitLabel="생성" onSubmit={handleSubmit} />
+		</AdminLayout>
+	);
+}
+
+export const getServerSideProps = requireAuth();
+
+export default AdminProjectsNew;


### PR DESCRIPTION
## 요약

- `/admin/projects` 경로에서 프로젝트를 **생성 · 조회 · 수정 · 삭제**할 수 있도록 API 와 UI 를 구현한다.
- 이미지 파일 업로드는 Phase 2b 에서 별도 처리. 이 PR 의 이미지 필드는 URL/경로 문자열 입력으로 다룸.
- Phase 2a 에서 뽑아낸 공용 컴포넌트(`AdminTable`, `AdminFormSection`, `DynamicList`, `fetchAdmin` 헬퍼)는 Phase 3/4 에서도 재사용 예정.

## 변경 내용

### 커밋 `fd0b72e feat(api): 어드민 Projects CRUD 엔드포인트 추가 (이미지 업로드 제외)`

- `dto/upsert-project.dto.ts` — POST/PUT 공용. 상위 필드 길이·필수 검증 + nested 자식(`images`, `companyInfo`, `technologies`, `details`) `class-validator`
- `admin-projects.service.ts`
  - `getById(id)`: 편집 프리필 용. 기존 mapper 재사용해 프론트 호환 응답 조립
  - `create(dto)`: slug 중복 검사 후 transaction 안에서 save
  - `update(id, dto)`: Image/CompanyInfo/Detail/Technology/TechnologyItem 순으로 삭제 후 재저장 (In(ids)로 하위 item 먼저 제거)
  - `remove(id)`: `repo.delete` 결과 `affected=0` 이면 NotFoundException
- `admin-projects.controller.ts` — 전 엔드포인트 `@UseGuards(JwtAuthGuard)`, Swagger 태그 `Admin · Projects`
- `projects.module.ts` 에 AdminProjectsController/Service 등록
- **엔드포인트**
  - `GET    /api/admin/projects/:id`
  - `POST   /api/admin/projects`
  - `PUT    /api/admin/projects/:id`
  - `DELETE /api/admin/projects/:id`

### 커밋 `b32d0a2 feat(web): 어드민 Projects 관리 UI (목록·생성·편집)와 공용 컴포넌트 추가`

공용 모듈 (⭐ 재사용, ✨ 신규)
- ✨ `lib/admin/api.js` — `fetchAdmin(path, { method, body })` + `AdminApiError(status, payload)`. `credentials: 'include'`, JSON 직렬화/역직렬화, 204 처리
- ✨ `components/admin/AdminTable.jsx` — columns/rows/actions/emptyMessage props. 목록형 어드민 페이지에서 공용
- ✨ `components/admin/AdminFormSection.jsx` — title/description/action 헤더 + children. 섹션 간격 일관
- ✨ `components/admin/DynamicList.jsx` — add/remove/move-up/move-down 을 내장한 N 행 편집 컨트롤. Projects 의 images/companyInfo/technologies/details 네 군데에서 재사용
- ✨ `components/admin/ProjectForm.jsx` — 생성/편집 공용 폼. `toFormState` / `toSubmitPayload` 로 프론트 상태 ↔ API DTO 변환 한 곳으로 모음
- ⭐ `AdminLayout`, `requireAuth` (Phase 1), `reusable/Button`, `reusable/FormInput`

페이지
- `pages/admin/projects/index.jsx` — 목록 조회에 공개 `/api/projects` 재사용. 삭제는 `DELETE /api/admin/projects/:id`, 401 시 `/admin/login` 리다이렉트
- `pages/admin/projects/new.jsx` — `ProjectForm` 기본값으로 생성 후 편집 화면으로 이동
- `pages/admin/projects/[id]/edit.jsx` — `GET /api/admin/projects/:id` 로 프리필, 404 notFound / 5xx throw

## 변경 이유

- DB 중심 데이터로 전환된 이후, 실데이터(시드 JSON) 편집은 사용자가 JSON 파일 + `npm run seed:projects` 를 돌려야 반영되는 구조였음. 어드민 UI 로 대체해 편집 피드백 사이클을 줄임.
- Phase 3/4 에서도 같은 톤의 CRUD 화면이 반복되므로, 이 PR 에서 공용 컴포넌트 4 개 + 헬퍼 1 개를 미리 추출해 후속 작업 비용을 낮춤.

## 영향 범위

- [x] `apps/web`
- [x] `apps/api`
- [ ] `packages`
- [ ] `repo`

## 스크린샷 / 데모

UI 는 기존 어드민 대시보드·로그인 톤을 그대로 따르므로 별도 스크린샷 없음. 로컬에서 `/admin/projects` → `/admin/projects/1/edit` 흐름 확인.

## 테스트 / 확인

- [x] `apps/api` 단위 테스트 **14 케이스** 신규 (controller 4 / service 10). 전체 57 케이스 모두 통과
  - controller: service 위임
  - service: `create` slug 충돌, 정상 save + 재로드, `update` 없음/충돌/자식 삭제 순서/tech 0 일 때 item 삭제 skip, `getById` 존재/부재, `remove` affected 0 NotFound / 성공 void
- [x] `npm run -w apps/api lint`, `build`, `test` 전부 통과
- [x] 수동 시나리오
  - `GET /api/admin/projects/1` 미인증 → 401, 인증 → 200, 없는 id → 404
  - `/admin/projects`, `/new`, `/:id/edit` 미인증 → 307 /admin/login
  - 인증 후 동일 경로 → 200, 목록 테이블에 기존 6 프로젝트 제목/카테고리 렌더

## 리뷰 포인트

- **자식 관계 삭제 전략**: update 에서 `orphanedRowAction` 대신 `transaction + 명시 delete` 선택. 예측 가능성과 테스트 용이성은 좋지만 장기적으로 TypeORM-native 방식으로 바꿀 여지는 있음
- **목록 API 재사용**: 어드민 목록에 공개 `/api/projects` 를 그대로 사용. 페이지네이션·검색이 추가되는 시점에 어드민 전용 목록 필요 여부 재검토 필요
- **슬러그 중복 검사**: DB 제약은 UNIQUE(url) 이지만, 더 친절한 에러를 위해 서비스 레이어에서 선행 조회 후 ConflictException. 레이스 컨디션은 UNIQUE 제약이 최종 방어선
- **이미지 필드 UX**: 이번 PR 에서는 URL 문자열 입력. Phase 2b 에 `ImageUploader` 가 투입될 때 `ProjectForm` 의 해당 영역만 교체하도록 경계를 나눠뒀음
- **공용 컴포넌트 경계**: `AdminTable/AdminFormSection/DynamicList` 의 API 가 About/Contact 에서도 무리 없이 재사용되는지 검토 부탁

## 참고 사항

- `apps/web` 에는 여전히 단위 테스트 인프라가 없어 UI 는 수동 검증만
- slug 변경 후에도 편집 URL 을 유지하도록 `[id]/edit` 라우팅 유지

Closes #24