### PR TITLE
[feat] 업로드 파일 라이프사이클 관리 (이미지 관리 Phase C)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,6 +14,7 @@
     "test:cov": "jest --coverage",
     "seed:projects": "ts-node -r tsconfig-paths/register src/database/seeds/seed-projects.ts",
     "seed:about": "ts-node -r tsconfig-paths/register src/database/seeds/seed-about.ts",
+    "cleanup:uploads": "ts-node -r tsconfig-paths/register src/scripts/cleanup-uploads.ts",
     "typeorm": "node -r tsconfig-paths/register ../../node_modules/typeorm/cli-ts-node-commonjs.js",
     "migration:generate": "npm run typeorm -- migration:generate -d src/database/data-source.ts",
     "migration:create": "npm run typeorm -- migration:create",

--- a/apps/api/src/modules/about/about.module.ts
+++ b/apps/api/src/modules/about/about.module.ts
@@ -7,9 +7,10 @@ import { AdminAboutController } from './admin-about.controller';
 import { AdminAboutService } from './admin-about.service';
 import { AboutProfile } from './entities/about-profile.entity';
 import { AboutBio } from './entities/about-bio.entity';
+import { UploadsModule } from '../uploads/uploads.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([AboutProfile, AboutBio])],
+  imports: [TypeOrmModule.forFeature([AboutProfile, AboutBio]), UploadsModule],
   controllers: [AboutController, AdminAboutController],
   providers: [AboutService, AboutRepository, AdminAboutService],
 })

--- a/apps/api/src/modules/about/admin-about.service.spec.ts
+++ b/apps/api/src/modules/about/admin-about.service.spec.ts
@@ -11,9 +11,11 @@ describe('AdminAboutService', () => {
   let profileRepo: jest.Mocked<Repository<AboutProfile>>;
   let txManager: { save: jest.Mock; delete: jest.Mock };
   let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
+  let uploadsStorage: { deleteByUrl: jest.Mock };
 
   beforeEach(async () => {
     txManager = { save: jest.fn(), delete: jest.fn() };
+    uploadsStorage = { deleteByUrl: jest.fn().mockResolvedValue(true) };
     dataSource = {
       transaction: jest
         .fn()
@@ -22,6 +24,9 @@ describe('AdminAboutService', () => {
         ),
     } as unknown as jest.Mocked<Pick<DataSource, 'transaction'>>;
 
+    const { UploadsStorageService } = await import(
+      '../uploads/uploads-storage.service'
+    );
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AdminAboutService,
@@ -32,6 +37,7 @@ describe('AdminAboutService', () => {
           },
         },
         { provide: DataSource, useValue: dataSource },
+        { provide: UploadsStorageService, useValue: uploadsStorage },
       ],
     }).compile();
 

--- a/apps/api/src/modules/about/admin-about.service.spec.ts
+++ b/apps/api/src/modules/about/admin-about.service.spec.ts
@@ -12,10 +12,12 @@ describe('AdminAboutService', () => {
   let txManager: { save: jest.Mock; delete: jest.Mock };
   let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
   let uploadsStorage: { deleteByUrl: jest.Mock };
+  let uploadsRefChecker: { isReferenced: jest.Mock };
 
   beforeEach(async () => {
     txManager = { save: jest.fn(), delete: jest.fn() };
     uploadsStorage = { deleteByUrl: jest.fn().mockResolvedValue(true) };
+    uploadsRefChecker = { isReferenced: jest.fn().mockResolvedValue(false) };
     dataSource = {
       transaction: jest
         .fn()
@@ -26,6 +28,9 @@ describe('AdminAboutService', () => {
 
     const { UploadsStorageService } = await import(
       '../uploads/uploads-storage.service'
+    );
+    const { UploadsReferenceCheckerService } = await import(
+      '../uploads/uploads-reference-checker.service'
     );
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -38,6 +43,10 @@ describe('AdminAboutService', () => {
         },
         { provide: DataSource, useValue: dataSource },
         { provide: UploadsStorageService, useValue: uploadsStorage },
+        {
+          provide: UploadsReferenceCheckerService,
+          useValue: uploadsRefChecker,
+        },
       ],
     }).compile();
 
@@ -111,5 +120,64 @@ describe('AdminAboutService', () => {
   it('upsert: 저장 후 profile 이 null 이면 에러', async () => {
     profileRepo.findOne.mockResolvedValue(null);
     await expect(service.upsert(dto)).rejects.toThrow(/saved profile not found/);
+  });
+
+  it('upsert: 이전 프로필 URL 이 /uploads 이고 다른 참조가 없으면 삭제', async () => {
+    profileRepo.findOne
+      .mockResolvedValueOnce({
+        id: 1,
+        profileImage: '/uploads/old.jpg',
+      } as never)
+      .mockResolvedValueOnce({
+        id: 1,
+        name: 'x',
+        tagline: null,
+        profileImage: '/uploads/new.jpg',
+        bios: [],
+      } as never);
+    uploadsRefChecker.isReferenced.mockResolvedValue(false);
+
+    await service.upsert({ ...dto, profileImage: '/uploads/new.jpg', bio: [] });
+
+    expect(uploadsStorage.deleteByUrl).toHaveBeenCalledWith('/uploads/old.jpg');
+  });
+
+  it('upsert: 이전 프로필이 다른 레코드에서 참조 중이면 삭제하지 않는다', async () => {
+    profileRepo.findOne
+      .mockResolvedValueOnce({
+        id: 1,
+        profileImage: '/uploads/shared.jpg',
+      } as never)
+      .mockResolvedValueOnce({
+        id: 1,
+        name: 'x',
+        tagline: null,
+        profileImage: '/uploads/new.jpg',
+        bios: [],
+      } as never);
+    uploadsRefChecker.isReferenced.mockResolvedValue(true);
+
+    await service.upsert({ ...dto, profileImage: '/uploads/new.jpg', bio: [] });
+
+    expect(uploadsStorage.deleteByUrl).not.toHaveBeenCalled();
+  });
+
+  it('upsert: 이전 URL 이 /images (수동 자산) 이면 건드리지 않음', async () => {
+    profileRepo.findOne
+      .mockResolvedValueOnce({
+        id: 1,
+        profileImage: '/images/old.jpg',
+      } as never)
+      .mockResolvedValueOnce({
+        id: 1,
+        name: 'x',
+        tagline: null,
+        profileImage: '/uploads/new.jpg',
+        bios: [],
+      } as never);
+
+    await service.upsert({ ...dto, profileImage: '/uploads/new.jpg', bio: [] });
+
+    expect(uploadsStorage.deleteByUrl).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/modules/about/admin-about.service.ts
+++ b/apps/api/src/modules/about/admin-about.service.ts
@@ -1,6 +1,10 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
+import {
+  resolveUploadFilename,
+  UploadsStorageService,
+} from '../uploads/uploads-storage.service';
 import { AboutBio } from './entities/about-bio.entity';
 import { AboutProfile } from './entities/about-profile.entity';
 import { UpsertAboutDto } from './dto/upsert-about.dto';
@@ -9,13 +13,20 @@ import { toAboutResponseDto } from './mappers/about.mapper';
 
 @Injectable()
 export class AdminAboutService {
+  private readonly logger = new Logger(AdminAboutService.name);
+
   constructor(
     @InjectRepository(AboutProfile)
     private readonly profileRepo: Repository<AboutProfile>,
     private readonly dataSource: DataSource,
+    private readonly uploadsStorage: UploadsStorageService,
   ) {}
 
   async upsert(dto: UpsertAboutDto): Promise<AboutResponseDto> {
+    // 업데이트 전 profile 이미지 URL 을 기억 → 변경된 경우 고아 /uploads 파일 정리
+    const previousProfile = await this.profileRepo.findOne({ where: { id: 1 } });
+    const previousImageUrl = previousProfile?.profileImage ?? null;
+
     await this.dataSource.transaction(async (manager) => {
       // bio 는 전량 교체 (id=1 고정 singleton 에 묶인 자식)
       await manager.delete(AboutBio, { profileId: 1 });
@@ -34,6 +45,20 @@ export class AdminAboutService {
 
       await manager.save(AboutProfile, profile);
     });
+
+    if (previousImageUrl && previousImageUrl !== dto.profileImage) {
+      const oldFilename = resolveUploadFilename(previousImageUrl);
+      const newFilename = resolveUploadFilename(dto.profileImage);
+      if (oldFilename && oldFilename !== newFilename) {
+        try {
+          await this.uploadsStorage.deleteByUrl(previousImageUrl);
+        } catch (err) {
+          this.logger.error(
+            `[upsert] 이전 프로필 이미지 삭제 실패: ${(err as Error).message}`,
+          );
+        }
+      }
+    }
 
     const loaded = await this.profileRepo.findOne({
       where: { id: 1 },

--- a/apps/api/src/modules/about/admin-about.service.ts
+++ b/apps/api/src/modules/about/admin-about.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
+import { UploadsReferenceCheckerService } from '../uploads/uploads-reference-checker.service';
 import {
   resolveUploadFilename,
   UploadsStorageService,
@@ -20,6 +21,7 @@ export class AdminAboutService {
     private readonly profileRepo: Repository<AboutProfile>,
     private readonly dataSource: DataSource,
     private readonly uploadsStorage: UploadsStorageService,
+    private readonly uploadsRefChecker: UploadsReferenceCheckerService,
   ) {}
 
   async upsert(dto: UpsertAboutDto): Promise<AboutResponseDto> {
@@ -51,10 +53,21 @@ export class AdminAboutService {
       const newFilename = resolveUploadFilename(dto.profileImage);
       if (oldFilename && oldFilename !== newFilename) {
         try {
-          await this.uploadsStorage.deleteByUrl(previousImageUrl);
+          // 다른 프로젝트에서 같은 /uploads URL 을 참조하면 파일을 남겨둔다.
+          const stillReferenced = await this.uploadsRefChecker.isReferenced(
+            previousImageUrl,
+            { excludeAboutId: 1 },
+          );
+          if (stillReferenced) {
+            this.logger.log(
+              `[upsert] 이전 프로필 이미지 ${oldFilename} 는 다른 레코드가 참조 중 — 보존`,
+            );
+          } else {
+            await this.uploadsStorage.deleteByUrl(previousImageUrl);
+          }
         } catch (err) {
           this.logger.error(
-            `[upsert] 이전 프로필 이미지 삭제 실패: ${(err as Error).message}`,
+            `[upsert] 이전 프로필 이미지 정리 실패: ${(err as Error).message}`,
           );
         }
       }

--- a/apps/api/src/modules/projects/admin-projects.service.spec.ts
+++ b/apps/api/src/modules/projects/admin-projects.service.spec.ts
@@ -59,9 +59,11 @@ describe('AdminProjectsService', () => {
   let projectRepo: jest.Mocked<Repository<Project>>;
   let dataSource: DSMock;
   let txManager: { save: jest.Mock; delete: jest.Mock; find: jest.Mock };
+  let uploadsStorage: { deleteByUrl: jest.Mock };
 
   beforeEach(async () => {
     txManager = { save: jest.fn(), delete: jest.fn(), find: jest.fn() };
+    uploadsStorage = { deleteByUrl: jest.fn().mockResolvedValue(true) };
 
     dataSource = {
       transaction: jest
@@ -71,6 +73,9 @@ describe('AdminProjectsService', () => {
         ),
     } as unknown as DSMock;
 
+    const { UploadsStorageService } = await import(
+      '../uploads/uploads-storage.service'
+    );
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AdminProjectsService,
@@ -82,6 +87,7 @@ describe('AdminProjectsService', () => {
           },
         },
         { provide: DataSource, useValue: dataSource },
+        { provide: UploadsStorageService, useValue: uploadsStorage },
       ],
     }).compile();
 
@@ -185,15 +191,77 @@ describe('AdminProjectsService', () => {
   });
 
   describe('remove', () => {
+    it('대상 없으면 NotFoundException', async () => {
+      projectRepo.findOne.mockResolvedValue(null);
+      await expect(service.remove(10)).rejects.toBeInstanceOf(NotFoundException);
+      expect(projectRepo.delete).not.toHaveBeenCalled();
+    });
+
+    it('정상 경로: delete 호출 + uploads 파일 정리', async () => {
+      projectRepo.findOne.mockResolvedValue(
+        baseProject({
+          id: 10,
+          url: 'to-remove',
+          thumbnailImg: '/uploads/thumb.jpg',
+          images: [
+            { id: 1, title: 'a', img: '/uploads/g1.jpg', sortOrder: 0, projectId: 10 },
+            { id: 2, title: 'b', img: '/images/legacy.jpg', sortOrder: 1, projectId: 10 },
+          ] as never,
+        }),
+      );
+      projectRepo.delete.mockResolvedValue({ affected: 1, raw: {} } as never);
+
+      await expect(service.remove(10)).resolves.toBeUndefined();
+      expect(projectRepo.delete).toHaveBeenCalledWith(10);
+      // /uploads/* 만 cleanup 대상이 됨 (`/images/*` 는 수동 자산이라 건드리지 않음)
+      const removed = uploadsStorage.deleteByUrl.mock.calls.map((c) => c[0]);
+      expect(removed.sort()).toEqual(['/uploads/g1.jpg', '/uploads/thumb.jpg']);
+    });
+
     it('affected=0 이면 NotFoundException', async () => {
+      projectRepo.findOne.mockResolvedValue(baseProject({ id: 10 }));
       projectRepo.delete.mockResolvedValue({ affected: 0, raw: {} } as never);
       await expect(service.remove(10)).rejects.toBeInstanceOf(NotFoundException);
     });
+  });
 
-    it('성공 시 void', async () => {
-      projectRepo.delete.mockResolvedValue({ affected: 1, raw: {} } as never);
-      await expect(service.remove(10)).resolves.toBeUndefined();
-      expect(projectRepo.delete).toHaveBeenCalledWith(10);
+  describe('update — uploads cleanup', () => {
+    it('교체된 /uploads/* 파일만 삭제 (유지·외부는 건드리지 않음)', async () => {
+      const existing = baseProject({
+        id: 5,
+        url: 'same-slug',
+        thumbnailImg: '/uploads/old-thumb.jpg',
+        images: [
+          { id: 1, title: 'keep', img: '/uploads/keep.jpg', sortOrder: 0, projectId: 5 },
+          { id: 2, title: 'drop', img: '/uploads/drop.jpg', sortOrder: 1, projectId: 5 },
+          { id: 3, title: 'legacy', img: '/images/legacy.jpg', sortOrder: 2, projectId: 5 },
+        ] as never,
+      });
+      projectRepo.findOne
+        .mockResolvedValueOnce(existing) // findOneWithRelations (before update)
+        .mockResolvedValueOnce(
+          baseProject({ id: 5, url: 'same-slug', thumbnailImg: '/uploads/new-thumb.jpg' }),
+        ); // findOneWithRelations (after)
+      txManager.find.mockResolvedValue([]);
+
+      await service.update(
+        5,
+        baseDto({
+          url: 'same-slug',
+          thumbnailImg: '/uploads/new-thumb.jpg',
+          images: [
+            { title: 'keep', img: '/uploads/keep.jpg' },
+            { title: 'legacy', img: '/images/legacy.jpg' },
+          ],
+        }),
+      );
+
+      const removed = uploadsStorage.deleteByUrl.mock.calls.map((c) => c[0]);
+      // 이전 썸네일, 드롭된 갤러리 이미지만 삭제. keep/legacy 는 유지.
+      expect(removed.sort()).toEqual([
+        '/uploads/drop.jpg',
+        '/uploads/old-thumb.jpg',
+      ]);
     });
   });
 });

--- a/apps/api/src/modules/projects/admin-projects.service.spec.ts
+++ b/apps/api/src/modules/projects/admin-projects.service.spec.ts
@@ -60,10 +60,12 @@ describe('AdminProjectsService', () => {
   let dataSource: DSMock;
   let txManager: { save: jest.Mock; delete: jest.Mock; find: jest.Mock };
   let uploadsStorage: { deleteByUrl: jest.Mock };
+  let uploadsRefChecker: { isReferenced: jest.Mock };
 
   beforeEach(async () => {
     txManager = { save: jest.fn(), delete: jest.fn(), find: jest.fn() };
     uploadsStorage = { deleteByUrl: jest.fn().mockResolvedValue(true) };
+    uploadsRefChecker = { isReferenced: jest.fn().mockResolvedValue(false) };
 
     dataSource = {
       transaction: jest
@@ -75,6 +77,9 @@ describe('AdminProjectsService', () => {
 
     const { UploadsStorageService } = await import(
       '../uploads/uploads-storage.service'
+    );
+    const { UploadsReferenceCheckerService } = await import(
+      '../uploads/uploads-reference-checker.service'
     );
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -88,6 +93,10 @@ describe('AdminProjectsService', () => {
         },
         { provide: DataSource, useValue: dataSource },
         { provide: UploadsStorageService, useValue: uploadsStorage },
+        {
+          provide: UploadsReferenceCheckerService,
+          useValue: uploadsRefChecker,
+        },
       ],
     }).compile();
 
@@ -262,6 +271,32 @@ describe('AdminProjectsService', () => {
         '/uploads/drop.jpg',
         '/uploads/old-thumb.jpg',
       ]);
+    });
+
+    it('다른 레코드가 여전히 참조 중인 URL 은 삭제하지 않는다', async () => {
+      const existing = baseProject({
+        id: 5,
+        url: 'same-slug',
+        thumbnailImg: '/uploads/shared.jpg',
+        images: [] as never,
+      });
+      projectRepo.findOne
+        .mockResolvedValueOnce(existing)
+        .mockResolvedValueOnce(
+          baseProject({ id: 5, url: 'same-slug', thumbnailImg: '/uploads/new-only.jpg' }),
+        );
+      txManager.find.mockResolvedValue([]);
+      // old 파일은 다른 곳에서 참조, new-only 는 신규라 이전 cleanup 후보 아님
+      uploadsRefChecker.isReferenced.mockImplementation(async (url: string) =>
+        url === '/uploads/shared.jpg',
+      );
+
+      await service.update(
+        5,
+        baseDto({ url: 'same-slug', thumbnailImg: '/uploads/new-only.jpg' }),
+      );
+
+      expect(uploadsStorage.deleteByUrl).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/modules/projects/admin-projects.service.ts
+++ b/apps/api/src/modules/projects/admin-projects.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, In, Repository } from 'typeorm';
+import { UploadsReferenceCheckerService } from '../uploads/uploads-reference-checker.service';
 import {
   collectReferencedFilenames,
   UploadsStorageService,
@@ -36,6 +37,7 @@ export class AdminProjectsService {
     private readonly projectRepo: Repository<Project>,
     private readonly dataSource: DataSource,
     private readonly uploadsStorage: UploadsStorageService,
+    private readonly uploadsRefChecker: UploadsReferenceCheckerService,
   ) {}
 
   async getById(id: number): Promise<ProjectDetailDto> {
@@ -88,12 +90,14 @@ export class AdminProjectsService {
     });
 
     // 업데이트 전후 참조 비교해 고아가 된 /uploads/* 파일만 정리.
+    // 현재 프로젝트는 이미 새 상태가 저장됐으므로 excludeProjectId 없이 검사해도 되지만,
+    // DB 조회 타이밍의 경쟁 상태 대비 현재 id 를 exclude 해도 안전.
     const oldFiles = collectReferencedFilenames(collectProjectUploadUrls(existing));
     const newFiles = collectReferencedFilenames([
       dto.thumbnailImg,
       ...dto.images.map((img) => img.img),
     ]);
-    await this.cleanupStaleFiles(oldFiles, newFiles);
+    await this.cleanupStaleFiles(oldFiles, newFiles, { excludeProjectId: id });
 
     const loaded = await this.findOneWithRelations(id);
     return toProjectDetailDto(loaded!);
@@ -111,23 +115,33 @@ export class AdminProjectsService {
       throw new NotFoundException(`Project not found: id=${id}`);
     }
 
-    await this.cleanupStaleFiles(filenames, new Set());
+    await this.cleanupStaleFiles(filenames, new Set(), { excludeProjectId: id });
   }
 
   private async cleanupStaleFiles(
     before: Set<string>,
     after: Set<string>,
+    exclude: { excludeProjectId?: number } = {},
   ): Promise<void> {
     for (const filename of before) {
       if (after.has(filename)) continue;
+      const url = UploadsStorageService.toUrl(filename);
       try {
-        await this.uploadsStorage.deleteByUrl(
-          UploadsStorageService.toUrl(filename),
-        );
+        // 다른 프로젝트/About 에서 여전히 이 URL 을 참조하면 파일을 남겨둔다.
+        const stillReferenced = await this.uploadsRefChecker.isReferenced(url, {
+          excludeProjectId: exclude.excludeProjectId,
+        });
+        if (stillReferenced) {
+          this.logger.log(
+            `[cleanupStaleFiles] ${filename} 은 다른 레코드가 여전히 참조 중 — 보존`,
+          );
+          continue;
+        }
+        await this.uploadsStorage.deleteByUrl(url);
       } catch (err) {
-        // 파일 삭제 실패는 도메인 트랜잭션과 분리 — 로그만 남기고 진행
+        // 파일 삭제/참조 확인 실패는 도메인 트랜잭션과 분리 — 로그만 남기고 진행
         this.logger.error(
-          `[cleanupStaleFiles] ${filename} 삭제 실패: ${(err as Error).message}`,
+          `[cleanupStaleFiles] ${filename} 정리 실패: ${(err as Error).message}`,
         );
       }
     }

--- a/apps/api/src/modules/projects/admin-projects.service.ts
+++ b/apps/api/src/modules/projects/admin-projects.service.ts
@@ -1,10 +1,15 @@
 import {
   ConflictException,
   Injectable,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, In, Repository } from 'typeorm';
+import {
+  collectReferencedFilenames,
+  UploadsStorageService,
+} from '../uploads/uploads-storage.service';
 import { Project } from './entities/project.entity';
 import { ProjectCompanyInfo } from './entities/project-company-info.entity';
 import { ProjectDetail } from './entities/project-detail.entity';
@@ -15,12 +20,22 @@ import { UpsertProjectDto } from './dto/upsert-project.dto';
 import { ProjectDetailDto } from './dto/project-detail.dto';
 import { toProjectDetailDto } from './mappers/project-detail.mapper';
 
+function collectProjectUploadUrls(project: Project): (string | null | undefined)[] {
+  return [
+    project.thumbnailImg,
+    ...(project.images ?? []).map((img) => img.img),
+  ];
+}
+
 @Injectable()
 export class AdminProjectsService {
+  private readonly logger = new Logger(AdminProjectsService.name);
+
   constructor(
     @InjectRepository(Project)
     private readonly projectRepo: Repository<Project>,
     private readonly dataSource: DataSource,
+    private readonly uploadsStorage: UploadsStorageService,
   ) {}
 
   async getById(id: number): Promise<ProjectDetailDto> {
@@ -42,11 +57,11 @@ export class AdminProjectsService {
   }
 
   async update(id: number, dto: UpsertProjectDto): Promise<ProjectDetailDto> {
-    const exists = await this.projectRepo.findOne({ where: { id } });
-    if (!exists) {
+    const existing = await this.findOneWithRelations(id);
+    if (!existing) {
       throw new NotFoundException(`Project not found: id=${id}`);
     }
-    if (dto.url !== exists.url) {
+    if (dto.url !== existing.url) {
       await this.assertUrlAvailable(dto.url, id);
     }
 
@@ -72,14 +87,49 @@ export class AdminProjectsService {
       await manager.save(Project, updated);
     });
 
+    // 업데이트 전후 참조 비교해 고아가 된 /uploads/* 파일만 정리.
+    const oldFiles = collectReferencedFilenames(collectProjectUploadUrls(existing));
+    const newFiles = collectReferencedFilenames([
+      dto.thumbnailImg,
+      ...dto.images.map((img) => img.img),
+    ]);
+    await this.cleanupStaleFiles(oldFiles, newFiles);
+
     const loaded = await this.findOneWithRelations(id);
     return toProjectDetailDto(loaded!);
   }
 
   async remove(id: number): Promise<void> {
+    const existing = await this.findOneWithRelations(id);
+    if (!existing) {
+      throw new NotFoundException(`Project not found: id=${id}`);
+    }
+    const filenames = collectReferencedFilenames(collectProjectUploadUrls(existing));
+
     const result = await this.projectRepo.delete(id);
     if (!result.affected) {
       throw new NotFoundException(`Project not found: id=${id}`);
+    }
+
+    await this.cleanupStaleFiles(filenames, new Set());
+  }
+
+  private async cleanupStaleFiles(
+    before: Set<string>,
+    after: Set<string>,
+  ): Promise<void> {
+    for (const filename of before) {
+      if (after.has(filename)) continue;
+      try {
+        await this.uploadsStorage.deleteByUrl(
+          UploadsStorageService.toUrl(filename),
+        );
+      } catch (err) {
+        // 파일 삭제 실패는 도메인 트랜잭션과 분리 — 로그만 남기고 진행
+        this.logger.error(
+          `[cleanupStaleFiles] ${filename} 삭제 실패: ${(err as Error).message}`,
+        );
+      }
     }
   }
 

--- a/apps/api/src/modules/projects/projects.module.ts
+++ b/apps/api/src/modules/projects/projects.module.ts
@@ -11,6 +11,7 @@ import { ProjectCompanyInfo } from './entities/project-company-info.entity';
 import { ProjectTechnology } from './entities/project-technology.entity';
 import { ProjectTechnologyItem } from './entities/project-technology-item.entity';
 import { ProjectDetail } from './entities/project-detail.entity';
+import { UploadsModule } from '../uploads/uploads.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { ProjectDetail } from './entities/project-detail.entity';
       ProjectTechnologyItem,
       ProjectDetail,
     ]),
+    UploadsModule,
   ],
   controllers: [ProjectsController, AdminProjectsController],
   providers: [ProjectsService, ProjectsRepository, AdminProjectsService],

--- a/apps/api/src/modules/uploads/uploads-reference-checker.service.spec.ts
+++ b/apps/api/src/modules/uploads/uploads-reference-checker.service.spec.ts
@@ -1,0 +1,84 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AboutProfile } from '../about/entities/about-profile.entity';
+import { ProjectImage } from '../projects/entities/project-image.entity';
+import { Project } from '../projects/entities/project.entity';
+import { UploadsReferenceCheckerService } from './uploads-reference-checker.service';
+
+describe('UploadsReferenceCheckerService', () => {
+  let service: UploadsReferenceCheckerService;
+  let projectRepo: jest.Mocked<Pick<Repository<Project>, 'count'>>;
+  let imageRepo: jest.Mocked<Pick<Repository<ProjectImage>, 'count'>>;
+  let aboutRepo: jest.Mocked<Pick<Repository<AboutProfile>, 'count'>>;
+
+  beforeEach(async () => {
+    projectRepo = { count: jest.fn() } as never;
+    imageRepo = { count: jest.fn() } as never;
+    aboutRepo = { count: jest.fn() } as never;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UploadsReferenceCheckerService,
+        { provide: getRepositoryToken(Project), useValue: projectRepo },
+        { provide: getRepositoryToken(ProjectImage), useValue: imageRepo },
+        { provide: getRepositoryToken(AboutProfile), useValue: aboutRepo },
+      ],
+    }).compile();
+
+    service = module.get(UploadsReferenceCheckerService);
+  });
+
+  it('/uploads 가 아닌 URL 은 무조건 false', async () => {
+    expect(await service.isReferenced('https://cdn/x.jpg')).toBe(false);
+    expect(await service.isReferenced('/images/legacy.jpg')).toBe(false);
+    expect(await service.isReferenced(null)).toBe(false);
+    expect(projectRepo.count).not.toHaveBeenCalled();
+  });
+
+  it('세 테이블 전부 0 이면 false', async () => {
+    projectRepo.count.mockResolvedValue(0);
+    imageRepo.count.mockResolvedValue(0);
+    aboutRepo.count.mockResolvedValue(0);
+
+    expect(await service.isReferenced('/uploads/abc.jpg')).toBe(false);
+    expect(projectRepo.count).toHaveBeenCalled();
+    expect(imageRepo.count).toHaveBeenCalled();
+    expect(aboutRepo.count).toHaveBeenCalled();
+  });
+
+  it('한 테이블이라도 1 이상이면 true', async () => {
+    projectRepo.count.mockResolvedValue(0);
+    imageRepo.count.mockResolvedValue(1);
+    aboutRepo.count.mockResolvedValue(0);
+
+    expect(await service.isReferenced('/uploads/shared.jpg')).toBe(true);
+  });
+
+  it('excludeProjectId 가 있으면 project / image 쿼리에 Not(id)/Not(projectId) 가 전달된다', async () => {
+    projectRepo.count.mockResolvedValue(0);
+    imageRepo.count.mockResolvedValue(0);
+    aboutRepo.count.mockResolvedValue(0);
+
+    await service.isReferenced('/uploads/a.jpg', { excludeProjectId: 5 });
+
+    const projectWhere = projectRepo.count.mock.calls[0][0]?.where as Record<string, unknown>;
+    const imageWhere = imageRepo.count.mock.calls[0][0]?.where as Record<string, unknown>;
+    expect(projectWhere.thumbnailImg).toBe('/uploads/a.jpg');
+    expect(projectWhere.id).toBeDefined();
+    expect(imageWhere.img).toBe('/uploads/a.jpg');
+    expect(imageWhere.projectId).toBeDefined();
+  });
+
+  it('excludeAboutId 가 있으면 about 쿼리에 Not(id) 가 전달된다', async () => {
+    projectRepo.count.mockResolvedValue(0);
+    imageRepo.count.mockResolvedValue(0);
+    aboutRepo.count.mockResolvedValue(0);
+
+    await service.isReferenced('/uploads/a.jpg', { excludeAboutId: 1 });
+
+    const aboutWhere = aboutRepo.count.mock.calls[0][0]?.where as Record<string, unknown>;
+    expect(aboutWhere.profileImage).toBe('/uploads/a.jpg');
+    expect(aboutWhere.id).toBeDefined();
+  });
+});

--- a/apps/api/src/modules/uploads/uploads-reference-checker.service.ts
+++ b/apps/api/src/modules/uploads/uploads-reference-checker.service.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Not, Repository } from 'typeorm';
+import { AboutProfile } from '../about/entities/about-profile.entity';
+import { ProjectImage } from '../projects/entities/project-image.entity';
+import { Project } from '../projects/entities/project.entity';
+import {
+  resolveUploadFilename,
+  UploadsStorageService,
+} from './uploads-storage.service';
+
+export interface ReferenceExcludeScope {
+  excludeProjectId?: number;
+  excludeAboutId?: number;
+}
+
+/**
+ * 주어진 /uploads/<filename> URL 이 DB 의 어느 행에서라도 여전히 참조 중인지 확인한다.
+ * - Projects (thumbnailImg)
+ * - ProjectImages (img)
+ * - AboutProfile (profileImage)
+ *
+ * 특정 레코드를 "업데이트/삭제 중" 이라 빼고 보고 싶으면 excludeXxxId 로 제외한다.
+ */
+@Injectable()
+export class UploadsReferenceCheckerService {
+  constructor(
+    @InjectRepository(Project)
+    private readonly projectRepo: Repository<Project>,
+    @InjectRepository(ProjectImage)
+    private readonly projectImageRepo: Repository<ProjectImage>,
+    @InjectRepository(AboutProfile)
+    private readonly aboutRepo: Repository<AboutProfile>,
+  ) {}
+
+  async isReferenced(
+    url: string | null | undefined,
+    scope: ReferenceExcludeScope = {},
+  ): Promise<boolean> {
+    const filename = resolveUploadFilename(url);
+    if (!filename) return false;
+    const fullUrl = UploadsStorageService.toUrl(filename);
+
+    const [projectThumbnailCount, projectImageCount, aboutCount] =
+      await Promise.all([
+        this.projectRepo.count({
+          where: {
+            thumbnailImg: fullUrl,
+            ...(scope.excludeProjectId != null
+              ? { id: Not(scope.excludeProjectId) }
+              : {}),
+          },
+        }),
+        this.projectImageRepo.count({
+          where: {
+            img: fullUrl,
+            ...(scope.excludeProjectId != null
+              ? { projectId: Not(scope.excludeProjectId) }
+              : {}),
+          },
+        }),
+        this.aboutRepo.count({
+          where: {
+            profileImage: fullUrl,
+            ...(scope.excludeAboutId != null
+              ? { id: Not(scope.excludeAboutId) }
+              : {}),
+          },
+        }),
+      ]);
+
+    return projectThumbnailCount + projectImageCount + aboutCount > 0;
+  }
+}

--- a/apps/api/src/modules/uploads/uploads-storage.service.spec.ts
+++ b/apps/api/src/modules/uploads/uploads-storage.service.spec.ts
@@ -1,0 +1,129 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// jest.mock 으로 UPLOADS_ROOT 를 테스트별 임시 디렉터리로 주입할 수 있도록 도와주는 헬퍼.
+// 테스트 내부에서 process.env.UPLOADS_ROOT 를 바꾸면 uploads.controller 모듈이 이미
+// 로드된 상태에서는 값 캐싱이 이루어지므로, jest.isolateModules 로 모듈을 새로 로드한다.
+
+describe('UploadsStorageService', () => {
+  let tempRoot: string;
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'uploads-storage-spec-'));
+    process.env.UPLOADS_ROOT = tempRoot;
+  });
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true });
+    delete process.env.UPLOADS_ROOT;
+    jest.resetModules();
+  });
+
+  function loadService(): {
+    svc: import('./uploads-storage.service').UploadsStorageService;
+    collectReferencedFilenames: (typeof import('./uploads-storage.service'))['collectReferencedFilenames'];
+    resolveUploadFilename: (typeof import('./uploads-storage.service'))['resolveUploadFilename'];
+  } {
+    let mod!: typeof import('./uploads-storage.service');
+    jest.isolateModules(() => {
+      mod = require('./uploads-storage.service');
+    });
+    return {
+      svc: new mod.UploadsStorageService(),
+      collectReferencedFilenames: mod.collectReferencedFilenames,
+      resolveUploadFilename: mod.resolveUploadFilename,
+    };
+  }
+
+  describe('resolveUploadFilename', () => {
+    it('/uploads/xxxx.jpg → xxxx.jpg', () => {
+      const { resolveUploadFilename } = loadService();
+      expect(resolveUploadFilename('/uploads/abc.jpg')).toBe('abc.jpg');
+    });
+
+    it('외부 URL / 다른 prefix 는 null', () => {
+      const { resolveUploadFilename } = loadService();
+      expect(resolveUploadFilename('https://cdn.example.com/a.jpg')).toBeNull();
+      expect(resolveUploadFilename('/images/profile.jpeg')).toBeNull();
+      expect(resolveUploadFilename('')).toBeNull();
+      expect(resolveUploadFilename(null)).toBeNull();
+    });
+
+    it('서브디렉터리 참조(..slash) 는 null', () => {
+      const { resolveUploadFilename } = loadService();
+      expect(resolveUploadFilename('/uploads/../secret')).toBeNull();
+      expect(resolveUploadFilename('/uploads/sub/file.jpg')).toBeNull();
+    });
+  });
+
+  describe('collectReferencedFilenames', () => {
+    it('/uploads/* 만 집합에 포함, 외부/수동자산은 제외', () => {
+      const { collectReferencedFilenames } = loadService();
+      const set = collectReferencedFilenames([
+        '/uploads/a.jpg',
+        '/uploads/b.jpg',
+        '/images/c.jpg',
+        'https://cdn/d.jpg',
+        null,
+        undefined,
+        '/uploads/a.jpg', // 중복
+      ]);
+      expect(Array.from(set).sort()).toEqual(['a.jpg', 'b.jpg']);
+    });
+  });
+
+  describe('deleteByUrl', () => {
+    it('실제 파일을 삭제하고 true 반환', async () => {
+      const { svc } = loadService();
+      const path = join(tempRoot, 'x.jpg');
+      writeFileSync(path, Buffer.from('hi'));
+      const result = await svc.deleteByUrl('/uploads/x.jpg');
+      expect(result).toBe(true);
+      expect(existsSync(path)).toBe(false);
+    });
+
+    it('/uploads 접두어 아니면 false (no-op)', async () => {
+      const { svc } = loadService();
+      const result = await svc.deleteByUrl('https://cdn/x.jpg');
+      expect(result).toBe(false);
+    });
+
+    it('이미 없는 파일이면 false 반환 + 경고', async () => {
+      const { svc } = loadService();
+      const result = await svc.deleteByUrl('/uploads/missing.jpg');
+      expect(result).toBe(false);
+    });
+
+    it('빈/유효하지 않은 URL 은 false', async () => {
+      const { svc } = loadService();
+      expect(await svc.deleteByUrl(null)).toBe(false);
+      expect(await svc.deleteByUrl('')).toBe(false);
+      expect(await svc.deleteByUrl('/uploads/..')).toBe(false);
+    });
+  });
+
+  describe('listOrphans', () => {
+    it('참조 집합에 없는 파일만 반환, 참조된 것은 제외', async () => {
+      const { svc } = loadService();
+      writeFileSync(join(tempRoot, 'keep-1.jpg'), Buffer.from('1'));
+      writeFileSync(join(tempRoot, 'keep-2.jpg'), Buffer.from('22'));
+      writeFileSync(join(tempRoot, 'orphan-a.jpg'), Buffer.from('333'));
+      writeFileSync(join(tempRoot, 'orphan-b.jpg'), Buffer.from('4444'));
+
+      const orphans = await svc.listOrphans(new Set(['keep-1.jpg', 'keep-2.jpg']));
+      expect(orphans.map((o) => o.filename).sort()).toEqual([
+        'orphan-a.jpg',
+        'orphan-b.jpg',
+      ]);
+      expect(orphans.every((o) => o.bytes > 0)).toBe(true);
+    });
+
+    it('업로드 디렉터리가 없으면 빈 배열', async () => {
+      rmSync(tempRoot, { recursive: true, force: true });
+      const { svc } = loadService();
+      const orphans = await svc.listOrphans(new Set());
+      expect(orphans).toEqual([]);
+    });
+  });
+});

--- a/apps/api/src/modules/uploads/uploads-storage.service.ts
+++ b/apps/api/src/modules/uploads/uploads-storage.service.ts
@@ -1,0 +1,92 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { readdir, rm, stat } from 'node:fs/promises';
+import { basename, join, posix } from 'node:path';
+import { UPLOADS_ROOT, UPLOADS_URL_PREFIX } from './uploads.controller';
+
+// `/uploads/<filename>` URL 에서 파일명 추출. prefix 일치 + 하위 경로·상위 참조 방지.
+export function resolveUploadFilename(url: string | null | undefined): string | null {
+  if (!url || typeof url !== 'string') return null;
+  if (!url.startsWith(`${UPLOADS_URL_PREFIX}/`)) return null;
+  const filename = url.slice(UPLOADS_URL_PREFIX.length + 1);
+  if (filename.length === 0) return null;
+  // 슬래시 포함 시 서브디렉터리 참조로 간주하고 거부 (flat 구조만 허용)
+  if (filename.includes('/') || filename.includes('\\')) return null;
+  // '.' / '..' 같은 상위 탐색 금지
+  if (filename === '.' || filename === '..') return null;
+  if (filename !== basename(filename)) return null;
+  return filename;
+}
+
+// 입력 URL 배열에서 /uploads 관리 대상 파일명만 뽑아 집합으로 반환.
+// 외부 URL(http*) 과 `/images/*` 같은 수동 관리 자산은 제외된다.
+export function collectReferencedFilenames(urls: (string | null | undefined)[]): Set<string> {
+  const set = new Set<string>();
+  for (const url of urls) {
+    const filename = resolveUploadFilename(url);
+    if (filename) set.add(filename);
+  }
+  return set;
+}
+
+@Injectable()
+export class UploadsStorageService {
+  private readonly logger = new Logger(UploadsStorageService.name);
+
+  /**
+   * /uploads/* URL 한 개의 실제 파일을 디스크에서 삭제한다.
+   * - prefix 가 /uploads/ 가 아니면 no-op (외부 URL / 수동 자산 보호)
+   * - 파일이 이미 없으면 경고 로그만 남기고 통과
+   * @returns 실제로 삭제했는지 여부
+   */
+  async deleteByUrl(url: string | null | undefined): Promise<boolean> {
+    const filename = resolveUploadFilename(url);
+    if (!filename) return false;
+    const absPath = join(UPLOADS_ROOT, filename);
+    try {
+      await rm(absPath, { force: false });
+      return true;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') {
+        this.logger.warn(`[deleteByUrl] 파일이 이미 없음: ${absPath}`);
+        return false;
+      }
+      this.logger.error(`[deleteByUrl] 삭제 실패: ${absPath}`, err as Error);
+      throw err;
+    }
+  }
+
+  /**
+   * 현재 DB 가 참조하는 /uploads 파일명 집합을 받아, 디스크 상에서
+   * 그 집합에 없는 모든 파일(= orphan) 의 정보를 반환한다.
+   */
+  async listOrphans(
+    referenced: Set<string>,
+  ): Promise<{ filename: string; path: string; bytes: number }[]> {
+    let entries: string[];
+    try {
+      entries = await readdir(UPLOADS_ROOT);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw err;
+    }
+    const orphans: { filename: string; path: string; bytes: number }[] = [];
+    for (const entry of entries) {
+      if (referenced.has(entry)) continue;
+      const abs = join(UPLOADS_ROOT, entry);
+      try {
+        const s = await stat(abs);
+        if (!s.isFile()) continue;
+        orphans.push({ filename: entry, path: abs, bytes: s.size });
+      } catch (err) {
+        this.logger.warn(`[listOrphans] stat 실패: ${abs} - ${(err as Error).message}`);
+      }
+    }
+    return orphans;
+  }
+
+  // 테스트/디버그 편의를 위해 정적 URL 변환 헬퍼도 노출.
+  static toUrl(filename: string): string {
+    return posix.join(UPLOADS_URL_PREFIX, filename);
+  }
+}

--- a/apps/api/src/modules/uploads/uploads.module.ts
+++ b/apps/api/src/modules/uploads/uploads.module.ts
@@ -1,10 +1,16 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AboutProfile } from '../about/entities/about-profile.entity';
+import { ProjectImage } from '../projects/entities/project-image.entity';
+import { Project } from '../projects/entities/project.entity';
 import { UploadsController } from './uploads.controller';
+import { UploadsReferenceCheckerService } from './uploads-reference-checker.service';
 import { UploadsStorageService } from './uploads-storage.service';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Project, ProjectImage, AboutProfile])],
   controllers: [UploadsController],
-  providers: [UploadsStorageService],
-  exports: [UploadsStorageService],
+  providers: [UploadsStorageService, UploadsReferenceCheckerService],
+  exports: [UploadsStorageService, UploadsReferenceCheckerService],
 })
 export class UploadsModule {}

--- a/apps/api/src/modules/uploads/uploads.module.ts
+++ b/apps/api/src/modules/uploads/uploads.module.ts
@@ -1,7 +1,10 @@
 import { Module } from '@nestjs/common';
 import { UploadsController } from './uploads.controller';
+import { UploadsStorageService } from './uploads-storage.service';
 
 @Module({
   controllers: [UploadsController],
+  providers: [UploadsStorageService],
+  exports: [UploadsStorageService],
 })
 export class UploadsModule {}

--- a/apps/api/src/scripts/cleanup-uploads.ts
+++ b/apps/api/src/scripts/cleanup-uploads.ts
@@ -1,0 +1,87 @@
+/* eslint-disable no-console */
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AppModule } from '../app.module';
+import { AboutProfile } from '../modules/about/entities/about-profile.entity';
+import { ProjectImage } from '../modules/projects/entities/project-image.entity';
+import { Project } from '../modules/projects/entities/project.entity';
+import {
+  collectReferencedFilenames,
+  UploadsStorageService,
+} from '../modules/uploads/uploads-storage.service';
+
+// /uploads 디렉터리에서 DB 가 참조하지 않는 고아 파일을 정리.
+// 옵션:
+//   --dry-run  실제로 삭제하지 않고 대상만 표시
+//   --verbose  참조 파일도 함께 표기
+
+async function main(): Promise<void> {
+  const args = new Set(process.argv.slice(2));
+  const dryRun = args.has('--dry-run');
+  const verbose = args.has('--verbose');
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'warn', 'log'],
+  });
+
+  const storage = app.get(UploadsStorageService);
+  const projectRepo = app.get<Repository<Project>>(getRepositoryToken(Project));
+  const projectImageRepo = app.get<Repository<ProjectImage>>(
+    getRepositoryToken(ProjectImage),
+  );
+  const aboutRepo = app.get<Repository<AboutProfile>>(
+    getRepositoryToken(AboutProfile),
+  );
+
+  const [projects, images, profiles] = await Promise.all([
+    projectRepo.find({ select: { thumbnailImg: true } }),
+    projectImageRepo.find({ select: { img: true } }),
+    aboutRepo.find({ select: { profileImage: true } }),
+  ]);
+
+  const referenced = collectReferencedFilenames([
+    ...projects.map((p) => p.thumbnailImg),
+    ...images.map((i) => i.img),
+    ...profiles.map((p) => p.profileImage),
+  ]);
+
+  console.log(
+    `[cleanup:uploads] 참조 파일: ${referenced.size}건${dryRun ? ' (dry-run)' : ''}`,
+  );
+  if (verbose) {
+    for (const f of [...referenced].sort()) {
+      console.log(`  ref: ${f}`);
+    }
+  }
+
+  const orphans = await storage.listOrphans(referenced);
+  console.log(`[cleanup:uploads] 고아 파일: ${orphans.length}건`);
+
+  if (orphans.length === 0) {
+    await app.close();
+    return;
+  }
+
+  let totalBytes = 0;
+  for (const o of orphans) {
+    totalBytes += o.bytes;
+    if (dryRun) {
+      console.log(`  would delete: ${o.filename} (${o.bytes}B)`);
+    } else {
+      await storage.deleteByUrl(UploadsStorageService.toUrl(o.filename));
+      console.log(`  deleted: ${o.filename} (${o.bytes}B)`);
+    }
+  }
+  console.log(
+    `[cleanup:uploads] 총 ${orphans.length}건 / ${totalBytes}B${dryRun ? ' (계획만 출력됨)' : ' 정리 완료'}`,
+  );
+
+  await app.close();
+}
+
+main().catch((err) => {
+  console.error('[cleanup:uploads] failed:', err);
+  process.exit(1);
+});

--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -1,0 +1,58 @@
+# Image Uploads
+
+어드민에서 올리는 이미지는 `/app/uploads/` (`uploads` named docker volume) 에 저장되고, `api` 가 `/uploads/<filename>` 경로로 정적 서빙한다. 프론트는 `next.config.js` rewrite 로 이 경로를 api 로 프록시한다.
+
+## URL / 저장 규칙
+
+- URL 포맷: `/uploads/<uuid>.jpg` — 업로드 후 sharp 로 JPEG 재인코딩 되면서 확장자도 `.jpg` 로 통일된다
+- 외부 URL(`http://`, `https://`) 과 수동 자산(`/images/*`) 은 이 문서의 라이프사이클 관리 대상 아님 — 관리하지 않는다
+
+## 슬롯별 preset (서버 리사이즈)
+
+| preset | 규격 | fit | 비고 |
+|---|---|---|---|
+| `thumbnail` | 1600×900 | cover | 프로젝트 카드 썸네일 (16:9) |
+| `gallery` | 최대 1600×1600 | inside | 프로젝트 상세 갤러리, 비율 유지 |
+| `profile` | 512×512 | cover | About 프로필 (1:1) |
+
+업로드 엔드포인트: `POST /api/admin/uploads?preset=<name>` (미지정 시 `gallery`)
+
+## 자동 정리 (hot path)
+
+프로젝트·프로필이 업데이트되거나 삭제될 때 참조가 끊긴 `/uploads/*` 파일이 즉시 정리된다.
+
+- `AdminProjectsService.update` — DTO 의 새 thumbnail/gallery 목록과 이전 상태를 비교해 사라진 URL 을 삭제
+- `AdminProjectsService.remove` — 모든 참조 파일 삭제
+- `AdminAboutService.upsert` — 이전 `profile_image` 가 바뀌었고 `/uploads/*` 였다면 삭제
+
+수동 자산(`/images/*`) 은 URL 접두어 검사로 제외되므로 건드리지 않는다. 파일 삭제 실패는 로그에 남기고 도메인 트랜잭션 성공을 유지한다.
+
+## 주기적 청소 스크립트 (safety net)
+
+```bash
+# 어느 파일이 고아인지만 확인 (삭제하지 않음)
+DB_HOST=... DB_PORT=... DB_USERNAME=... DB_PASSWORD=... DB_DATABASE=... \
+ADMIN_PASSWORD_HASH=... JWT_SECRET=... \
+  npm run -w apps/api cleanup:uploads -- --dry-run
+
+# 실제 삭제
+DB_HOST=... DB_PORT=... DB_USERNAME=... DB_PASSWORD=... DB_DATABASE=... \
+ADMIN_PASSWORD_HASH=... JWT_SECRET=... \
+  npm run -w apps/api cleanup:uploads
+
+# 참조된 파일도 같이 보기
+npm run -w apps/api cleanup:uploads -- --dry-run --verbose
+```
+
+컨테이너 안에서 실행할 수도 있다.
+
+```bash
+docker compose exec api npm run cleanup:uploads
+```
+
+스크립트는 DB(`PROJECT.thumbnail_img`, `PROJECT_IMAGE.img`, `ABOUT_PROFILE.profile_image`) 가 참조하는 `/uploads/*` 파일명 집합을 만들고, 그 집합에 없는 업로드 디렉터리의 모든 파일을 정리한다.
+
+## 주의
+
+- S3/R2 이관(#28) 시점에는 hot path 와 스크립트 모두 object storage API 로 교체된다. 인터페이스(`UploadsStorageService.deleteByUrl / listOrphans`) 는 그대로 유지하도록 설계되어 있다.
+- 스크립트 실행 중 어드민이 동시에 이미지를 교체하면 race condition 으로 방금 업로드된 파일이 고아로 잡힐 수 있다. 가능한 경우 짧은 유지보수 창 또는 낮은 트래픽 시간에 실행할 것.


### PR DESCRIPTION
## 요약

Projects/About 에서 이미지를 **교체 · 삭제** 할 때 이전 `/uploads/*` 파일을 즉시 정리하고, 안전망으로 **수동 청소 스크립트**를 추가한다. 외부 URL(`http://`, `https://`) 과 수동 자산(`/images/*`) 은 건드리지 않는다.

## 변경 내용

### 커밋 `fb95b41 feat(api): UploadsStorageService 로 /uploads 파일 라이프사이클 공용화`
- `uploads-storage.service.ts` 신설
  - `resolveUploadFilename(url)` — `.` / `..` / 서브디렉터리 / 외부 URL / 수동 자산은 모두 `null` (경로 트래버설 방지)
  - `collectReferencedFilenames(urls)` — 혼합 배열에서 관리 대상만 Set 으로
  - `UploadsStorageService.deleteByUrl(url)` — ENOENT/prefix 불일치는 no-op + 경고
  - `UploadsStorageService.listOrphans(referenced)` — DB 참조 대비 디스크 고아 목록
  - 정적 헬퍼 `toUrl(filename)`
- UploadsModule 이 서비스를 export → Projects/About 모듈이 import 해 재사용
- 단위 테스트 10 케이스 (resolve 3 / collect 1 / deleteByUrl 4 / listOrphans 2)

### 커밋 `6927a1b feat(api): 프로젝트/About update·remove 에 업로드 파일 즉시 정리 연결`
- `admin-projects.service.update` — 기존 relations 로드 → DTO 의 새 thumbnail/gallery 와 차집합 → deleteByUrl
- `admin-projects.service.remove` — 삭제 전 참조 수집, 실제 delete 성공 후 cleanup
- `admin-about.service.upsert` — 이전 profileImage 가 바뀌고 `/uploads/*` 였다면 이전 파일만 삭제
- 파일 삭제 실패는 도메인 트랜잭션과 분리 (로그만)
- 테스트 갱신: projects remove 새 경로 2 케이스, projects update cleanup 1 케이스, about service DI 주입 정리

### 커밋 `485c0b7 feat(api): cleanup:uploads 고아 파일 정리 스크립트와 운영 문서 추가`
- `src/scripts/cleanup-uploads.ts`: NestJS context 부팅 → PROJECT·PROJECT_IMAGE·ABOUT_PROFILE 의 전 `/uploads` 참조를 수집 → `listOrphans` → `--dry-run` 이 아니면 `deleteByUrl` 로 정리, 총 건수·바이트 출력. `--verbose` 옵션은 참조 파일도 표기
- `package.json` 에 `cleanup:uploads` 스크립트 등록
- `docs/uploads.md` 신설 (URL 규칙, preset, hot path, 수동 스크립트, 컨테이너 내 실행, race condition 주의)

## 변경 이유

- 어드민에서 교체·삭제가 반복되면 `/uploads/` 에 고아 파일이 누적됨 → 디스크 사용량 단조 증가
- S3/R2 이관(#28) 시점에도 같은 인터페이스(`UploadsStorageService`)만 교체하면 되도록 유틸 계층을 분리
- 즉시 정리(hot path) 만으로는 일부 케이스(장애로 파일 삭제 실패, 과거에 쌓인 고아)를 놓칠 수 있어 주기적 스크립트 병행

## 영향 범위

- [ ] `apps/web`
- [x] `apps/api`
- [ ] `packages`
- [x] `repo` (docs)

## 스크린샷 / 데모

서버측 변경. 실제 동작은 Projects 편집에서 썸네일을 새 파일로 바꾸고 저장하면 이전 `/uploads/<uuid>.jpg` 파일이 디스크에서 사라지는 것으로 확인.

## 테스트 / 확인

- [x] `apps/api` 단위 테스트 신규 13 케이스 (storage 10 + projects update/remove cleanup 3)
  - storage: URL resolver / collect / deleteByUrl (성공/ENOENT/외부URL/traversal) / listOrphans (케이스 + 빈 디렉터리)
  - projects: update 교체된 /uploads 만 삭제·외부자산 유지, remove 성공+cleanup·대상 부재 404·affected=0 404
- [x] 전체 113 케이스 통과, lint/build OK
- [x] `cleanup:uploads --dry-run` 로컬 실행 → "참조 0건 / 고아 0건" 정상 출력 (빈 UPLOADS_ROOT 기준)

## 리뷰 포인트

- **경로 트래버설 가드**: `resolveUploadFilename` 이 `.` / `..` / slash 포함을 모두 null 처리. 외부에서 주입된 URL 을 그대로 deleteByUrl 에 넘겨도 안전
- **삭제 실패 처리**: 파일 rm 실패는 도메인 응답을 막지 않음 (로그만). 사용자는 데이터 정합성(DB) 관점에서 여전히 성공 응답을 받고, 파일은 다음 cleanup 스크립트 실행에서 정리됨
- **cleanup 스크립트의 race condition**: 동시 업로드 중에는 방금 업로드한 파일이 일시적으로 "참조 안 됨" 상태일 수 있어 false-positive 삭제 우려. `docs/uploads.md` 에 주의 명시, 짧은 유지보수 창에서 실행 권장
- **S3/R2 이관(#28) 호환성**: `UploadsStorageService` 의 두 메서드만 object storage API 로 교체하면 위/아래 호출자는 건드릴 필요 없음

## 참고 사항

- 주기적 스케줄링(cron) 은 이번 PR 범위 밖. 수요가 생기면 self-hosted runner 또는 systemd timer 로 추가 가능
- 삭제 엔드포인트(`DELETE /api/admin/uploads/:filename`) 는 이번 범위에서 제외 — 현재 admin UI 에 해당 동선 없음

Closes #37