### PR TITLE
[feat] 업로드 preset 과 서버 사이드 리사이즈 (이미지 관리 Phase B)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -57,6 +57,7 @@
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "sharp": "^0.34.5",
     "typeorm": "^0.3.28"
   },
   "devDependencies": {

--- a/apps/api/src/modules/uploads/upload-preset.spec.ts
+++ b/apps/api/src/modules/uploads/upload-preset.spec.ts
@@ -1,0 +1,46 @@
+import { getPresetSpec, resolvePreset, UploadPreset } from './upload-preset';
+
+describe('upload-preset', () => {
+  describe('resolvePreset', () => {
+    it('빈/누락 입력은 기본값 gallery', () => {
+      expect(resolvePreset(undefined)).toBe(UploadPreset.GALLERY);
+      expect(resolvePreset('')).toBe(UploadPreset.GALLERY);
+      expect(resolvePreset(null)).toBe(UploadPreset.GALLERY);
+    });
+
+    it('thumbnail / gallery / profile 모두 허용 (대소문자 무시)', () => {
+      expect(resolvePreset('thumbnail')).toBe(UploadPreset.THUMBNAIL);
+      expect(resolvePreset('GALLERY')).toBe(UploadPreset.GALLERY);
+      expect(resolvePreset('Profile')).toBe(UploadPreset.PROFILE);
+    });
+
+    it('알 수 없는 값은 예외', () => {
+      expect(() => resolvePreset('banner')).toThrow(/unknown/i);
+    });
+  });
+
+  describe('getPresetSpec', () => {
+    it('thumbnail 은 16:9 (1600×900) cover', () => {
+      expect(getPresetSpec(UploadPreset.THUMBNAIL)).toEqual({
+        width: 1600,
+        height: 900,
+        fit: 'cover',
+      });
+    });
+
+    it('profile 은 1:1 (512×512) cover', () => {
+      expect(getPresetSpec(UploadPreset.PROFILE)).toEqual({
+        width: 512,
+        height: 512,
+        fit: 'cover',
+      });
+    });
+
+    it('gallery 는 장축 1600 까지 비율 유지(inside)', () => {
+      const spec = getPresetSpec(UploadPreset.GALLERY);
+      expect(spec.fit).toBe('inside');
+      expect(spec.width).toBe(1600);
+      expect(spec.height).toBe(1600);
+    });
+  });
+});

--- a/apps/api/src/modules/uploads/upload-preset.ts
+++ b/apps/api/src/modules/uploads/upload-preset.ts
@@ -1,0 +1,38 @@
+// 업로드 슬롯별 resize/crop 프리셋.
+// - thumbnail: 프로젝트 카드 썸네일. 16:9 로 중앙 crop + 1600×900 까지 다운스케일
+// - gallery: 프로젝트 상세 갤러리. 비율 유지하되 장축 1600px 이하로만 다운스케일
+// - profile: About 프로필. 1:1 중앙 crop + 512×512 까지 다운스케일
+
+export enum UploadPreset {
+  THUMBNAIL = 'thumbnail',
+  GALLERY = 'gallery',
+  PROFILE = 'profile',
+}
+
+export interface PresetSpec {
+  width?: number;
+  height?: number;
+  fit: 'cover' | 'inside';
+}
+
+const SPEC: Record<UploadPreset, PresetSpec> = {
+  [UploadPreset.THUMBNAIL]: { width: 1600, height: 900, fit: 'cover' },
+  [UploadPreset.GALLERY]: { width: 1600, height: 1600, fit: 'inside' },
+  [UploadPreset.PROFILE]: { width: 512, height: 512, fit: 'cover' },
+};
+
+export function resolvePreset(input: unknown): UploadPreset {
+  if (typeof input !== 'string' || input.length === 0) {
+    return UploadPreset.GALLERY;
+  }
+  const lower = input.toLowerCase();
+  const all = Object.values(UploadPreset);
+  if ((all as string[]).includes(lower)) {
+    return lower as UploadPreset;
+  }
+  throw new Error(`Unknown upload preset: ${input}`);
+}
+
+export function getPresetSpec(preset: UploadPreset): PresetSpec {
+  return SPEC[preset];
+}

--- a/apps/api/src/modules/uploads/uploads.controller.spec.ts
+++ b/apps/api/src/modules/uploads/uploads.controller.spec.ts
@@ -1,50 +1,115 @@
 import { BadRequestException } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { Test, TestingModule } from '@nestjs/testing';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import sharp from 'sharp';
 import { UploadsController, UPLOADS_URL_PREFIX } from './uploads.controller';
+import { UploadPreset } from './upload-preset';
 
-const fakeFile = (
-  overrides: Partial<Express.Multer.File> = {},
-): Express.Multer.File =>
-  ({
-    fieldname: 'file',
-    originalname: 'a.png',
-    encoding: '7bit',
-    mimetype: 'image/png',
-    size: 1234,
-    destination: '/app/uploads',
-    filename: 'abc-uuid.png',
-    path: '/app/uploads/abc-uuid.png',
-    buffer: Buffer.alloc(0),
-    stream: undefined as never,
-    ...overrides,
-  }) as Express.Multer.File;
+// 원본 이미지(실 파일) 를 준비하고 controller.upload() 를 직접 호출해,
+// sharp 파이프 결과와 반환 shape 를 검증한다. multer interceptor 는 테스트에서 우회 —
+// Express.Multer.File 을 손으로 만들어서 파일시스템 상에 실제 파일을 둔다.
 
 describe('UploadsController', () => {
   let controller: UploadsController;
+  let workDir: string;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      controllers: [UploadsController],
-      providers: [
-        {
-          provide: ConfigService,
-          useValue: { get: jest.fn() },
-        },
-      ],
-    }).compile();
-
-    controller = module.get(UploadsController);
+  beforeEach(() => {
+    controller = new UploadsController();
+    workDir = mkdtempSync(join(tmpdir(), 'uploads-spec-'));
   });
 
-  it('정상 업로드 시 URL / bytes / mime 를 반환한다', () => {
-    const result = controller.upload(fakeFile());
-    expect(result.url).toBe(`${UPLOADS_URL_PREFIX}/abc-uuid.png`);
-    expect(result.bytes).toBe(1234);
-    expect(result.mime).toBe('image/png');
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
   });
 
-  it('file 이 undefined 면 BadRequestException', () => {
-    expect(() => controller.upload(undefined)).toThrow(BadRequestException);
+  async function seedFile(
+    filename: string,
+    originalWidth: number,
+    originalHeight: number,
+    mime: 'image/jpeg' | 'image/png' | 'image/webp' = 'image/jpeg',
+  ): Promise<Express.Multer.File> {
+    const path = join(workDir, filename);
+    const buffer = await sharp({
+      create: {
+        width: originalWidth,
+        height: originalHeight,
+        channels: 3,
+        background: { r: 200, g: 100, b: 40 },
+      },
+    })
+      .jpeg({ quality: 90 })
+      .toBuffer();
+    writeFileSync(path, buffer);
+    return {
+      fieldname: 'file',
+      originalname: `${filename}`,
+      encoding: '7bit',
+      mimetype: mime,
+      size: buffer.length,
+      destination: workDir,
+      filename,
+      path,
+      buffer,
+      stream: undefined as never,
+    } as Express.Multer.File;
+  }
+
+  it('file 이 undefined 면 BadRequestException', async () => {
+    await expect(controller.upload(undefined)).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it('알 수 없는 preset 은 BadRequestException', async () => {
+    const file = await seedFile('x.jpg', 1920, 1080);
+    await expect(controller.upload(file, 'banner')).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it('thumbnail preset 은 16:9 로 중앙 crop 된다 (1920×1080 → 1600×900)', async () => {
+    const file = await seedFile('t.jpg', 1920, 1080);
+    const result = await controller.upload(file, UploadPreset.THUMBNAIL);
+    expect(result.url).toBe(`${UPLOADS_URL_PREFIX}/t.jpg`);
+    expect(result.mime).toBe('image/jpeg');
+    expect(result.preset).toBe(UploadPreset.THUMBNAIL);
+    expect(result.width).toBe(1600);
+    expect(result.height).toBe(900);
+  });
+
+  it('thumbnail 은 cover 이므로 작은 원본도 목표 크기로 업스케일', async () => {
+    const file = await seedFile('small.jpg', 800, 450);
+    const result = await controller.upload(file, UploadPreset.THUMBNAIL);
+    expect(result.width).toBe(1600);
+    expect(result.height).toBe(900);
+  });
+
+  it('profile preset 은 1:1 로 중앙 crop 된다', async () => {
+    const file = await seedFile('p.jpg', 1200, 800);
+    const result = await controller.upload(file, UploadPreset.PROFILE);
+    expect(result.width).toBe(512);
+    expect(result.height).toBe(512);
+  });
+
+  it('gallery preset 은 비율 유지 + 장축 1600 으로 다운스케일', async () => {
+    const file = await seedFile('g.jpg', 3200, 1000);
+    const result = await controller.upload(file, UploadPreset.GALLERY);
+    expect(result.width).toBe(1600);
+    expect(result.height).toBe(500);
+  });
+
+  it('gallery 는 inside 이므로 원본이 작으면 확대하지 않는다', async () => {
+    const file = await seedFile('gs.jpg', 800, 300);
+    const result = await controller.upload(file, UploadPreset.GALLERY);
+    expect(result.width).toBe(800);
+    expect(result.height).toBe(300);
+  });
+
+  it('preset 미지정이면 기본값 gallery 적용', async () => {
+    const file = await seedFile('d.jpg', 3200, 1000);
+    const result = await controller.upload(file);
+    expect(result.preset).toBe(UploadPreset.GALLERY);
+    expect(result.width).toBe(1600);
   });
 });

--- a/apps/api/src/modules/uploads/uploads.controller.ts
+++ b/apps/api/src/modules/uploads/uploads.controller.ts
@@ -1,30 +1,29 @@
 import {
   BadRequestException,
   Controller,
-  HttpException,
-  HttpStatus,
   Post,
+  Query,
   UploadedFile,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { ApiConsumes, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiConsumes, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync } from 'node:fs';
-import { extname, join } from 'node:path';
+import { rm, stat } from 'node:fs/promises';
+import { join } from 'node:path';
 import type { Request } from 'express';
 import { diskStorage } from 'multer';
+import sharp from 'sharp';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { getPresetSpec, resolvePreset, UploadPreset } from './upload-preset';
 
 export const UPLOADS_ROOT = process.env.UPLOADS_ROOT ?? '/app/uploads';
-// URL 경로. 공개 static 서빙 (web 컨테이너가 /app/apps/web/public/uploads 로 같은 볼륨 마운트) 기준.
 export const UPLOADS_URL_PREFIX = '/uploads';
 
 const ALLOWED_MIME = new Set(['image/jpeg', 'image/png', 'image/webp']);
 
-// multer FileFilterCallback 시그니처 (acceptFile 은 non-optional).
 type FileFilterCallback = (err: Error | null, acceptFile: boolean) => void;
 
 function ensureUploadsRoot(): void {
@@ -33,17 +32,27 @@ function ensureUploadsRoot(): void {
   }
 }
 
+export interface UploadResultDto {
+  url: string;
+  bytes: number;
+  mime: string;
+  width: number;
+  height: number;
+  preset: UploadPreset;
+}
+
 @ApiTags('Admin · Uploads')
 @Controller('api/admin/uploads')
 @UseGuards(JwtAuthGuard)
 export class UploadsController {
-  constructor(private readonly config: ConfigService) {}
-
   @Post()
-  @ApiOperation({ summary: '이미지 업로드 (multipart/form-data, field name: file)' })
+  @ApiOperation({
+    summary: '이미지 업로드 (multipart/form-data, field name: file) + preset 기반 서버 리사이즈',
+  })
   @ApiConsumes('multipart/form-data')
+  @ApiQuery({ name: 'preset', enum: UploadPreset, required: false })
   @ApiResponse({ status: 201 })
-  @ApiResponse({ status: 400, description: 'MIME 또는 크기 검증 실패' })
+  @ApiResponse({ status: 400 })
   @UseInterceptors(
     FileInterceptor('file', {
       storage: diskStorage({
@@ -51,9 +60,9 @@ export class UploadsController {
           ensureUploadsRoot();
           cb(null, UPLOADS_ROOT);
         },
-        filename: (_req, file, cb) => {
-          const ext = extname(file.originalname).toLowerCase() || '.bin';
-          cb(null, `${randomUUID()}${ext}`);
+        filename: (_req, _file, cb) => {
+          // 서버 리사이즈 후 항상 JPEG 로 재인코딩하므로 확장자도 .jpg 로 통일한다.
+          cb(null, `${randomUUID()}.jpg`);
         },
       }),
       fileFilter: (
@@ -75,21 +84,53 @@ export class UploadsController {
       },
     }),
   )
-  upload(
+  async upload(
     @UploadedFile() file: Express.Multer.File | undefined,
-  ): { url: string; bytes: number; mime: string } {
+    @Query('preset') presetQuery?: string,
+  ): Promise<UploadResultDto> {
     if (!file) {
       throw new BadRequestException('업로드된 파일이 없습니다.');
     }
-    return {
-      url: join(UPLOADS_URL_PREFIX, file.filename).replace(/\\/g, '/'),
-      bytes: file.size,
-      mime: file.mimetype,
-    };
+
+    let preset: UploadPreset;
+    try {
+      preset = resolvePreset(presetQuery);
+    } catch (err) {
+      await rm(file.path, { force: true });
+      throw new BadRequestException((err as Error).message);
+    }
+
+    const spec = getPresetSpec(preset);
+    try {
+      const buffer = await sharp(file.path)
+        .rotate() // EXIF orientation 적용
+        .resize({
+          width: spec.width,
+          height: spec.height,
+          fit: spec.fit,
+          // cover(썸네일/프로필) 는 공개 페이지 레이아웃 일관성을 위해 목표 크기까지
+          // 업스케일 허용. inside(갤러리) 는 원본 > 1600 일 때만 축소하고 그 이하는
+          // 원본 품질 유지.
+          withoutEnlargement: spec.fit === 'inside',
+        })
+        .jpeg({ quality: 88, mozjpeg: true })
+        .toBuffer({ resolveWithObject: true });
+
+      await sharp(buffer.data).toFile(file.path);
+      const stats = await stat(file.path);
+
+      return {
+        url: join(UPLOADS_URL_PREFIX, file.filename).replace(/\\/g, '/'),
+        bytes: stats.size,
+        mime: 'image/jpeg',
+        width: buffer.info.width,
+        height: buffer.info.height,
+        preset,
+      };
+    } catch (err) {
+      // 처리 실패 시 디스크에 깨진 파일을 남기지 않는다.
+      await rm(file.path, { force: true });
+      throw err;
+    }
   }
 }
-
-// multer 의 file size 초과 에러를 400 으로 매핑하고 싶으면 필요 시 exception filter 에서 처리.
-// 현재 전역 HttpExceptionFilter 가 이미 HttpException 계열을 일관 포맷으로 변환하므로 따로 두지 않는다.
-void HttpException;
-void HttpStatus;

--- a/apps/web/components/about/AboutMeBio.jsx
+++ b/apps/web/components/about/AboutMeBio.jsx
@@ -5,13 +5,16 @@ function AboutMeBio({ name, tagline, profileImage, bio = [] }) {
 	return (
 		<div className="block sm:flex sm:gap-10 mt-10 sm:mt-20">
 			<div className="w-full sm:w-1/4 mb-7 sm:mb-0">
-				<Image
-					src={profileImage}
-					width={200}
-					height={200}
-					className="rounded-lg"
-					alt={name ? `${name} profile` : 'Profile Image'}
-				/>
+				{/* profile preset 이 1:1 로 정규화되므로 프레임도 1:1 로 고정. */}
+				<div className="relative w-48 sm:w-full aspect-square overflow-hidden rounded-full">
+					<Image
+						src={profileImage}
+						alt={name ? `${name} profile` : 'Profile Image'}
+						fill
+						sizes="(min-width: 640px) 25vw, 192px"
+						style={{ objectFit: 'cover' }}
+					/>
+				</div>
 			</div>
 
 			<div className="font-general-regular w-full sm:w-3/4 text-left">

--- a/apps/web/components/admin/ImageUploader.jsx
+++ b/apps/web/components/admin/ImageUploader.jsx
@@ -15,7 +15,13 @@ function formatBytes(bytes) {
 	return `${Math.round(bytes / (1024 * 102.4)) / 10}MB`;
 }
 
-function ImageUploader({ value, onChange, previewAlt = 'Upload preview', className = '' }) {
+function ImageUploader({
+	value,
+	onChange,
+	previewAlt = 'Upload preview',
+	className = '',
+	preset,
+}) {
 	const inputRef = useRef(null);
 	const [uploading, setUploading] = useState(false);
 	const [error, setError] = useState('');
@@ -61,7 +67,10 @@ function ImageUploader({ value, onChange, previewAlt = 'Upload preview', classNa
 		try {
 			const form = new FormData();
 			form.append('file', fileList[0]);
-			const res = await fetch('/api/admin/uploads', {
+			const endpoint = preset
+				? `/api/admin/uploads?preset=${encodeURIComponent(preset)}`
+				: '/api/admin/uploads';
+			const res = await fetch(endpoint, {
 				method: 'POST',
 				credentials: 'include',
 				body: form,

--- a/apps/web/components/admin/ProjectForm.jsx
+++ b/apps/web/components/admin/ProjectForm.jsx
@@ -327,6 +327,7 @@ function ProjectForm({ initialValue, submitLabel = '저장', onSubmit }) {
 								value={item.img}
 								onChange={(url) => onItemChange({ img: url })}
 								previewAlt={item.title || 'Gallery preview'}
+								preset="gallery"
 							/>
 						</div>
 					)}

--- a/apps/web/components/admin/ProjectForm.jsx
+++ b/apps/web/components/admin/ProjectForm.jsx
@@ -140,12 +140,13 @@ function ProjectForm({ initialValue, submitLabel = '저장', onSubmit }) {
 					onChange={(e) => set('category', e.target.value)}
 				/>
 				<label className="block text-lg text-primary-dark dark:text-primary-light mb-1 font-general-regular">
-					썸네일 이미지
+					썸네일 이미지 (16:9 자동 crop)
 				</label>
 				<ImageUploader
 					value={form.thumbnailImg}
 					onChange={(url) => set('thumbnailImg', url)}
 					previewAlt="Thumbnail preview"
+					preset="thumbnail"
 					className="mb-4"
 				/>
 				<FormInput

--- a/apps/web/components/projects/ProjectSingle.jsx
+++ b/apps/web/components/projects/ProjectSingle.jsx
@@ -20,15 +20,14 @@ const ProjectSingle = ({ url, img, title, category }) => {
 				passHref
 			>
 				<div className="rounded-xl shadow-lg hover:shadow-xl cursor-pointer mb-10 sm:mb-0 bg-secondary-light dark:bg-ternary-dark">
-					<div>
+					{/* thumbnail preset 이 16:9 로 정규화되므로 카드 썸네일도 같은 비율로 고정. */}
+					<div className="relative w-full aspect-video overflow-hidden rounded-t-xl">
 						<Image
 							src={img}
-							className="rounded-t-xl border-none"
 							alt={title}
-							sizes="100vw"
-							style={{ width: '100%', height: 'auto' }}
-							width={100}
-							height={90}
+							fill
+							sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+							style={{ objectFit: 'cover' }}
 						/>
 					</div>
 					<div className="text-center px-4 py-6">

--- a/apps/web/pages/admin/about.jsx
+++ b/apps/web/pages/admin/about.jsx
@@ -99,12 +99,13 @@ function AdminAboutEditor({ initialAbout }) {
 						onChange={(e) => set('tagline', e.target.value)}
 					/>
 					<label className="block text-lg text-primary-dark dark:text-primary-light mb-1 font-general-regular">
-						프로필 이미지
+						프로필 이미지 (1:1 자동 crop)
 					</label>
 					<ImageUploader
 						value={form.profileImage}
 						onChange={(url) => set('profileImage', url)}
 						previewAlt={form.name ? `${form.name} profile` : 'Profile preview'}
+						preset="profile"
 					/>
 				</AdminFormSection>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "sharp": "^0.34.5",
         "typeorm": "^0.3.28"
       },
       "devDependencies": {
@@ -1334,7 +1335,6 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1479,6 +1479,471 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -5740,6 +6205,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -12611,6 +13085,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/shebang-command": {


### PR DESCRIPTION
## 요약

- 업로드 슬롯별로 **preset** 을 정해 서버에서 자동 crop + resize + 재인코딩 → 공개 페이지 레이아웃이 원본 비율에 영향받지 않도록 한다.
- 클라이언트 cropper 는 도입하지 않음 (모바일/EXIF 리스크 대비 ROI 낮음).
- 공개 `/projects` 카드와 `/about` 프로필 프레임도 preset 비율에 맞춰 고정.

## 변경 내용

### 커밋 `fe4f38a feat(api): 업로드 preset 도입과 sharp 기반 서버 사이드 리사이즈`

- `upload-preset.ts` — 프리셋 정의 + 유틸
  - `thumbnail` — 1600×900, `cover` (16:9 crop + 필요 시 업스케일)
  - `gallery` — 1600×1600 박스, `inside` (비율 유지, 장축 기준 다운스케일만)
  - `profile` — 512×512, `cover` (1:1 crop + 필요 시 업스케일)
- `uploads.controller.ts`
  - `POST /api/admin/uploads?preset=...` — 미지정 시 `gallery`, 알 수 없는 preset 은 400
  - sharp 파이프: `rotate()`(EXIF) → `resize({fit, withoutEnlargement: fit === 'inside'})` → `jpeg({quality:88, mozjpeg:true})` → 원본 덮어쓰기
  - 업로드 파일명 `.jpg` 통일
  - 응답에 `{ width, height, preset }` 추가
  - 처리 실패 시 `rm(force)` 로 깨진 파일 정리
- 신규 의존성 `sharp`

### 커밋 `734397c feat(web): ImageUploader preset 전파와 공개 페이지 비율 고정`

- `ImageUploader` 에 `preset` prop 수용 → 업로드 쿼리에 전달
- `ProjectForm` — 썸네일 `preset="thumbnail"` / 갤러리 `preset="gallery"` + 라벨에 힌트
- `AdminAboutEditor` — 프로필 `preset="profile"` + 힌트
- 공개 페이지 프레임 고정
  - `ProjectSingle.jsx` — 카드 썸네일을 `relative w-full aspect-video overflow-hidden` 컨테이너 + `fill` + `object-cover`
  - `AboutMeBio.jsx` — 프로필을 `aspect-square rounded-full overflow-hidden` 컨테이너 + `fill` + `object-cover`
- 레거시 이미지(기존 `/images/*.jpg`, 780×680 등) 도 object-cover 로 자동 center-crop 되어 프레임이 흐트러지지 않음

## 변경 이유

- 원본 비율이 제각각이라 프로젝트 카드/프로필이 일관된 모양으로 보이지 않는 문제 해결
- 썸네일이 업로드마다 다른 비율이면 레이아웃에 빈 공간이 생기거나 이미지가 흐릿하게 늘어남. 서버에서 표준 사이즈로 정규화해 공개 페이지는 **단순 고정 프레임** 만 신경 쓰면 되도록

## 영향 범위

- [x] `apps/web`
- [x] `apps/api`
- [ ] `packages`
- [ ] `repo`

## 스크린샷 / 데모

UI 변화는 `/projects` 카드(일관된 16:9 썸네일), `/about` 프로필(원형). 업로드 UX 는 동일하며 슬롯별 힌트 문구 추가.

## 테스트 / 확인

- [x] `apps/api` 단위 테스트 **14 케이스** 신규 (preset 유틸 6 + controller 8). 전체 109 케이스 통과
  - preset 기본값 / 유효 값 / 알 수 없는 값
  - thumbnail 16:9 crop, 작은 원본 업스케일
  - gallery 장축 1600 다운스케일, 작은 원본 유지
  - profile 1:1 crop + 512 정규화
  - 파일 없음 / 알 수 없는 preset → 400
- [x] `npm run -w apps/api lint / build / test` 전부 통과
- [x] 수동 시나리오
  - 780×680 원본 + thumbnail → 1600×900 결과, 동일 원본 + gallery → 780×680 유지
  - 알 수 없는 preset → 400 "Unknown upload preset: …"
  - 공개 `/projects`, `/about`, `/projects/:url` 모두 200

## 리뷰 포인트

- **업스케일 정책**: `cover` 계열(thumbnail/profile) 은 공개 레이아웃 일관성을 위해 업스케일 허용. `inside`(gallery) 는 원본 품질 유지. 저해상도 원본 업로드 시 흐릿해질 수 있지만 카드·프로필 프레임은 깨지지 않는 쪽을 우선
- **재인코딩**: 모든 업로드를 JPEG(q=88 mozjpeg) 로 통일. webp 원본도 JPEG 로 변환 → 호환성 우선. 추후 webp 출력 옵션이 필요하면 preset 에 추가 가능
- **레거시 이미지 처리**: 기존 업로드된 `/uploads/*` 는 건드리지 않음. 공개 페이지는 object-cover 로 프레임에 맞춰 노출. 일괄 재처리 스크립트는 Phase C 에서 고려
- **`width` / `height` 메타**: 업로드 응답에 포함돼 `ImageUploader` 가 메타 라인에 즉시 표시 (Phase A 산출물과 조합)

## 참고 사항

- `UPLOAD_MAX_BYTES` 는 **원본 크기** 기준. sharp 가 리사이즈한 결과물은 보통 훨씬 작음
- Phase A(#38) 의 Replace/메타 UX 위에 올라가는 변경
- Phase C(#37) 에서는 교체·삭제 시 orphan 파일 정리 로직을 추가할 예정 — 인터페이스 호환

Closes #36