### PR TITLE
[fix] 어드민 UI 다크 모드·모바일 가시성 보강 (#44 #45)

### DIFF
--- a/apps/web/components/admin/AdminFormSection.jsx
+++ b/apps/web/components/admin/AdminFormSection.jsx
@@ -1,7 +1,7 @@
 // 어드민 폼의 섹션 단위 래퍼. 제목/설명/본문을 일관된 간격으로 묶는다.
 function AdminFormSection({ title, description, action, children }) {
 	return (
-		<section className="mb-8 rounded-xl border border-gray-200 dark:border-secondary-dark bg-secondary-light dark:bg-secondary-dark p-5 sm:p-6">
+		<section className="mb-8 rounded-xl border border-gray-200 dark:border-ternary-dark bg-secondary-light dark:bg-secondary-dark p-5 sm:p-6">
 			<header className="flex items-start justify-between gap-3 mb-4">
 				<div>
 					<h2 className="font-general-medium text-xl text-primary-dark dark:text-primary-light">

--- a/apps/web/components/admin/AdminTable.jsx
+++ b/apps/web/components/admin/AdminTable.jsx
@@ -46,7 +46,7 @@ function AdminTable({ columns, rows, actions, emptyMessage = '데이터가 없�
 								</td>
 							))}
 							{showActions && (
-								<td className="px-4 py-3 text-right">
+								<td className="px-4 py-3 text-right whitespace-nowrap">
 									<div className="flex justify-end gap-2">
 										{actions(row)}
 									</div>

--- a/apps/web/components/admin/DynamicList.jsx
+++ b/apps/web/components/admin/DynamicList.jsx
@@ -45,7 +45,7 @@ function DynamicList({
 			{items.map((item, i) => (
 				<div
 					key={item._key ?? i}
-					className="rounded-lg border border-gray-200 dark:border-ternary-dark bg-primary-light dark:bg-ternary-dark p-3 sm:p-4"
+					className="rounded-lg border border-gray-200 dark:border-white/10 bg-primary-light dark:bg-ternary-dark p-3 sm:p-4"
 				>
 					<div className="flex justify-between items-start gap-2 mb-2">
 						<span className="font-general-medium text-xs text-ternary-dark dark:text-ternary-light">

--- a/apps/web/components/admin/ImageUploader.jsx
+++ b/apps/web/components/admin/ImageUploader.jsx
@@ -198,7 +198,7 @@ function ImageUploader({
 					onDragOver={handleDragOver}
 					onDragLeave={handleDragLeave}
 					onDrop={handleDrop}
-					className={`flex flex-col items-center justify-center gap-1 border border-dashed border-gray-300 dark:border-ternary-dark rounded-md px-4 py-6 text-ternary-dark dark:text-ternary-light hover:border-indigo-400 dark:hover:border-indigo-500 duration-300 ${dropRingClass}`}
+					className={`flex flex-col items-center justify-center gap-1 border border-dashed border-gray-300 dark:border-gray-500 rounded-md px-4 py-6 text-ternary-dark dark:text-ternary-light hover:border-indigo-400 dark:hover:border-indigo-400 duration-300 ${dropRingClass}`}
 				>
 					<FiUploadCloud className="w-6 h-6" />
 					<span className="text-sm font-general-medium">

--- a/apps/web/components/admin/ImageUploader.jsx
+++ b/apps/web/components/admin/ImageUploader.jsx
@@ -148,39 +148,41 @@ function ImageUploader({
 		<div className={`flex flex-col gap-2 ${className}`}>
 			{value ? (
 				<div
-					className={`relative inline-block rounded-md ${dropRingClass}`}
+					className="inline-block"
 					onDragOver={handleDragOver}
 					onDragLeave={handleDragLeave}
 					onDrop={handleDrop}
 				>
-					{/* eslint-disable-next-line @next/next/no-img-element */}
-					<img
-						src={value}
-						alt={previewAlt}
-						onLoad={handleImageLoad}
-						className="rounded-md max-h-40 border border-gray-200 dark:border-ternary-dark"
-					/>
-					<div className="absolute top-1 right-1 flex gap-1">
-						<button
-							type="button"
-							onClick={openPicker}
-							disabled={uploading}
-							aria-label="Replace image"
-							title="교체"
-							className="p-1 rounded-full bg-white/90 dark:bg-secondary-dark/90 text-ternary-dark hover:text-indigo-500 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
-						>
-							<FiRefreshCw className={`w-4 h-4 ${uploading ? 'animate-spin' : ''}`} />
-						</button>
-						<button
-							type="button"
-							onClick={clear}
-							disabled={uploading}
-							aria-label="Remove image"
-							title="제거"
-							className="p-1 rounded-full bg-white/90 dark:bg-secondary-dark/90 text-ternary-dark hover:text-red-500 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
-						>
-							<FiX className="w-4 h-4" />
-						</button>
+					<div className={`relative inline-block rounded-md ${dropRingClass}`}>
+						{/* eslint-disable-next-line @next/next/no-img-element */}
+						<img
+							src={value}
+							alt={previewAlt}
+							onLoad={handleImageLoad}
+							className="rounded-md max-h-40 block border border-gray-200 dark:border-ternary-dark"
+						/>
+						<div className="absolute top-1 right-1 flex gap-1">
+							<button
+								type="button"
+								onClick={openPicker}
+								disabled={uploading}
+								aria-label="Replace image"
+								title="교체"
+								className="p-1 rounded-full bg-white/90 dark:bg-secondary-dark/90 text-ternary-dark dark:text-ternary-light hover:text-indigo-500 dark:hover:text-indigo-300 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+							>
+								<FiRefreshCw className={`w-4 h-4 ${uploading ? 'animate-spin' : ''}`} />
+							</button>
+							<button
+								type="button"
+								onClick={clear}
+								disabled={uploading}
+								aria-label="Remove image"
+								title="제거"
+								className="p-1 rounded-full bg-white/90 dark:bg-secondary-dark/90 text-ternary-dark dark:text-ternary-light hover:text-red-500 dark:hover:text-red-400 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+							>
+								<FiX className="w-4 h-4" />
+							</button>
+						</div>
 					</div>
 					{metaLabel && (
 						<p className="mt-1 text-xs text-ternary-dark dark:text-ternary-light font-general-regular">

--- a/apps/web/components/admin/ImageUploader.jsx
+++ b/apps/web/components/admin/ImageUploader.jsx
@@ -148,41 +148,39 @@ function ImageUploader({
 		<div className={`flex flex-col gap-2 ${className}`}>
 			{value ? (
 				<div
-					className="inline-block"
+					className={`relative inline-block rounded-md ${dropRingClass}`}
 					onDragOver={handleDragOver}
 					onDragLeave={handleDragLeave}
 					onDrop={handleDrop}
 				>
-					<div className={`relative inline-block rounded-md ${dropRingClass}`}>
-						{/* eslint-disable-next-line @next/next/no-img-element */}
-						<img
-							src={value}
-							alt={previewAlt}
-							onLoad={handleImageLoad}
-							className="rounded-md max-h-40 block border border-gray-200 dark:border-ternary-dark"
-						/>
-						<div className="absolute top-1 right-1 flex gap-1">
-							<button
-								type="button"
-								onClick={openPicker}
-								disabled={uploading}
-								aria-label="Replace image"
-								title="교체"
-								className="p-1 rounded-full bg-white/90 dark:bg-secondary-dark/90 text-ternary-dark dark:text-ternary-light hover:text-indigo-500 dark:hover:text-indigo-300 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
-							>
-								<FiRefreshCw className={`w-4 h-4 ${uploading ? 'animate-spin' : ''}`} />
-							</button>
-							<button
-								type="button"
-								onClick={clear}
-								disabled={uploading}
-								aria-label="Remove image"
-								title="제거"
-								className="p-1 rounded-full bg-white/90 dark:bg-secondary-dark/90 text-ternary-dark dark:text-ternary-light hover:text-red-500 dark:hover:text-red-400 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
-							>
-								<FiX className="w-4 h-4" />
-							</button>
-						</div>
+					{/* eslint-disable-next-line @next/next/no-img-element */}
+					<img
+						src={value}
+						alt={previewAlt}
+						onLoad={handleImageLoad}
+						className="rounded-md max-h-40 border border-gray-200 dark:border-ternary-dark"
+					/>
+					<div className="absolute top-1 right-1 flex gap-1">
+						<button
+							type="button"
+							onClick={openPicker}
+							disabled={uploading}
+							aria-label="Replace image"
+							title="교체"
+							className="p-1 rounded-full bg-white/90 dark:bg-secondary-dark/90 text-ternary-dark dark:text-ternary-light hover:text-indigo-500 dark:hover:text-indigo-300 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							<FiRefreshCw className={`w-4 h-4 ${uploading ? 'animate-spin' : ''}`} />
+						</button>
+						<button
+							type="button"
+							onClick={clear}
+							disabled={uploading}
+							aria-label="Remove image"
+							title="제거"
+							className="p-1 rounded-full bg-white/90 dark:bg-secondary-dark/90 text-ternary-dark dark:text-ternary-light hover:text-red-500 dark:hover:text-red-400 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							<FiX className="w-4 h-4" />
+						</button>
 					</div>
 					{metaLabel && (
 						<p className="mt-1 text-xs text-ternary-dark dark:text-ternary-light font-general-regular">

--- a/apps/web/pages/admin/contact.jsx
+++ b/apps/web/pages/admin/contact.jsx
@@ -119,6 +119,7 @@ function AdminContactInbox({ initialPage, initialStatus }) {
 					{
 						key: 'createdAt',
 						label: '시간',
+						className: 'whitespace-nowrap',
 						render: (row) => (
 							<span className="text-xs text-ternary-dark dark:text-ternary-light">
 								{formatDate(row.createdAt)}

--- a/apps/web/pages/admin/contact.jsx
+++ b/apps/web/pages/admin/contact.jsx
@@ -150,7 +150,7 @@ function AdminContactInbox({ initialPage, initialStatus }) {
 									value={row.status}
 									disabled={pendingId === row.id}
 									onChange={(e) => handleStatusChange(row, e.target.value)}
-									className="px-2 py-1 text-xs border border-gray-300 dark:border-primary-dark border-opacity-50 bg-ternary-light dark:bg-ternary-dark rounded font-general-regular disabled:opacity-50"
+									className="pl-2 pr-6 py-1 text-xs border border-gray-300 dark:border-primary-dark border-opacity-50 bg-ternary-light dark:bg-ternary-dark rounded font-general-regular disabled:opacity-50"
 									aria-label="Change status"
 								>
 									{STATUS_OPTIONS.map((opt) => (


### PR DESCRIPTION
## 요약

- 이슈 #44 (어드민 다크 모드 가독성) 와 #45 (어드민 모바일 레이아웃) 을 한 브랜치에서 해결.
- 섹션/리스트 테두리와 이미지 프리뷰 버튼 색이 다크 모드에서 배경과 섞이던 문제, 모바일에서 짧은 한글 라벨·날짜가 강제 개행되던 문제, 상태 select 화살표와 옵션 텍스트가 겹치던 문제를 수정했습니다.

## 변경 내용

- `fix(web): ImageUploader 빈 업로드 박스 다크 모드 가시성 개선` — 점선 border 를 `dark:border-gray-500` (뉴트럴 톤) 로 상향.
- `fix(web): AdminFormSection 다크 모드 테두리 보이게 조정` — border 만 `dark:border-ternary-dark` 로 분리 (bg 와 색 분리).
- `fix(web): DynamicList 행 구분 보강` — 팔레트에 ternary-dark 보다 밝은 색이 없어 `dark:border-white/10` 로 처리.
- `fix(web): ImageUploader 미리보기 액션 버튼 위치·다크 가시성 개선` → `... 위치 원복` 쌍: 래퍼를 잠깐 분리했다가 사용자 피드백에 따라 원복. 다크용 `text-ternary-light` / hover 색은 유지.
- `fix(web): AdminTable 액션 컬럼 모바일 줄바꿈 방지` — 액션 td 에 `whitespace-nowrap` 추가 (프로젝트 편집/삭제 뿐 아니라 공용 어드민 테이블 전반에 반영).
- `fix(web): 어드민 컨택트 시간 컬럼 줄바꿈 방지` — 시간 컬럼에 `whitespace-nowrap` 지정.
- `fix(web): 어드민 컨택트 상태 select 화살표와 옵션 텍스트 겹침 해소` — `px-2` → `pl-2 pr-6` 로 오른쪽 패딩 확보.

## 변경 이유

- 다크 모드 팔레트(primary/secondary/ternary-dark) 가 모두 어두운 청색 계열이라, 컴포넌트에서 border 와 bg 에 같은 토큰을 쓰면 다크 모드에서 경계가 완전히 사라지는 케이스가 여러 군데 있었습니다. 팔레트 안에서 최소한의 톤 차이로 구분되도록 했고, ternary-dark 행처럼 팔레트 한계에 걸리는 곳은 `white/10` 같은 반투명으로 회피.
- 모바일(≈ 400~500px) 에서 어드민 테이블은 overflow-x-auto 로 가로 스크롤이 가능하지만, 셀 내부의 짧은 한글 라벨이 공백·글자 단위로 꺾이면 행 높이가 과하게 커지는 문제가 있었습니다. 해당 컬럼에 `whitespace-nowrap` 을 지정해 한 줄로 유지합니다.

## 영향 범위

- [x] `apps/web`
- [ ] `apps/api`
- [ ] `packages`
- [ ] `repo`

## 스크린샷 / 데모

- 직접 docker compose 로 로컬 배포해서 About / Projects / Contact 어드민 페이지의 다크 모드·모바일 뷰에서 확인했습니다. (텔레그램 리뷰 루프로 이미지 공유 진행)

## 테스트 / 확인

- [x] 웹 이미지 재빌드 (`docker compose build web`) 및 컨테이너 교체로 배포 확인
- [x] `/admin/login`, `/admin/projects`, `/admin/contact`, `/admin/about` 수동 확인
- [ ] 유닛 테스트: 이번 변경은 순수 스타일 변경이라 별도 추가 없음

## 리뷰 포인트

- `0435123 → 44eed0a` 쌍으로 ImageUploader 래퍼 구조를 잠깐 바꿨다가 원복했습니다. 의도된 동작 (버튼이 이미지 외곽, URL 텍스트 줄 우측) 유지를 원하셔서 구조는 그대로 두고 색상만 수정된 상태입니다.
- `AdminTable` 액션 컬럼의 `whitespace-nowrap` 은 전역 적용이라 다른 어드민 페이지에도 영향이 갑니다. 현재 사용처(Projects/Contact) 기준으로는 문제 없지만, 향후 액션 텍스트가 길어지면 가로 스크롤이 자주 발생할 수 있습니다.
- `DynamicList` 에 `border-white/10` 을 사용했습니다. 팔레트 밖 색이라 일관성은 약하지만, 팔레트에 ternary-dark 위에 놓일 더 밝은 토큰이 없어 대안으로 선택했습니다.

## 참고 사항

- 이슈 #44 / #45 는 본 PR 로 해결.
- 이미지 라이프사이클(#28) · 정적 자산 배치 개선 등 별건 이슈는 변경하지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)