### PR TITLE
[feat] 어드민 About 편집 화면 (Phase 3)

### DIFF
--- a/apps/api/src/modules/about/about.module.ts
+++ b/apps/api/src/modules/about/about.module.ts
@@ -3,12 +3,14 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AboutController } from './about.controller';
 import { AboutService } from './about.service';
 import { AboutRepository } from './about.repository';
+import { AdminAboutController } from './admin-about.controller';
+import { AdminAboutService } from './admin-about.service';
 import { AboutProfile } from './entities/about-profile.entity';
 import { AboutBio } from './entities/about-bio.entity';
 
 @Module({
   imports: [TypeOrmModule.forFeature([AboutProfile, AboutBio])],
-  controllers: [AboutController],
-  providers: [AboutService, AboutRepository],
+  controllers: [AboutController, AdminAboutController],
+  providers: [AboutService, AboutRepository, AdminAboutService],
 })
 export class AboutModule {}

--- a/apps/api/src/modules/about/admin-about.controller.spec.ts
+++ b/apps/api/src/modules/about/admin-about.controller.spec.ts
@@ -1,0 +1,40 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminAboutController } from './admin-about.controller';
+import { AdminAboutService } from './admin-about.service';
+import { UpsertAboutDto } from './dto/upsert-about.dto';
+
+describe('AdminAboutController', () => {
+  let controller: AdminAboutController;
+  let service: jest.Mocked<AdminAboutService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminAboutController],
+      providers: [
+        {
+          provide: AdminAboutService,
+          useValue: { upsert: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(AdminAboutController);
+    service = module.get(AdminAboutService);
+  });
+
+  it('upsert: service.upsert 결과를 위임한다', async () => {
+    const dto: UpsertAboutDto = {
+      name: 'Lagoon',
+      tagline: 'Backend',
+      profileImage: '/images/profile.jpeg',
+      bio: ['p1', 'p2'],
+    };
+    const returned = { name: 'Lagoon' } as never;
+    service.upsert.mockResolvedValue(returned);
+
+    const result = await controller.upsert(dto);
+
+    expect(service.upsert).toHaveBeenCalledWith(dto);
+    expect(result).toBe(returned);
+  });
+});

--- a/apps/api/src/modules/about/admin-about.controller.ts
+++ b/apps/api/src/modules/about/admin-about.controller.ts
@@ -1,0 +1,20 @@
+import { Body, Controller, Put, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminAboutService } from './admin-about.service';
+import { AboutResponseDto } from './dto/about-response.dto';
+import { UpsertAboutDto } from './dto/upsert-about.dto';
+
+@ApiTags('Admin · About')
+@Controller('api/admin/about')
+@UseGuards(JwtAuthGuard)
+export class AdminAboutController {
+  constructor(private readonly adminAboutService: AdminAboutService) {}
+
+  @Put()
+  @ApiOperation({ summary: '자기소개 전체 덮어쓰기 (singleton)' })
+  @ApiResponse({ status: 200, type: AboutResponseDto })
+  async upsert(@Body() dto: UpsertAboutDto): Promise<AboutResponseDto> {
+    return this.adminAboutService.upsert(dto);
+  }
+}

--- a/apps/api/src/modules/about/admin-about.service.spec.ts
+++ b/apps/api/src/modules/about/admin-about.service.spec.ts
@@ -1,0 +1,109 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { AdminAboutService } from './admin-about.service';
+import { UpsertAboutDto } from './dto/upsert-about.dto';
+import { AboutBio } from './entities/about-bio.entity';
+import { AboutProfile } from './entities/about-profile.entity';
+
+describe('AdminAboutService', () => {
+  let service: AdminAboutService;
+  let profileRepo: jest.Mocked<Repository<AboutProfile>>;
+  let txManager: { save: jest.Mock; delete: jest.Mock };
+  let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
+
+  beforeEach(async () => {
+    txManager = { save: jest.fn(), delete: jest.fn() };
+    dataSource = {
+      transaction: jest
+        .fn()
+        .mockImplementation(async (cb: (m: typeof txManager) => unknown) =>
+          cb(txManager),
+        ),
+    } as unknown as jest.Mocked<Pick<DataSource, 'transaction'>>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminAboutService,
+        {
+          provide: getRepositoryToken(AboutProfile),
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+        { provide: DataSource, useValue: dataSource },
+      ],
+    }).compile();
+
+    service = module.get(AdminAboutService);
+    profileRepo = module.get(getRepositoryToken(AboutProfile));
+  });
+
+  const dto: UpsertAboutDto = {
+    name: 'Lagoon',
+    tagline: 'Backend',
+    profileImage: '/images/profile.jpeg',
+    bio: ['첫 단락', '두 단락'],
+  };
+
+  it('upsert: 기존 bios 전량 삭제 후 profile 재저장', async () => {
+    profileRepo.findOne.mockResolvedValue({
+      id: 1,
+      name: 'Lagoon',
+      tagline: 'Backend',
+      profileImage: '/images/profile.jpeg',
+      bios: [
+        { id: 1, paragraph: '첫 단락', sortOrder: 0 },
+        { id: 2, paragraph: '두 단락', sortOrder: 1 },
+      ],
+    } as never);
+
+    const result = await service.upsert(dto);
+
+    expect(dataSource.transaction).toHaveBeenCalledTimes(1);
+    // 자식 삭제 호출 확인
+    expect(txManager.delete).toHaveBeenCalledWith(AboutBio, { profileId: 1 });
+    // 저장 호출 확인 (AboutProfile + 자식 포함)
+    expect(txManager.save).toHaveBeenCalledWith(AboutProfile, expect.any(AboutProfile));
+    expect(result.name).toBe('Lagoon');
+    expect(result.bio).toEqual(['첫 단락', '두 단락']);
+  });
+
+  it('upsert: tagline 이 undefined 이면 null 로 저장한다', async () => {
+    profileRepo.findOne.mockResolvedValue({
+      id: 1,
+      name: 'Lagoon',
+      tagline: null,
+      profileImage: '/p.jpg',
+      bios: [],
+    } as never);
+
+    const payload: UpsertAboutDto = { ...dto, tagline: undefined, bio: [] };
+    const result = await service.upsert(payload);
+
+    const savedEntity = txManager.save.mock.calls[0][1] as AboutProfile;
+    expect(savedEntity.tagline).toBeNull();
+    expect(result.tagline).toBeNull();
+  });
+
+  it('upsert: bio 는 입력 순서대로 sort_order 0..N-1 부여', async () => {
+    profileRepo.findOne.mockResolvedValue({
+      id: 1,
+      name: 'Lagoon',
+      tagline: null,
+      profileImage: '/p.jpg',
+      bios: [],
+    } as never);
+
+    await service.upsert({ ...dto, bio: ['a', 'b', 'c'] });
+
+    const savedEntity = txManager.save.mock.calls[0][1] as AboutProfile;
+    expect(savedEntity.bios.map((b) => b.sortOrder)).toEqual([0, 1, 2]);
+    expect(savedEntity.bios.map((b) => b.paragraph)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('upsert: 저장 후 profile 이 null 이면 에러', async () => {
+    profileRepo.findOne.mockResolvedValue(null);
+    await expect(service.upsert(dto)).rejects.toThrow(/saved profile not found/);
+  });
+});

--- a/apps/api/src/modules/about/admin-about.service.ts
+++ b/apps/api/src/modules/about/admin-about.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { AboutBio } from './entities/about-bio.entity';
+import { AboutProfile } from './entities/about-profile.entity';
+import { UpsertAboutDto } from './dto/upsert-about.dto';
+import { AboutResponseDto } from './dto/about-response.dto';
+import { toAboutResponseDto } from './mappers/about.mapper';
+
+@Injectable()
+export class AdminAboutService {
+  constructor(
+    @InjectRepository(AboutProfile)
+    private readonly profileRepo: Repository<AboutProfile>,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  async upsert(dto: UpsertAboutDto): Promise<AboutResponseDto> {
+    await this.dataSource.transaction(async (manager) => {
+      // bio 는 전량 교체 (id=1 고정 singleton 에 묶인 자식)
+      await manager.delete(AboutBio, { profileId: 1 });
+
+      const profile = new AboutProfile();
+      profile.id = 1;
+      profile.name = dto.name;
+      profile.tagline = dto.tagline ?? null;
+      profile.profileImage = dto.profileImage;
+      profile.bios = dto.bio.map((paragraph, idx) => {
+        const bio = new AboutBio();
+        bio.paragraph = paragraph;
+        bio.sortOrder = idx;
+        return bio;
+      });
+
+      await manager.save(AboutProfile, profile);
+    });
+
+    const loaded = await this.profileRepo.findOne({
+      where: { id: 1 },
+      relations: { bios: true },
+    });
+    // upsert 가 방금 끝났으니 null 일 리 없지만, 타입 만족을 위해 fallback
+    if (!loaded) {
+      throw new Error('[admin about] saved profile not found after upsert');
+    }
+    return toAboutResponseDto(loaded);
+  }
+}

--- a/apps/api/src/modules/about/dto/upsert-about.dto.spec.ts
+++ b/apps/api/src/modules/about/dto/upsert-about.dto.spec.ts
@@ -1,0 +1,60 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { UpsertAboutDto } from './upsert-about.dto';
+
+const base = (overrides: Partial<UpsertAboutDto> = {}): Partial<UpsertAboutDto> => ({
+  name: 'Lagoon',
+  tagline: 'Backend',
+  profileImage: '/images/profile.jpeg',
+  bio: ['첫 단락', '두 단락'],
+  ...overrides,
+});
+
+function build(overrides: Partial<UpsertAboutDto> = {}): UpsertAboutDto {
+  return plainToInstance(UpsertAboutDto, base(overrides));
+}
+
+describe('UpsertAboutDto', () => {
+  it('정상 payload 는 검증 통과', async () => {
+    const dto = build();
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('name 이 공백-only 이면 trim 후 IsNotEmpty 위반', async () => {
+    const dto = build({ name: '   ' });
+    const errors = await validate(dto);
+    expect(errors.find((e) => e.property === 'name')?.constraints).toHaveProperty(
+      'isNotEmpty',
+    );
+  });
+
+  it('tagline 이 공백-only 이면 null 로 정규화 (선택 필드)', async () => {
+    const dto = build({ tagline: '   ' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+    expect(dto.tagline).toBeNull();
+  });
+
+  it('bio 의 공백-only 항목은 trim 후 IsNotEmpty 위반', async () => {
+    const dto = build({ bio: ['ok', '   '] });
+    const errors = await validate(dto);
+    const bioErr = errors.find((e) => e.property === 'bio');
+    expect(bioErr?.constraints).toHaveProperty('isNotEmpty');
+  });
+
+  it('bio 의 앞뒤 공백은 제거되어 저장된다', async () => {
+    const dto = build({ bio: ['  단락  '] });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+    expect(dto.bio).toEqual(['단락']);
+  });
+
+  it('profileImage 공백-only 는 trim 후 IsNotEmpty 위반', async () => {
+    const dto = build({ profileImage: '   ' });
+    const errors = await validate(dto);
+    expect(errors.find((e) => e.property === 'profileImage')?.constraints).toHaveProperty(
+      'isNotEmpty',
+    );
+  });
+});

--- a/apps/api/src/modules/about/dto/upsert-about.dto.ts
+++ b/apps/api/src/modules/about/dto/upsert-about.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+
+export class UpsertAboutDto {
+  @ApiProperty({ maxLength: 100 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name!: string;
+
+  @ApiProperty({ maxLength: 255, nullable: true, required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  tagline?: string | null;
+
+  @ApiProperty({ maxLength: 500 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(500)
+  profileImage!: string;
+
+  @ApiProperty({ type: [String], description: '마크다운 허용, 입력 순서가 sort_order' })
+  @IsArray()
+  @ArrayMaxSize(50)
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  bio!: string[];
+}

--- a/apps/api/src/modules/about/dto/upsert-about.dto.ts
+++ b/apps/api/src/modules/about/dto/upsert-about.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import {
   ArrayMaxSize,
   IsArray,
@@ -8,26 +9,41 @@ import {
   MaxLength,
 } from 'class-validator';
 
+const trimIfString = (value: unknown): unknown =>
+  typeof value === 'string' ? value.trim() : value;
+
+const trimArray = (value: unknown): unknown =>
+  Array.isArray(value) ? value.map(trimIfString) : value;
+
 export class UpsertAboutDto {
   @ApiProperty({ maxLength: 100 })
+  @Transform(({ value }) => trimIfString(value))
   @IsString()
   @IsNotEmpty()
   @MaxLength(100)
   name!: string;
 
   @ApiProperty({ maxLength: 255, nullable: true, required: false })
+  @Transform(({ value }) => {
+    // 빈 문자열/공백-only 는 명시적으로 null 로 정규화 (tagline 은 null 허용)
+    if (typeof value !== 'string') return value;
+    const trimmed = value.trim();
+    return trimmed.length === 0 ? null : trimmed;
+  })
   @IsOptional()
   @IsString()
   @MaxLength(255)
   tagline?: string | null;
 
   @ApiProperty({ maxLength: 500 })
+  @Transform(({ value }) => trimIfString(value))
   @IsString()
   @IsNotEmpty()
   @MaxLength(500)
   profileImage!: string;
 
   @ApiProperty({ type: [String], description: '마크다운 허용, 입력 순서가 sort_order' })
+  @Transform(({ value }) => trimArray(value))
   @IsArray()
   @ArrayMaxSize(50)
   @IsString({ each: true })

--- a/apps/web/pages/admin/about.jsx
+++ b/apps/web/pages/admin/about.jsx
@@ -43,7 +43,9 @@ function AdminAboutEditor({ initialAbout }) {
 				name: form.name.trim(),
 				tagline: form.tagline.trim() || null,
 				profileImage: form.profileImage.trim(),
-				bio: form.bio.map((b) => b.paragraph).filter((p) => p.length > 0),
+				bio: form.bio
+					.map((b) => b.paragraph.trim())
+					.filter((p) => p.length > 0),
 			};
 			const saved = await fetchAdmin('/api/admin/about', {
 				method: 'PUT',

--- a/apps/web/pages/admin/about.jsx
+++ b/apps/web/pages/admin/about.jsx
@@ -1,0 +1,173 @@
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import AdminFormSection from '../../components/admin/AdminFormSection';
+import AdminLayout from '../../components/admin/AdminLayout';
+import DynamicList from '../../components/admin/DynamicList';
+import ImageUploader from '../../components/admin/ImageUploader';
+import Button from '../../components/reusable/Button';
+import FormInput from '../../components/reusable/FormInput';
+import { AdminApiError, fetchAdmin } from '../../lib/admin/api';
+import { requireAuth } from '../../lib/admin/requireAuth';
+
+function toFormState(about) {
+	return {
+		name: about?.name ?? '',
+		tagline: about?.tagline ?? '',
+		profileImage: about?.profileImage ?? '',
+		bio: (about?.bio ?? []).map((paragraph, i) => ({
+			_key: `bio-${i}-${Math.random()}`,
+			paragraph,
+		})),
+	};
+}
+
+function AdminAboutEditor({ initialAbout }) {
+	const router = useRouter();
+	const [form, setForm] = useState(() => toFormState(initialAbout));
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState('');
+	const [message, setMessage] = useState('');
+
+	function set(name, value) {
+		setForm((prev) => ({ ...prev, [name]: value }));
+	}
+
+	async function handleSubmit(event) {
+		event.preventDefault();
+		if (submitting) return;
+		setError('');
+		setMessage('');
+		setSubmitting(true);
+		try {
+			const payload = {
+				name: form.name.trim(),
+				tagline: form.tagline.trim() || null,
+				profileImage: form.profileImage.trim(),
+				bio: form.bio.map((b) => b.paragraph).filter((p) => p.length > 0),
+			};
+			const saved = await fetchAdmin('/api/admin/about', {
+				method: 'PUT',
+				body: payload,
+			});
+			setForm(toFormState(saved));
+			setMessage('저장되었습니다.');
+		} catch (err) {
+			if (err instanceof AdminApiError && err.status === 401) {
+				router.replace('/admin/login');
+				return;
+			}
+			setError(err?.message ?? '저장에 실패했습니다.');
+		} finally {
+			setSubmitting(false);
+		}
+	}
+
+	return (
+		<AdminLayout title="About">
+			<form onSubmit={handleSubmit}>
+				<AdminFormSection
+					title="프로필"
+					description="공개 /about 페이지 상단에 노출되는 정보입니다."
+				>
+					<FormInput
+						inputLabel="이름"
+						labelFor="about-name"
+						inputType="text"
+						inputId="about-name"
+						inputName="name"
+						ariaLabelName="Name"
+						placeholderText="Lagoon"
+						value={form.name}
+						onChange={(e) => set('name', e.target.value)}
+					/>
+					<label
+						className="block text-lg text-primary-dark dark:text-primary-light mb-1 font-general-regular"
+						htmlFor="about-tagline"
+					>
+						태그라인 (선택)
+					</label>
+					<input
+						id="about-tagline"
+						name="tagline"
+						type="text"
+						placeholder="Backend Developer"
+						aria-label="Tagline"
+						className="w-full px-5 py-2 mb-4 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-ternary-dark rounded-md shadow-sm text-md font-general-regular"
+						value={form.tagline}
+						onChange={(e) => set('tagline', e.target.value)}
+					/>
+					<label className="block text-lg text-primary-dark dark:text-primary-light mb-1 font-general-regular">
+						프로필 이미지
+					</label>
+					<ImageUploader
+						value={form.profileImage}
+						onChange={(url) => set('profileImage', url)}
+						previewAlt={form.name ? `${form.name} profile` : 'Profile preview'}
+					/>
+				</AdminFormSection>
+
+				<AdminFormSection
+					title="Bio 단락"
+					description="입력 순서가 그대로 공개 페이지 노출 순서가 됩니다. 각 단락은 마크다운을 지원합니다."
+				>
+					<DynamicList
+						items={form.bio}
+						onChange={(next) => set('bio', next)}
+						emptyItem={() => ({ _key: `bio-${Date.now()}`, paragraph: '' })}
+						addLabel="단락 추가"
+						renderItem={(item, _idx, onItemChange) => (
+							<textarea
+								className="w-full px-3 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-secondary-dark rounded-md text-sm font-mono"
+								rows={6}
+								placeholder="단락 본문 (마크다운 가능)"
+								aria-label="Bio paragraph"
+								value={item.paragraph}
+								onChange={(e) => onItemChange({ paragraph: e.target.value })}
+								required
+							/>
+						)}
+					/>
+				</AdminFormSection>
+
+				{error && (
+					<p className="font-general-regular text-sm text-red-500 dark:text-red-400 mb-3" role="alert">
+						{error}
+					</p>
+				)}
+				{message && (
+					<p className="font-general-regular text-sm text-green-600 dark:text-green-400 mb-3" role="status">
+						{message}
+					</p>
+				)}
+				<div className="flex justify-end gap-2">
+					<Button
+						title={submitting ? '저장 중…' : '저장'}
+						type="submit"
+						variant="primary"
+						disabled={submitting}
+						ariaLabel="Save about"
+					/>
+				</div>
+			</form>
+		</AdminLayout>
+	);
+}
+
+const API_BASE_URL = process.env.API_INTERNAL_URL || 'http://localhost:7341';
+
+export const getServerSideProps = requireAuth(async (ctx) => {
+	const cookieHeader = ctx.req?.headers?.cookie ?? '';
+	const res = await fetch(`${API_BASE_URL}/api/about`, {
+		headers: cookieHeader ? { cookie: cookieHeader } : undefined,
+	});
+	if (res.status === 404) {
+		return { props: { initialAbout: null } };
+	}
+	if (!res.ok) {
+		throw new Error(`[admin about] API returned ${res.status}`);
+	}
+	const body = await res.json();
+	return { props: { initialAbout: body?.data ?? null } };
+});
+
+export default AdminAboutEditor;


### PR DESCRIPTION
## 요약

- 어드민에서 `/admin/about` 으로 이동해 프로필 이름·태그라인·이미지·Bio 단락을 편집할 수 있도록 한다.
- API 는 `PUT /api/admin/about` 하나로 전체 덮어쓰기. Bio 는 입력 순서 = 화면 노출 순서.
- 프론트 페이지는 **Phase 2a/2b 공용 컴포넌트만 조합** (AdminFormSection, DynamicList, ImageUploader, fetchAdmin). 신규 컴포넌트 추가 0 개.

## 변경 내용

### 커밋 `f747af8 feat(api): 어드민 About 편집 엔드포인트 추가`
- `dto/upsert-about.dto.ts` — name / tagline(optional, null 허용) / profileImage / bio[] 검증. bio 는 입력 순서 = `sort_order`
- `admin-about.service.ts`
  - `upsert(dto)`: transaction 안에서 기존 `AboutBio` 전량 삭제 후 `AboutProfile`(id=1 singleton) + 새 bios 재저장. `tagline undefined → null` 정규화
  - 완료 후 relations 로 재로드해 `AboutResponseDto` 반환
- `admin-about.controller.ts` — `PUT /api/admin/about` `@UseGuards(JwtAuthGuard)`, Swagger 태그 `Admin · About`
- `about.module.ts` 에 AdminAboutController / Service 등록
- 단위 테스트 5 케이스 신규 (controller 1 / service 4)

### 커밋 `4857d7c feat(web): /admin/about 편집 페이지 추가`
- `pages/admin/about.jsx`
  - `requireAuth` + `getServerSideProps` 에서 `/api/about` 프리필 (없으면 빈 폼)
  - 저장은 `fetchAdmin('/api/admin/about', { method: 'PUT', body })`. 응답을 그대로 폼 상태에 되반영해 "저장 후 확인" UX
  - `tagline` 빈 문자열 → null, `bio` 빈 문자열 문항 자동 필터링
  - 401 은 `/admin/login` 리다이렉트, 기타 에러는 인라인 메시지
- 사용 컴포넌트: 전부 기존 (AdminLayout, AdminFormSection, DynamicList, ImageUploader, reusable/Button, reusable/FormInput). **신규 0**

## 변경 이유

- About 컨텐츠 편집이 아직 JSON 시드 + `seed:about` 수동 실행 루프였던 것을 어드민 UI 로 일원화
- Phase 2a/2b 에서 추출한 공용 컴포넌트의 "재사용 대상" 검증 — About 페이지 전체가 공용 컴포넌트 조합만으로 완성되는지 확인

## 영향 범위

- [x] `apps/web`
- [x] `apps/api`
- [ ] `packages`
- [ ] `repo`

## 스크린샷 / 데모

UI 는 기존 어드민 폼(Projects) 톤과 동일 — 상단 프로필 블록 + 하단 Bio DynamicList. 별도 스크린샷 없음.

## 테스트 / 확인

- [x] 단위 테스트 5 케이스 신규 (controller/service). 전체 73 케이스 통과
- [x] `npm run -w apps/api lint / build` 통과
- [x] 수동 시나리오
  - 미인증 `PUT /api/admin/about` → 401
  - 인증 후 `PUT` → 200 + 응답 데이터
  - 공개 `GET /api/about` 이 즉시 업데이트된 데이터 반환
  - `/admin/about` 미인증 → 307 `/admin/login`, 인증 후 200
  - 저장 후 공개 `/about` 페이지에 반영 확인

## 리뷰 포인트

- **전체 덮어쓰기 방식**: bio 를 부분 수정하지 않고 항상 통째 교체. singleton + 단순 구조 전제에서 충분하지만 향후 단락별 `PATCH` 수요가 생기면 확장 필요
- **공용 컴포넌트 경계**: About 페이지가 공용 컴포넌트 조합만으로 완성되는지가 Phase 3 이슈의 완료 조건. 실제로 신규 컴포넌트 0 개로 구성됨을 확인 부탁
- **초기 상태 404 처리**: seed 전(프로필 미존재) 에는 공개 `/api/about` 이 404. 어드민 페이지는 이 경우 빈 폼으로 열어 초기 등록을 유도하도록 `getServerSideProps` 에서 404 를 graceful 처리

## 참고 사항

- tagline 을 DB 에 명시적으로 NULL 저장하기 위해 DTO 에서 `null` 을 허용하고, 서비스에서 `undefined → null` 로 정규화
- 프로필 이미지 업로드는 Phase 2b 의 공용 `ImageUploader` + `POST /api/admin/uploads` 를 그대로 사용

Closes #26