### PR TITLE
[feat] ImageUploader 교체 UX 개선 (이미지 관리 Phase A)

### DIFF
--- a/apps/web/components/admin/ImageUploader.jsx
+++ b/apps/web/components/admin/ImageUploader.jsx
@@ -27,15 +27,22 @@ function ImageUploader({ value, onChange, previewAlt = 'Upload preview', classNa
 		bytes: null,
 		mime: null,
 	});
+	// 방금 업로드한 URL 을 기억해둬서, value 변경이 "우리 업로드에서 온 것" 인지
+	// "외부에서 다른 URL 이 주입된 것" 인지 구분한다. 전자는 bytes/mime 을 유지,
+	// 후자는 네 필드 모두 초기화해 이전 업로드의 메타가 다른 이미지에 붙어 보이지 않도록 한다.
+	const lastUploadedUrlRef = useRef(null);
 
-	// value 가 바뀌면 해상도 재측정(업로드 메타는 handleFiles 가 별도로 덮어쓴다).
 	useEffect(() => {
-		setMeta((prev) => ({
-			width: null,
-			height: null,
-			bytes: prev.bytes,
-			mime: prev.mime,
-		}));
+		if (value && value === lastUploadedUrlRef.current) {
+			setMeta((prev) => ({
+				width: null,
+				height: null,
+				bytes: prev.bytes,
+				mime: prev.mime,
+			}));
+		} else {
+			setMeta({ width: null, height: null, bytes: null, mime: null });
+		}
 	}, [value]);
 
 	const handleImageLoad = useCallback((event) => {
@@ -79,6 +86,7 @@ function ImageUploader({ value, onChange, previewAlt = 'Upload preview', classNa
 				bytes: data.bytes ?? null,
 				mime: data.mime ?? null,
 			});
+			lastUploadedUrlRef.current = data.url;
 			onChange(data.url);
 		} catch (err) {
 			console.error('[ImageUploader] failed', err);

--- a/apps/web/components/admin/ImageUploader.jsx
+++ b/apps/web/components/admin/ImageUploader.jsx
@@ -1,5 +1,5 @@
-import { useRef, useState } from 'react';
-import { FiUploadCloud, FiX } from 'react-icons/fi';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { FiRefreshCw, FiUploadCloud, FiX } from 'react-icons/fi';
 
 // 어드민에서 이미지를 업로드하고 결과 URL 을 form 상태에 전달하는 공용 컴포넌트.
 // props
@@ -7,10 +7,45 @@ import { FiUploadCloud, FiX } from 'react-icons/fi';
 //   onChange: (newUrl: string) => void  — 업로드 성공 시 호출
 //   previewAlt: img alt 텍스트
 //   className: 외곽 래퍼 커스터마이징
+
+function formatBytes(bytes) {
+	if (bytes == null || Number.isNaN(bytes)) return null;
+	if (bytes < 1024) return `${bytes}B`;
+	if (bytes < 1024 * 1024) return `${Math.round(bytes / 102.4) / 10}KB`;
+	return `${Math.round(bytes / (1024 * 102.4)) / 10}MB`;
+}
+
 function ImageUploader({ value, onChange, previewAlt = 'Upload preview', className = '' }) {
 	const inputRef = useRef(null);
 	const [uploading, setUploading] = useState(false);
 	const [error, setError] = useState('');
+	const [dragOver, setDragOver] = useState(false);
+	// 해상도 · 용량 · MIME. 업로드 직후엔 서버 응답에서, prefill/기존 URL 에는 img.onload 로 해상도만 채움.
+	const [meta, setMeta] = useState({
+		width: null,
+		height: null,
+		bytes: null,
+		mime: null,
+	});
+
+	// value 가 바뀌면 해상도 재측정(업로드 메타는 handleFiles 가 별도로 덮어쓴다).
+	useEffect(() => {
+		setMeta((prev) => ({
+			width: null,
+			height: null,
+			bytes: prev.bytes,
+			mime: prev.mime,
+		}));
+	}, [value]);
+
+	const handleImageLoad = useCallback((event) => {
+		const img = event.currentTarget;
+		setMeta((prev) => ({
+			...prev,
+			width: img.naturalWidth,
+			height: img.naturalHeight,
+		}));
+	}, []);
 
 	async function handleFiles(fileList) {
 		if (!fileList || fileList.length === 0) return;
@@ -33,12 +68,18 @@ function ImageUploader({ value, onChange, previewAlt = 'Upload preview', classNa
 				setError(payload?.error?.message ?? `업로드 실패 (${res.status})`);
 				return;
 			}
-			const url = payload?.data?.url;
-			if (!url) {
+			const data = payload?.data;
+			if (!data?.url) {
 				setError('서버가 URL 을 돌려주지 않았습니다.');
 				return;
 			}
-			onChange(url);
+			setMeta({
+				width: null,
+				height: null,
+				bytes: data.bytes ?? null,
+				mime: data.mime ?? null,
+			});
+			onChange(data.url);
 		} catch (err) {
 			console.error('[ImageUploader] failed', err);
 			setError('네트워크 오류로 업로드에 실패했습니다.');
@@ -49,37 +90,87 @@ function ImageUploader({ value, onChange, previewAlt = 'Upload preview', classNa
 	}
 
 	function openPicker() {
+		if (uploading) return;
 		inputRef.current?.click();
 	}
 
 	function handleDrop(event) {
 		event.preventDefault();
+		setDragOver(false);
 		handleFiles(event.dataTransfer?.files);
 	}
 
+	function handleDragOver(event) {
+		event.preventDefault();
+		if (!dragOver) setDragOver(true);
+	}
+
+	function handleDragLeave() {
+		setDragOver(false);
+	}
+
 	function clear() {
+		if (uploading) return;
+		setMeta({ width: null, height: null, bytes: null, mime: null });
 		onChange('');
 	}
+
+	const metaLabel = [
+		meta.width && meta.height ? `${meta.width}×${meta.height}` : null,
+		formatBytes(meta.bytes),
+		meta.mime,
+	]
+		.filter(Boolean)
+		.join(' · ');
+
+	const dropRingClass = dragOver
+		? 'ring-2 ring-indigo-400 dark:ring-indigo-500'
+		: '';
 
 	return (
 		<div className={`flex flex-col gap-2 ${className}`}>
 			{value ? (
-				<div className="relative inline-block">
+				<div
+					className={`relative inline-block rounded-md ${dropRingClass}`}
+					onDragOver={handleDragOver}
+					onDragLeave={handleDragLeave}
+					onDrop={handleDrop}
+				>
 					{/* eslint-disable-next-line @next/next/no-img-element */}
 					<img
 						src={value}
 						alt={previewAlt}
+						onLoad={handleImageLoad}
 						className="rounded-md max-h-40 border border-gray-200 dark:border-ternary-dark"
 					/>
-					<button
-						type="button"
-						onClick={clear}
-						className="absolute top-1 right-1 p-1 rounded-full bg-white/90 dark:bg-secondary-dark/90 text-ternary-dark hover:text-red-500 shadow-sm"
-						aria-label="Remove image"
-					>
-						<FiX className="w-4 h-4" />
-					</button>
-					<p className="mt-1 text-xs text-ternary-dark dark:text-ternary-light break-all">
+					<div className="absolute top-1 right-1 flex gap-1">
+						<button
+							type="button"
+							onClick={openPicker}
+							disabled={uploading}
+							aria-label="Replace image"
+							title="교체"
+							className="p-1 rounded-full bg-white/90 dark:bg-secondary-dark/90 text-ternary-dark hover:text-indigo-500 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							<FiRefreshCw className={`w-4 h-4 ${uploading ? 'animate-spin' : ''}`} />
+						</button>
+						<button
+							type="button"
+							onClick={clear}
+							disabled={uploading}
+							aria-label="Remove image"
+							title="제거"
+							className="p-1 rounded-full bg-white/90 dark:bg-secondary-dark/90 text-ternary-dark hover:text-red-500 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							<FiX className="w-4 h-4" />
+						</button>
+					</div>
+					{metaLabel && (
+						<p className="mt-1 text-xs text-ternary-dark dark:text-ternary-light font-general-regular">
+							{metaLabel}
+						</p>
+					)}
+					<p className="mt-0.5 text-xs text-ternary-dark dark:text-ternary-light break-all">
 						{value}
 					</p>
 				</div>
@@ -87,9 +178,10 @@ function ImageUploader({ value, onChange, previewAlt = 'Upload preview', classNa
 				<button
 					type="button"
 					onClick={openPicker}
-					onDragOver={(e) => e.preventDefault()}
+					onDragOver={handleDragOver}
+					onDragLeave={handleDragLeave}
 					onDrop={handleDrop}
-					className="flex flex-col items-center justify-center gap-1 border border-dashed border-gray-300 dark:border-ternary-dark rounded-md px-4 py-6 text-ternary-dark dark:text-ternary-light hover:border-indigo-400 dark:hover:border-indigo-500 duration-300"
+					className={`flex flex-col items-center justify-center gap-1 border border-dashed border-gray-300 dark:border-ternary-dark rounded-md px-4 py-6 text-ternary-dark dark:text-ternary-light hover:border-indigo-400 dark:hover:border-indigo-500 duration-300 ${dropRingClass}`}
 				>
 					<FiUploadCloud className="w-6 h-6" />
 					<span className="text-sm font-general-medium">


### PR DESCRIPTION
## 요약

`ImageUploader` 의 교체 흐름을 1-step 으로 단축하고, 업로드된 파일의 메타(해상도·용량·MIME) 를 preview 하단에 노출한다. 백엔드 변경 없음. 공용 컴포넌트라 `ProjectForm` / `AdminAboutEditor` 양쪽이 같이 개선된다.

## 변경 내용

### 커밋 `4aa3b42 feat(web): ImageUploader 교체 UX 개선 (Replace 버튼·drop 교체·메타 표시)`
- preview 상태에 **Replace 버튼** (`FiRefreshCw`) 추가 — 클릭 1회로 파일 picker 오픈 → 같은 자리 교체. 업로드 중엔 아이콘 회전 애니메이션
- preview 영역 자체가 **drag&drop 타깃** — 기존 이미지 위에 파일 drop 하면 교체. `onDragOver` / `onDragLeave` 로 ring 하이라이트
- 업로드 직후 서버 응답의 `{ bytes, mime }` 을 meta state 에 저장
- `value` 변경 시 `<img onLoad>` 로 `naturalWidth` / `naturalHeight` 측정
- preview 하단 메타 라인: `1920×1080 · 234KB · image/jpeg` 형식 (prefill 이미지는 해상도만 노출)
- 업로드 중 Replace / Remove 버튼 disable

## 변경 이유

- 교체 흐름이 `X → 빈 박스 → 선택` 2-step 이었음. Replace 버튼과 drop-to-replace 로 **클릭 1회** 또는 **drop 1회** 로 단축
- 기존엔 현재 이미지 해상도·용량·MIME 을 UI 에서 확인할 방법이 없었음. 상태 파악 + "이미 저장된 이미지" 와 "방금 올린 이미지" 구분이 쉬워짐

## 영향 범위

- [x] `apps/web`
- [ ] `apps/api`
- [ ] `packages`
- [ ] `repo`

## 스크린샷 / 데모

UI 변화는 `/admin/projects/:id/edit` · `/admin/about` 의 ImageUploader 자리. 별도 스크린샷은 생략하고 수동 확인.

## 테스트 / 확인

- [x] `/admin/projects/1/edit`, `/admin/about` 모두 200
- [x] HTML 에 `aria-label="Replace image"`, `aria-label="Remove image"` 두 버튼 존재 확인
- [ ] `apps/web` 은 단위 테스트 인프라가 없어 동작 검증은 수동 시나리오 (preview Replace 클릭·drop 교체·해상도 표시)

## 리뷰 포인트

- **Replace 중 중복 클릭 방지**: `uploading` 상태에서 Replace / Remove 모두 disable. 업로드 중에는 아이콘 회전으로 진행 표시
- **Drop 하이라이트**: `onDragOver` → ring 표시. 외부 드래그 취소 시 `onDragLeave` 로 해제. 자식 요소 간 이벤트 버블 관련 edge case 는 수동 확인
- **메타 정보 불완전**: prefill 된 이미지는 해상도만 표시되고 용량/MIME 은 비어있음. HEAD 요청으로 채울 수도 있지만 비용 대비 효과가 작아 생략
- **다음 Phase 연결**: Phase B(#36) 에서 `preset` prop 이 추가되면 이 컴포넌트에 전달되어 업로드 쿼리에 반영될 예정. 현재 prop 계약은 그대로 유지

## 참고 사항

- 백엔드·docker·env 변경 없음
- `react-icons/fi` 의 `FiRefreshCw` 로 교체 의미를 표현. 기존 아이콘 팔레트 유지

Closes #35