### PR TITLE
[feat] 어드민 Contact 수신함 (Phase 4)

### DIFF
--- a/apps/api/src/modules/contact/admin-contact.controller.spec.ts
+++ b/apps/api/src/modules/contact/admin-contact.controller.spec.ts
@@ -1,0 +1,53 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminContactController } from './admin-contact.controller';
+import { AdminContactService } from './admin-contact.service';
+import { ContactStatus } from './entities/contact-submission.entity';
+
+describe('AdminContactController', () => {
+  let controller: AdminContactController;
+  let service: jest.Mocked<AdminContactService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminContactController],
+      providers: [
+        {
+          provide: AdminContactService,
+          useValue: {
+            list: jest.fn(),
+            getById: jest.fn(),
+            updateStatus: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(AdminContactController);
+    service = module.get(AdminContactService);
+  });
+
+  it('list: query 를 service.list 에 위임', async () => {
+    const page = { items: [], total: 0, page: 1, limit: 20 } as never;
+    service.list.mockResolvedValue(page);
+    const result = await controller.list({ status: ContactStatus.PENDING });
+    expect(service.list).toHaveBeenCalledWith({ status: ContactStatus.PENDING });
+    expect(result).toBe(page);
+  });
+
+  it('getById: service.getById(id) 위임', async () => {
+    const detail = { id: 5 } as never;
+    service.getById.mockResolvedValue(detail);
+    const result = await controller.getById(5);
+    expect(service.getById).toHaveBeenCalledWith(5);
+    expect(result).toBe(detail);
+  });
+
+  it('updateStatus: (id, dto) 를 service 로 위임', async () => {
+    const detail = { id: 7, status: ContactStatus.READ } as never;
+    service.updateStatus.mockResolvedValue(detail);
+    const dto = { status: ContactStatus.READ };
+    const result = await controller.updateStatus(7, dto);
+    expect(service.updateStatus).toHaveBeenCalledWith(7, dto);
+    expect(result).toBe(detail);
+  });
+});

--- a/apps/api/src/modules/contact/admin-contact.controller.ts
+++ b/apps/api/src/modules/contact/admin-contact.controller.ts
@@ -1,0 +1,56 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminContactService } from './admin-contact.service';
+import {
+  ContactDetailDto,
+  ContactListPageDto,
+} from './dto/contact-list.dto';
+import { ListContactQueryDto } from './dto/list-contact-query.dto';
+import { UpdateStatusDto } from './dto/update-status.dto';
+
+@ApiTags('Admin · Contact')
+@Controller('api/admin/contact')
+@UseGuards(JwtAuthGuard)
+export class AdminContactController {
+  constructor(private readonly adminContactService: AdminContactService) {}
+
+  @Get()
+  @ApiOperation({ summary: '연락 폼 제출 목록 (status 필터 + 페이지네이션)' })
+  @ApiResponse({ status: 200, type: ContactListPageDto })
+  async list(
+    @Query() query: ListContactQueryDto,
+  ): Promise<ContactListPageDto> {
+    return this.adminContactService.list(query);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: '연락 폼 단건 조회 (본문 message 포함)' })
+  @ApiResponse({ status: 200, type: ContactDetailDto })
+  @ApiResponse({ status: 404 })
+  async getById(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<ContactDetailDto> {
+    return this.adminContactService.getById(id);
+  }
+
+  @Patch(':id/status')
+  @ApiOperation({ summary: 'status 토글 (pending / read / replied)' })
+  @ApiResponse({ status: 200, type: ContactDetailDto })
+  @ApiResponse({ status: 404 })
+  async updateStatus(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateStatusDto,
+  ): Promise<ContactDetailDto> {
+    return this.adminContactService.updateStatus(id, dto);
+  }
+}

--- a/apps/api/src/modules/contact/admin-contact.service.spec.ts
+++ b/apps/api/src/modules/contact/admin-contact.service.spec.ts
@@ -1,0 +1,122 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AdminContactService } from './admin-contact.service';
+import {
+  ContactStatus,
+  ContactSubmission,
+} from './entities/contact-submission.entity';
+
+const row = (overrides: Partial<ContactSubmission> = {}): ContactSubmission =>
+  ({
+    id: 1,
+    name: 'Alice',
+    email: 'a@example.com',
+    subject: 'hello',
+    message: 'body',
+    status: ContactStatus.PENDING,
+    createdAt: new Date('2026-04-01T00:00:00.000Z'),
+    ...overrides,
+  }) as ContactSubmission;
+
+describe('AdminContactService', () => {
+  let service: AdminContactService;
+  let repo: jest.Mocked<Repository<ContactSubmission>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminContactService,
+        {
+          provide: getRepositoryToken(ContactSubmission),
+          useValue: {
+            findAndCount: jest.fn(),
+            findOne: jest.fn(),
+            update: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(AdminContactService);
+    repo = module.get(getRepositoryToken(ContactSubmission));
+  });
+
+  describe('list', () => {
+    it('status 미지정 시 빈 where 로 페이징 조회', async () => {
+      repo.findAndCount.mockResolvedValue([[row()], 1]);
+      const result = await service.list({});
+      expect(repo.findAndCount).toHaveBeenCalledWith({
+        where: {},
+        order: { createdAt: 'DESC', id: 'DESC' },
+        take: 20,
+        skip: 0,
+      });
+      expect(result.items).toHaveLength(1);
+      expect(result.total).toBe(1);
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(20);
+    });
+
+    it('status 지정 시 where 에 포함, page/limit 반영된 skip 계산', async () => {
+      repo.findAndCount.mockResolvedValue([[], 0]);
+      await service.list({
+        status: ContactStatus.READ,
+        page: 3,
+        limit: 5,
+      });
+      expect(repo.findAndCount).toHaveBeenCalledWith({
+        where: { status: ContactStatus.READ },
+        order: { createdAt: 'DESC', id: 'DESC' },
+        take: 5,
+        skip: 10,
+      });
+    });
+
+    it('응답은 message 를 포함하지 않는다 (목록 경량화)', async () => {
+      repo.findAndCount.mockResolvedValue([[row({ message: 'secret body' })], 1]);
+      const result = await service.list({});
+      const item = result.items[0] as unknown as Record<string, unknown>;
+      expect(item.message).toBeUndefined();
+    });
+  });
+
+  describe('getById', () => {
+    it('없으면 NotFoundException', async () => {
+      repo.findOne.mockResolvedValue(null);
+      await expect(service.getById(99)).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('있으면 message 포함 전체 필드 반환', async () => {
+      repo.findOne.mockResolvedValue(row({ id: 2, message: 'hi' }));
+      const result = await service.getById(2);
+      expect(result.id).toBe(2);
+      expect(result.message).toBe('hi');
+    });
+  });
+
+  describe('updateStatus', () => {
+    it('대상 없으면 NotFoundException', async () => {
+      repo.findOne.mockResolvedValue(null);
+      await expect(
+        service.updateStatus(9, { status: ContactStatus.READ }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(repo.update).not.toHaveBeenCalled();
+    });
+
+    it('성공 시 update 호출 후 최신 데이터 반환', async () => {
+      repo.findOne
+        .mockResolvedValueOnce(row({ id: 5, status: ContactStatus.PENDING }))
+        .mockResolvedValueOnce(row({ id: 5, status: ContactStatus.READ }));
+      repo.update.mockResolvedValue({ affected: 1, raw: {} } as never);
+
+      const result = await service.updateStatus(5, {
+        status: ContactStatus.READ,
+      });
+
+      expect(repo.update).toHaveBeenCalledWith(5, { status: ContactStatus.READ });
+      expect(result.status).toBe(ContactStatus.READ);
+    });
+  });
+});

--- a/apps/api/src/modules/contact/admin-contact.service.ts
+++ b/apps/api/src/modules/contact/admin-contact.service.ts
@@ -1,0 +1,64 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ContactSubmission } from './entities/contact-submission.entity';
+import {
+  ContactDetailDto,
+  ContactListItemDto,
+  ContactListPageDto,
+} from './dto/contact-list.dto';
+import { ListContactQueryDto } from './dto/list-contact-query.dto';
+import { UpdateStatusDto } from './dto/update-status.dto';
+
+@Injectable()
+export class AdminContactService {
+  constructor(
+    @InjectRepository(ContactSubmission)
+    private readonly repo: Repository<ContactSubmission>,
+  ) {}
+
+  async list(query: ListContactQueryDto): Promise<ContactListPageDto> {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    const [rows, total] = await this.repo.findAndCount({
+      where: query.status ? { status: query.status } : {},
+      order: { createdAt: 'DESC', id: 'DESC' },
+      take: limit,
+      skip: (page - 1) * limit,
+    });
+    const items: ContactListItemDto[] = rows.map((r) => ({
+      id: r.id,
+      name: r.name,
+      email: r.email,
+      subject: r.subject,
+      status: r.status,
+      createdAt: r.createdAt,
+    }));
+    return { items, total, page, limit };
+  }
+
+  async getById(id: number): Promise<ContactDetailDto> {
+    const found = await this.repo.findOne({ where: { id } });
+    if (!found) {
+      throw new NotFoundException(`Contact submission not found: id=${id}`);
+    }
+    return {
+      id: found.id,
+      name: found.name,
+      email: found.email,
+      subject: found.subject,
+      message: found.message,
+      status: found.status,
+      createdAt: found.createdAt,
+    };
+  }
+
+  async updateStatus(id: number, dto: UpdateStatusDto): Promise<ContactDetailDto> {
+    const exists = await this.repo.findOne({ where: { id } });
+    if (!exists) {
+      throw new NotFoundException(`Contact submission not found: id=${id}`);
+    }
+    await this.repo.update(id, { status: dto.status });
+    return this.getById(id);
+  }
+}

--- a/apps/api/src/modules/contact/contact.module.ts
+++ b/apps/api/src/modules/contact/contact.module.ts
@@ -3,11 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ContactController } from './contact.controller';
 import { ContactService } from './contact.service';
 import { ContactRepository } from './contact.repository';
+import { AdminContactController } from './admin-contact.controller';
+import { AdminContactService } from './admin-contact.service';
 import { ContactSubmission } from './entities/contact-submission.entity';
 
 @Module({
   imports: [TypeOrmModule.forFeature([ContactSubmission])],
-  controllers: [ContactController],
-  providers: [ContactService, ContactRepository],
+  controllers: [ContactController, AdminContactController],
+  providers: [ContactService, ContactRepository, AdminContactService],
 })
 export class ContactModule {}

--- a/apps/api/src/modules/contact/dto/contact-list.dto.ts
+++ b/apps/api/src/modules/contact/dto/contact-list.dto.ts
@@ -1,0 +1,59 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ContactStatus } from '../entities/contact-submission.entity';
+
+export class ContactListItemDto {
+  @ApiProperty()
+  id!: number;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty()
+  email!: string;
+
+  @ApiProperty()
+  subject!: string;
+
+  @ApiProperty({ enum: ContactStatus })
+  status!: ContactStatus;
+
+  @ApiProperty()
+  createdAt!: Date;
+}
+
+export class ContactListPageDto {
+  @ApiProperty({ type: [ContactListItemDto] })
+  items!: ContactListItemDto[];
+
+  @ApiProperty()
+  total!: number;
+
+  @ApiProperty()
+  page!: number;
+
+  @ApiProperty()
+  limit!: number;
+}
+
+export class ContactDetailDto {
+  @ApiProperty()
+  id!: number;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty()
+  email!: string;
+
+  @ApiProperty()
+  subject!: string;
+
+  @ApiProperty()
+  message!: string;
+
+  @ApiProperty({ enum: ContactStatus })
+  status!: ContactStatus;
+
+  @ApiProperty()
+  createdAt!: Date;
+}

--- a/apps/api/src/modules/contact/dto/list-contact-query.dto.ts
+++ b/apps/api/src/modules/contact/dto/list-contact-query.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
+import { ContactStatus } from '../entities/contact-submission.entity';
+
+export class ListContactQueryDto {
+  @ApiProperty({ enum: ContactStatus, required: false })
+  @IsOptional()
+  @IsEnum(ContactStatus)
+  status?: ContactStatus;
+
+  @ApiProperty({ required: false, default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiProperty({ required: false, default: 20, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/apps/api/src/modules/contact/dto/update-status.dto.ts
+++ b/apps/api/src/modules/contact/dto/update-status.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+import { ContactStatus } from '../entities/contact-submission.entity';
+
+export class UpdateStatusDto {
+  @ApiProperty({ enum: ContactStatus })
+  @IsEnum(ContactStatus)
+  status!: ContactStatus;
+}

--- a/apps/web/components/admin/StatusBadge.jsx
+++ b/apps/web/components/admin/StatusBadge.jsx
@@ -1,0 +1,31 @@
+// 어드민에서 Contact 제출 status 를 한눈에 보여주는 배지. 기존 팔레트 안에서만 톤 조합.
+const STATUS_STYLES = {
+	pending: {
+		label: 'Pending',
+		className:
+			'bg-gray-100 text-primary-dark dark:bg-ternary-dark dark:text-ternary-light',
+	},
+	read: {
+		label: 'Read',
+		className:
+			'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300',
+	},
+	replied: {
+		label: 'Replied',
+		className:
+			'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300',
+	},
+};
+
+function StatusBadge({ status }) {
+	const style = STATUS_STYLES[status] ?? STATUS_STYLES.pending;
+	return (
+		<span
+			className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-general-medium ${style.className}`}
+		>
+			{style.label}
+		</span>
+	);
+}
+
+export default StatusBadge;

--- a/apps/web/pages/admin/contact.jsx
+++ b/apps/web/pages/admin/contact.jsx
@@ -1,0 +1,198 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useCallback, useState } from 'react';
+import AdminLayout from '../../components/admin/AdminLayout';
+import AdminTable from '../../components/admin/AdminTable';
+import StatusBadge from '../../components/admin/StatusBadge';
+import { AdminApiError, fetchAdmin } from '../../lib/admin/api';
+import { requireAuth } from '../../lib/admin/requireAuth';
+
+const FILTERS = [
+	{ key: '', label: 'All' },
+	{ key: 'pending', label: 'Pending' },
+	{ key: 'read', label: 'Read' },
+	{ key: 'replied', label: 'Replied' },
+];
+
+const STATUS_OPTIONS = ['pending', 'read', 'replied'];
+
+function formatDate(iso) {
+	try {
+		return new Date(iso).toLocaleString('ko-KR', {
+			year: 'numeric',
+			month: '2-digit',
+			day: '2-digit',
+			hour: '2-digit',
+			minute: '2-digit',
+		});
+	} catch {
+		return iso;
+	}
+}
+
+function AdminContactInbox({ initialPage, initialStatus }) {
+	const router = useRouter();
+	const [page, setPage] = useState(initialPage);
+	const [status, setStatus] = useState(initialStatus);
+	const [pendingId, setPendingId] = useState(null);
+	const [error, setError] = useState('');
+
+	const applyFilter = useCallback(
+		(nextStatus) => {
+			router.push(
+				nextStatus
+					? { pathname: '/admin/contact', query: { status: nextStatus } }
+					: { pathname: '/admin/contact' },
+			);
+		},
+		[router],
+	);
+
+	const handleStatusChange = useCallback(
+		async (item, nextStatus) => {
+			if (nextStatus === item.status) return;
+			setPendingId(item.id);
+			setError('');
+			try {
+				await fetchAdmin(`/api/admin/contact/${item.id}/status`, {
+					method: 'PATCH',
+					body: { status: nextStatus },
+				});
+				setPage((prev) => ({
+					...prev,
+					items: prev.items.map((row) =>
+						row.id === item.id ? { ...row, status: nextStatus } : row,
+					),
+				}));
+			} catch (err) {
+				if (err instanceof AdminApiError && err.status === 401) {
+					router.replace('/admin/login');
+					return;
+				}
+				setError(err?.message ?? '상태 변경에 실패했습니다.');
+			} finally {
+				setPendingId(null);
+			}
+		},
+		[router],
+	);
+
+	return (
+		<AdminLayout title="Contact">
+			<div className="flex flex-wrap items-center gap-2 mb-5">
+				{FILTERS.map(({ key, label }) => {
+					const active = (status ?? '') === key;
+					return (
+						<button
+							key={label}
+							type="button"
+							onClick={() => applyFilter(key)}
+							className={`px-3 py-1.5 rounded-full text-sm font-general-medium duration-300 ${
+								active
+									? 'bg-indigo-500 text-white'
+									: 'bg-ternary-light dark:bg-ternary-dark text-primary-dark dark:text-primary-light hover:bg-indigo-100 dark:hover:bg-secondary-dark'
+							}`}
+						>
+							{label}
+						</button>
+					);
+				})}
+				<span className="ml-auto text-sm font-general-regular text-ternary-dark dark:text-ternary-light">
+					{page.total}건 (페이지 {page.page})
+				</span>
+			</div>
+
+			{error && (
+				<p className="font-general-regular text-sm text-red-500 dark:text-red-400 mb-3" role="alert">
+					{error}
+				</p>
+			)}
+
+			<AdminTable
+				columns={[
+					{
+						key: 'createdAt',
+						label: '시간',
+						render: (row) => (
+							<span className="text-xs text-ternary-dark dark:text-ternary-light">
+								{formatDate(row.createdAt)}
+							</span>
+						),
+					},
+					{ key: 'name', label: '이름' },
+					{
+						key: 'email',
+						label: '이메일',
+						render: (row) => (
+							<a
+								href={`mailto:${row.email}`}
+								className="text-indigo-600 dark:text-indigo-400 hover:underline"
+							>
+								{row.email}
+							</a>
+						),
+					},
+					{ key: 'subject', label: '주제' },
+					{
+						key: 'status',
+						label: '상태',
+						render: (row) => (
+							<div className="flex items-center gap-2">
+								<StatusBadge status={row.status} />
+								<select
+									value={row.status}
+									disabled={pendingId === row.id}
+									onChange={(e) => handleStatusChange(row, e.target.value)}
+									className="px-2 py-1 text-xs border border-gray-300 dark:border-primary-dark border-opacity-50 bg-ternary-light dark:bg-ternary-dark rounded font-general-regular disabled:opacity-50"
+									aria-label="Change status"
+								>
+									{STATUS_OPTIONS.map((opt) => (
+										<option key={opt} value={opt}>
+											{opt}
+										</option>
+									))}
+								</select>
+							</div>
+						),
+					},
+				]}
+				rows={page.items}
+				actions={(row) => (
+					<Link
+						href={`/admin/contact/${row.id}`}
+						className="text-indigo-600 dark:text-indigo-400 hover:underline text-sm"
+					>
+						상세
+					</Link>
+				)}
+				emptyMessage="조건에 맞는 제출 내역이 없습니다."
+			/>
+		</AdminLayout>
+	);
+}
+
+const API_BASE_URL = process.env.API_INTERNAL_URL || 'http://localhost:7341';
+
+export const getServerSideProps = requireAuth(async (ctx) => {
+	const cookieHeader = ctx.req?.headers?.cookie ?? '';
+	const status = typeof ctx.query.status === 'string' ? ctx.query.status : '';
+	const params = new URLSearchParams();
+	if (status) params.set('status', status);
+
+	const res = await fetch(
+		`${API_BASE_URL}/api/admin/contact?${params.toString()}`,
+		{ headers: cookieHeader ? { cookie: cookieHeader } : undefined },
+	);
+	if (!res.ok) {
+		throw new Error(`[admin contact] list API returned ${res.status}`);
+	}
+	const body = await res.json();
+	return {
+		props: {
+			initialPage: body?.data ?? { items: [], total: 0, page: 1, limit: 20 },
+			initialStatus: status || null,
+		},
+	};
+});
+
+export default AdminContactInbox;

--- a/apps/web/pages/admin/contact.jsx
+++ b/apps/web/pages/admin/contact.jsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import AdminLayout from '../../components/admin/AdminLayout';
 import AdminTable from '../../components/admin/AdminTable';
 import StatusBadge from '../../components/admin/StatusBadge';
@@ -32,8 +32,14 @@ function formatDate(iso) {
 
 function AdminContactInbox({ initialPage, initialStatus }) {
 	const router = useRouter();
+	// 필터 탭 클릭 → router.push 로 쿼리만 변경 → getServerSideProps 재실행 → 새 props 주입.
+	// optimistic 상태 변경(드롭다운 PATCH) 을 위해 page 는 state 로 들고 있되,
+	// 라우팅 후 내려온 initialPage 로 다시 동기화한다. status 는 파생값이라 props 그대로 사용.
 	const [page, setPage] = useState(initialPage);
-	const [status, setStatus] = useState(initialStatus);
+	useEffect(() => {
+		setPage(initialPage);
+	}, [initialPage]);
+	const status = initialStatus;
 	const [pendingId, setPendingId] = useState(null);
 	const [error, setError] = useState('');
 

--- a/apps/web/pages/admin/contact/[id].jsx
+++ b/apps/web/pages/admin/contact/[id].jsx
@@ -1,0 +1,141 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import { FiArrowLeft } from 'react-icons/fi';
+import AdminFormSection from '../../../components/admin/AdminFormSection';
+import AdminLayout from '../../../components/admin/AdminLayout';
+import StatusBadge from '../../../components/admin/StatusBadge';
+import { AdminApiError, fetchAdmin } from '../../../lib/admin/api';
+import { requireAuth } from '../../../lib/admin/requireAuth';
+
+const STATUS_OPTIONS = ['pending', 'read', 'replied'];
+
+function formatDate(iso) {
+	try {
+		return new Date(iso).toLocaleString('ko-KR');
+	} catch {
+		return iso;
+	}
+}
+
+function AdminContactDetail({ initial }) {
+	const router = useRouter();
+	const [detail, setDetail] = useState(initial);
+	const [updating, setUpdating] = useState(false);
+	const [error, setError] = useState('');
+
+	async function handleStatusChange(nextStatus) {
+		if (nextStatus === detail.status) return;
+		setUpdating(true);
+		setError('');
+		try {
+			const updated = await fetchAdmin(
+				`/api/admin/contact/${detail.id}/status`,
+				{ method: 'PATCH', body: { status: nextStatus } },
+			);
+			setDetail(updated);
+		} catch (err) {
+			if (err instanceof AdminApiError && err.status === 401) {
+				router.replace('/admin/login');
+				return;
+			}
+			setError(err?.message ?? '상태 변경에 실패했습니다.');
+		} finally {
+			setUpdating(false);
+		}
+	}
+
+	return (
+		<AdminLayout title={`Contact · ${detail.subject}`}>
+			<div className="mb-4">
+				<Link
+					href="/admin/contact"
+					className="inline-flex items-center gap-1 text-indigo-600 dark:text-indigo-400 hover:underline text-sm"
+				>
+					<FiArrowLeft className="w-4 h-4" />
+					목록으로
+				</Link>
+			</div>
+
+			<AdminFormSection title="메타 정보">
+				<dl className="grid grid-cols-1 sm:grid-cols-2 gap-y-2 gap-x-6 font-general-regular">
+					<div>
+						<dt className="text-xs text-ternary-dark dark:text-ternary-light">이름</dt>
+						<dd className="text-primary-dark dark:text-primary-light">{detail.name}</dd>
+					</div>
+					<div>
+						<dt className="text-xs text-ternary-dark dark:text-ternary-light">이메일</dt>
+						<dd>
+							<a
+								href={`mailto:${detail.email}`}
+								className="text-indigo-600 dark:text-indigo-400 hover:underline"
+							>
+								{detail.email}
+							</a>
+						</dd>
+					</div>
+					<div>
+						<dt className="text-xs text-ternary-dark dark:text-ternary-light">주제</dt>
+						<dd className="text-primary-dark dark:text-primary-light">{detail.subject}</dd>
+					</div>
+					<div>
+						<dt className="text-xs text-ternary-dark dark:text-ternary-light">제출 시각</dt>
+						<dd className="text-primary-dark dark:text-primary-light">
+							{formatDate(detail.createdAt)}
+						</dd>
+					</div>
+					<div>
+						<dt className="text-xs text-ternary-dark dark:text-ternary-light">상태</dt>
+						<dd className="flex items-center gap-2">
+							<StatusBadge status={detail.status} />
+							<select
+								value={detail.status}
+								onChange={(e) => handleStatusChange(e.target.value)}
+								disabled={updating}
+								className="px-2 py-1 text-xs border border-gray-300 dark:border-primary-dark border-opacity-50 bg-ternary-light dark:bg-ternary-dark rounded disabled:opacity-50"
+								aria-label="Change status"
+							>
+								{STATUS_OPTIONS.map((opt) => (
+									<option key={opt} value={opt}>
+										{opt}
+									</option>
+								))}
+							</select>
+						</dd>
+					</div>
+				</dl>
+				{error && (
+					<p className="mt-3 text-sm text-red-500 dark:text-red-400" role="alert">
+						{error}
+					</p>
+				)}
+			</AdminFormSection>
+
+			<AdminFormSection title="메시지">
+				<pre className="whitespace-pre-wrap font-general-regular text-sm text-primary-dark dark:text-primary-light leading-relaxed">
+					{detail.message}
+				</pre>
+			</AdminFormSection>
+		</AdminLayout>
+	);
+}
+
+const API_BASE_URL = process.env.API_INTERNAL_URL || 'http://localhost:7341';
+
+export const getServerSideProps = requireAuth(async (ctx) => {
+	const id = ctx.params?.id;
+	const cookieHeader = ctx.req?.headers?.cookie ?? '';
+	const res = await fetch(`${API_BASE_URL}/api/admin/contact/${id}`, {
+		headers: cookieHeader ? { cookie: cookieHeader } : undefined,
+	});
+	if (res.status === 404) {
+		return { notFound: true };
+	}
+	if (!res.ok) {
+		throw new Error(`[admin contact detail] API returned ${res.status}`);
+	}
+	const body = await res.json();
+	return { props: { initial: body?.data } };
+});
+
+export default AdminContactDetail;


### PR DESCRIPTION
## 요약

- 공개 `/contact` 폼으로 쌓인 제출 내역을 어드민이 확인하고 상태를 관리할 수 있도록 `/admin/contact` 목록·상세 화면과 admin 전용 엔드포인트 3 개를 추가한다.
- 공용 어드민 컴포넌트(AdminLayout, AdminFormSection, AdminTable, fetchAdmin) 를 그대로 재사용. 신규 컴포넌트는 **`StatusBadge` 하나**로 제한 (이슈 #27 명시 범위).

## 변경 내용

### 커밋 `1abc82f feat(api): 어드민 Contact 수신함 엔드포인트 추가`

- 엔드포인트 (전부 `@UseGuards(JwtAuthGuard)`)
  - `GET    /api/admin/contact?status=&page=&limit=` — 페이지네이션 + 상태 필터. 응답에 `message` 는 제외해 목록 경량화
  - `GET    /api/admin/contact/:id` — 본문 포함 상세
  - `PATCH  /api/admin/contact/:id/status` — 상태 토글(pending/read/replied)
- DTO: `ListContactQueryDto` (IsEnum/IsInt/Min/Max, page·limit 기본 20/최대 100), `UpdateStatusDto` (IsEnum), `ContactListItemDto` / `ContactListPageDto` / `ContactDetailDto`
- Service
  - `list`: `findAndCount` + `createdAt DESC, id DESC`
  - `getById`: 404 시 NotFoundException
  - `updateStatus`: 존재 확인 후 update, 갱신된 상세 재조회 반환
- 단위 테스트 10 케이스 (controller 3 / service 7). 전체 89 케이스 통과, lint/build OK

### 커밋 `b76ba1d feat(web): /admin/contact 수신함 목록/상세 페이지 추가`

- ✨ 신규 `components/admin/StatusBadge.jsx` — pending/read/replied 상태를 기존 팔레트 안에서만 구분 (gray / indigo tint / green tint), dark 모드 대응
- `pages/admin/contact.jsx` (목록)
  - 필터 탭(All/Pending/Read/Replied)은 쿼리스트링으로 라우팅
  - `AdminTable` 에 시간·이름·이메일·주제·상태·상세 링크 컬럼
  - 상태 셀 안에 inline select → `PATCH` 즉시 호출, 401 로그인 리다이렉트, 기타 에러는 인라인
- `pages/admin/contact/[id].jsx` (상세)
  - 메타 dl 블록 + 본문 `<pre>` (whitespace preserving)
  - 상세 화면에서도 동일 드롭다운으로 상태 변경

## 변경 이유

- 그동안 Contact 제출 내역은 DB 에 쌓이기만 하고 확인/추적 경로가 없었음. 어드민 UI 에서 읽고 `pending → read → replied` 로 관리할 수 있어야 운영이 성립
- 공용 컴포넌트 재사용 목표: Phase 2a 에서 추출한 `AdminTable` + Phase 1 의 `AdminLayout` + `fetchAdmin` 만으로 화면의 90% 를 채울 수 있는지 검증 (결과: StatusBadge 하나 추가로 충분)

## 영향 범위

- [x] `apps/web`
- [x] `apps/api`
- [ ] `packages`
- [ ] `repo`

## 스크린샷 / 데모

기존 어드민 톤 그대로. 필터 탭 + 테이블 + inline 드롭다운. 별도 스크린샷 없음.

## 테스트 / 확인

- [x] `apps/api` 단위 테스트 10 케이스 신규 (controller 3 / service 7). 전체 89 케이스 통과
- [x] `npm run -w apps/api lint / build / test` 전부 통과
- [x] 수동 시나리오
  - 미인증 `GET /api/admin/contact` → 401
  - 인증 후 기본 목록, `?status=pending` 필터, `/:id` 단건, `/:id/status` PATCH 동작 확인
  - 프론트 `/admin/contact`, `?status=pending`, `/admin/contact/1` → 200
  - `/admin/contact/9999` → 404 (notFound)
  - 미인증 `/admin/contact*` → 307 `/admin/login`

## 리뷰 포인트

- **목록 응답에서 `message` 제외**: 리스트 트래픽 경량화 목적. 상세에서 따로 로드. 필요 시 향후 옵션 파라미터(`includeMessage=true`) 로 확장 가능
- **페이지네이션 UI**: 이번 PR 에선 API 만 구현했고 프론트에는 현재 페이지 표기만. "이전/다음" 버튼이나 숫자 네비는 후속 이슈 범위로 판단
- **삭제(DELETE)**: 이번 스코프 밖. 제출 내역은 status 관리만 하고 물리 삭제는 도입 안 함
- **StatusBadge 색상 톤**: 기존 Tailwind 팔레트 기반 (`gray-100`, `indigo-100`, `green-100` + dark 변형). 별도 색 추가 없이 구성

## 참고 사항

- 페이지네이션은 offset/limit 방식. 건수가 많아지면 cursor 기반으로 교체 고려
- 이메일 답장 기능(외부 SaaS 연동)은 후속 이슈

Closes #27