### PR TITLE
[feat] 프론트 UI 애니메이션 (#47 #48 #49 #50 #51)

### DIFF
--- a/apps/web/components/HireMeModal.jsx
+++ b/apps/web/components/HireMeModal.jsx
@@ -13,17 +13,24 @@ const selectOptions = [
 function HireMeModal({ onClose, onRequest }) {
 	return (
 		<motion.div
-			initial={false}
+			initial={{ opacity: 0 }}
 			animate={{ opacity: 1 }}
 			exit={{ opacity: 0 }}
-			className="font-general-medium fixed inset-0 z-30 transition-all duration-500"
+			transition={{ duration: 0.2, ease: 'easeOut' }}
+			className="font-general-medium fixed inset-0 z-30"
 		>
 			{/* Modal Backdrop */}
 			<div className="bg-filter bg-black bg-opacity-50 fixed inset-0 w-full h-full z-20"></div>
 
 			{/* Modal Content */}
 			<main className="flex flex-col items-center justify-center h-full w-full">
-				<div className="modal-wrapper flex items-center z-30">
+				<motion.div
+					className="modal-wrapper flex items-center z-30"
+					initial={{ opacity: 0, scale: 0.95 }}
+					animate={{ opacity: 1, scale: 1 }}
+					exit={{ opacity: 0, scale: 0.95 }}
+					transition={{ duration: 0.22, ease: 'easeOut' }}
+				>
 					<div className="modal max-w-md mx-5 xl:max-w-xl lg:max-w-xl md:max-w-xl bg-secondary-light dark:bg-primary-dark max-h-screen shadow-lg flex-row rounded-lg relative">
 						<div className="modal-header flex justify-between gap-10 p-5 border-b border-ternary-light dark:border-ternary-dark">
 							<h5 className=" text-primary-dark dark:text-primary-light text-xl">
@@ -106,7 +113,7 @@ function HireMeModal({ onClose, onRequest }) {
 							/>
 						</div>
 					</div>
-				</div>
+				</motion.div>
 			</main>
 		</motion.div>
 	);

--- a/apps/web/components/projects/ProjectSingle.jsx
+++ b/apps/web/components/projects/ProjectSingle.jsx
@@ -2,17 +2,14 @@ import { motion } from 'framer-motion';
 import Image from 'next/image';
 import Link from 'next/link';
 
+const itemVariants = {
+	hidden: { opacity: 0, y: 12 },
+	visible: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+};
+
 const ProjectSingle = ({ url, img, title, category }) => {
 	return (
-		<motion.div
-			initial={false}
-			animate={{ opacity: 1, delay: 1 }}
-			transition={{
-				ease: 'easeInOut',
-				duration: 0.7,
-				delay: 0.15,
-			}}
-		>
+		<motion.div variants={itemVariants}>
 			<Link
 				href="/projects/[url]"
 				as={`/projects/${url}`}

--- a/apps/web/components/projects/ProjectSingle.jsx
+++ b/apps/web/components/projects/ProjectSingle.jsx
@@ -3,8 +3,8 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 const itemVariants = {
-	hidden: { opacity: 0, y: 12 },
-	visible: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+	hidden: { opacity: 0, y: 20 },
+	visible: { opacity: 1, y: 0, transition: { duration: 0.4, ease: 'easeOut' } },
 };
 
 const ProjectSingle = ({ url, img, title, category }) => {

--- a/apps/web/components/projects/ProjectSingle.jsx
+++ b/apps/web/components/projects/ProjectSingle.jsx
@@ -16,7 +16,11 @@ const ProjectSingle = ({ url, img, title, category }) => {
 				aria-label={title}
 				passHref
 			>
-				<div className="rounded-xl shadow-lg hover:shadow-xl cursor-pointer mb-10 sm:mb-0 bg-secondary-light dark:bg-ternary-dark">
+				<motion.div
+					whileHover={{ y: -4 }}
+					transition={{ duration: 0.2, ease: 'easeOut' }}
+					className="rounded-xl shadow-lg hover:shadow-xl cursor-pointer mb-10 sm:mb-0 bg-secondary-light dark:bg-ternary-dark"
+				>
 					{/* thumbnail preset 이 16:9 로 정규화되므로 카드 썸네일도 같은 비율로 고정. */}
 					<div className="relative w-full aspect-video overflow-hidden rounded-t-xl">
 						<Image
@@ -37,7 +41,7 @@ const ProjectSingle = ({ url, img, title, category }) => {
 							</span>
 						)}
 					</div>
-				</div>
+				</motion.div>
 			</Link>
 		</motion.div>
 	);

--- a/apps/web/components/projects/ProjectSingle.jsx
+++ b/apps/web/components/projects/ProjectSingle.jsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 
 const itemVariants = {
 	hidden: { opacity: 0, y: 20 },
-	visible: { opacity: 1, y: 0, transition: { duration: 0.4, ease: 'easeOut' } },
+	visible: { opacity: 1, y: 0, transition: { duration: 0.5, ease: 'easeOut' } },
 };
 
 const ProjectSingle = ({ url, img, title, category }) => {

--- a/apps/web/components/projects/ProjectsGrid.jsx
+++ b/apps/web/components/projects/ProjectsGrid.jsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
 import { useState } from 'react';
 import { FiSearch } from 'react-icons/fi';
 import ProjectSingle from './ProjectSingle';
@@ -105,16 +105,22 @@ function ProjectsGrid({ projects = [] }) {
 				</div>
 			</div>
 
-			<motion.div
-				className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 mt-6 sm:gap-5"
-				variants={gridVariants}
-				initial="hidden"
-				animate="visible"
-			>
-				{filteredProjects.map((project) => (
-					<ProjectSingle key={project.id ?? project.url} {...project} />
-				))}
-			</motion.div>
+			{/* 자체 AnimatePresence 로 감싸 상위 _app.jsx 의 initial={false}
+			    가 PresenceContext 를 통해 내려와 stagger 첫 렌더 애니메이션을
+			    차단하는 것을 우회한다. */}
+			<AnimatePresence>
+				<motion.div
+					key="projects-grid"
+					className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 mt-6 sm:gap-5"
+					variants={gridVariants}
+					initial="hidden"
+					animate="visible"
+				>
+					{filteredProjects.map((project) => (
+						<ProjectSingle key={project.id ?? project.url} {...project} />
+					))}
+				</motion.div>
+			</AnimatePresence>
 		</section>
 	);
 }

--- a/apps/web/components/projects/ProjectsGrid.jsx
+++ b/apps/web/components/projects/ProjectsGrid.jsx
@@ -5,8 +5,11 @@ import ProjectSingle from './ProjectSingle';
 import ProjectsFilter from './ProjectsFilter';
 
 const gridVariants = {
-	hidden: { opacity: 0 },
-	visible: { opacity: 1, transition: { staggerChildren: 0.06 } },
+	hidden: { opacity: 1 },
+	visible: {
+		opacity: 1,
+		transition: { delayChildren: 0.1, staggerChildren: 0.1 },
+	},
 };
 
 function ProjectsGrid({ projects = [] }) {

--- a/apps/web/components/projects/ProjectsGrid.jsx
+++ b/apps/web/components/projects/ProjectsGrid.jsx
@@ -1,7 +1,13 @@
+import { motion } from 'framer-motion';
 import { useState } from 'react';
 import { FiSearch } from 'react-icons/fi';
 import ProjectSingle from './ProjectSingle';
 import ProjectsFilter from './ProjectsFilter';
+
+const gridVariants = {
+	hidden: { opacity: 0 },
+	visible: { opacity: 1, transition: { staggerChildren: 0.06 } },
+};
 
 function ProjectsGrid({ projects = [] }) {
 	const [searchProject, setSearchProject] = useState('');
@@ -99,11 +105,16 @@ function ProjectsGrid({ projects = [] }) {
 				</div>
 			</div>
 
-			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 mt-6 sm:gap-5">
+			<motion.div
+				className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 mt-6 sm:gap-5"
+				variants={gridVariants}
+				initial="hidden"
+				animate="visible"
+			>
 				{filteredProjects.map((project) => (
 					<ProjectSingle key={project.id ?? project.url} {...project} />
 				))}
-			</div>
+			</motion.div>
 		</section>
 	);
 }

--- a/apps/web/components/projects/ProjectsGrid.jsx
+++ b/apps/web/components/projects/ProjectsGrid.jsx
@@ -8,7 +8,7 @@ const gridVariants = {
 	hidden: { opacity: 1 },
 	visible: {
 		opacity: 1,
-		transition: { delayChildren: 0.1, staggerChildren: 0.1 },
+		transition: { delayChildren: 0.15, staggerChildren: 0.15 },
 	},
 };
 

--- a/apps/web/components/shared/AppHeader.jsx
+++ b/apps/web/components/shared/AppHeader.jsx
@@ -228,14 +228,14 @@ function AppHeader() {
 					</div>
 				</div>
 			</div>
-			<div>
-				{showModal ? (
+			<AnimatePresence>
+				{showModal && (
 					<HireMeModal
 						onClose={showHireMeModal}
 						onRequest={showHireMeModal}
 					/>
-				) : null}
-			</div>
+				)}
+			</AnimatePresence>
 		</motion.nav>
 	);
 }

--- a/apps/web/components/shared/AppHeader.jsx
+++ b/apps/web/components/shared/AppHeader.jsx
@@ -16,6 +16,42 @@ const navLinks = [
 	{ href: '/contact', label: 'Contact' },
 ];
 
+// 테마 토글 버튼 안에 들어가는 아이콘. 햄버거와 동일한 rotate+fade 크로스
+// 트랜지션을 쓰되 dark ↔ light 전환 특성상 mounted 가 false 일 땐 SSR 결과와
+// 같은 sun 아이콘을 그대로 보여주고 애니메이션은 최초 전환부터 적용한다.
+function ThemeSwitchIcon({ mounted, activeTheme }) {
+	const isDark = mounted && activeTheme === 'dark';
+	return (
+		<span className="relative block w-5 h-5">
+			<AnimatePresence initial={false} mode="wait">
+				{isDark ? (
+					<motion.span
+						key="moon"
+						initial={{ rotate: -90, opacity: 0 }}
+						animate={{ rotate: 0, opacity: 1 }}
+						exit={{ rotate: 90, opacity: 0 }}
+						transition={{ duration: 0.2, ease: 'easeInOut' }}
+						className="absolute inset-0 flex items-center justify-center"
+					>
+						<FiMoon className="text-ternary-dark hover:text-gray-400 dark:text-ternary-light dark:hover:text-primary-light text-xl" />
+					</motion.span>
+				) : (
+					<motion.span
+						key="sun"
+						initial={{ rotate: 90, opacity: 0 }}
+						animate={{ rotate: 0, opacity: 1 }}
+						exit={{ rotate: -90, opacity: 0 }}
+						transition={{ duration: 0.2, ease: 'easeInOut' }}
+						className="absolute inset-0 flex items-center justify-center"
+					>
+						<FiSun className="text-gray-200 hover:text-gray-50 text-xl" />
+					</motion.span>
+				)}
+			</AnimatePresence>
+		</span>
+	);
+}
+
 function AppHeader() {
 	const router = useRouter();
 	const [showMenu, setShowMenu] = useState(false);
@@ -82,11 +118,7 @@ function AppHeader() {
 							aria-label="Theme Switcher"
 							className="bg-primary-light dark:bg-ternary-dark p-3 shadow-sm rounded-xl cursor-pointer"
 						>
-							{mounted && activeTheme === 'dark' ? (
-								<FiMoon className="text-ternary-dark hover:text-gray-400 dark:text-ternary-light dark:hover:text-primary-light text-xl" />
-							) : (
-								<FiSun className="text-gray-200 hover:text-gray-50 text-xl" />
-							)}
+							<ThemeSwitchIcon mounted={mounted} activeTheme={activeTheme} />
 						</div>
 						<div>
 						<button
@@ -192,11 +224,7 @@ function AppHeader() {
 						aria-label="Theme Switcher"
 						className="ml-8 bg-primary-light dark:bg-ternary-dark p-3 shadow-sm rounded-xl cursor-pointer"
 					>
-						{mounted && activeTheme === 'dark' ? (
-							<FiMoon className="text-ternary-dark hover:text-gray-400 dark:text-ternary-light dark:hover:text-primary-light text-xl" />
-						) : (
-							<FiSun className="text-gray-200 hover:text-gray-50 text-xl" />
-						)}
+						<ThemeSwitchIcon mounted={mounted} activeTheme={activeTheme} />
 					</div>
 				</div>
 			</div>

--- a/apps/web/components/shared/AppHeader.jsx
+++ b/apps/web/components/shared/AppHeader.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import { motion } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
 import { FiSun, FiMoon, FiX, FiMenu } from 'react-icons/fi';
 import HireMeModal from '../HireMeModal';
 import Button from '../reusable/Button';
@@ -82,52 +82,74 @@ function AppHeader() {
 						<button
 							onClick={toggleMenu}
 							type="button"
-							className="focus:outline-none"
+							className="focus:outline-none text-secondary-dark dark:text-ternary-light text-3xl"
 							aria-label="Hamburger Menu"
+							aria-expanded={showMenu}
 						>
-							<svg
-								xmlns="http://www.w3.org/2000/svg"
-								viewBox="0 0 24 24"
-								className="h-7 w-7 fill-current text-secondary-dark dark:text-ternary-light"
-							>
+							<AnimatePresence initial={false} mode="wait">
 								{showMenu ? (
-									<FiX className="text-3xl" />
+									<motion.span
+										key="close"
+										initial={{ rotate: -90, opacity: 0 }}
+										animate={{ rotate: 0, opacity: 1 }}
+										exit={{ rotate: 90, opacity: 0 }}
+										transition={{ duration: 0.15, ease: 'easeInOut' }}
+										className="inline-flex"
+									>
+										<FiX />
+									</motion.span>
 								) : (
-									<FiMenu className="text-3xl" />
+									<motion.span
+										key="open"
+										initial={{ rotate: 90, opacity: 0 }}
+										animate={{ rotate: 0, opacity: 1 }}
+										exit={{ rotate: -90, opacity: 0 }}
+										transition={{ duration: 0.15, ease: 'easeInOut' }}
+										className="inline-flex"
+									>
+										<FiMenu />
+									</motion.span>
 								)}
-							</svg>
+							</AnimatePresence>
 						</button>
 					</div>
 					</div>
 				</div>
 
 				{/* Header links small screen */}
-				<div
-					className={
-						showMenu
-							? 'block m-0 sm:ml-4 sm:mt-3 md:flex px-5 py-3 sm:p-0 justify-between items-center shadow-lg sm:shadow-none'
-							: 'hidden'
-					}
-				>
-					{navLinks.map((link, i) => (
-						<div
-							key={link.href}
-							className={`block text-left text-lg text-primary-dark dark:text-ternary-light hover:text-secondary-dark dark:hover:text-secondary-light sm:mx-4 mb-2 sm:py-2${i > 0 ? ' border-t-2 pt-3 sm:pt-2 sm:border-t-0 border-primary-light dark:border-secondary-dark' : ''}`}
+				<AnimatePresence initial={false}>
+					{showMenu && (
+						<motion.div
+							key="mobile-menu"
+							initial={{ height: 0, opacity: 0 }}
+							animate={{ height: 'auto', opacity: 1 }}
+							exit={{ height: 0, opacity: 0 }}
+							transition={{ duration: 0.22, ease: 'easeInOut' }}
+							className="overflow-hidden sm:hidden"
 						>
-							<Link href={link.href} aria-label={link.label}>
-								{link.label}
-							</Link>
-						</div>
-					))}
-					<div className="border-t-2 pt-3 sm:pt-0 sm:border-t-0 border-primary-light dark:border-secondary-dark">
-						<Button
-							title="Hire Me"
-							onClick={showHireMeModal}
-							ariaLabel="Hire Me Button"
-							className="sm:hidden block text-left text-md shadow-sm rounded-sm mt-2 w-24"
-						/>
-					</div>
-				</div>
+							<div className="block px-5 py-3 shadow-lg">
+								{navLinks.map((link, i) => (
+									<div
+										key={link.href}
+										className={`block text-left text-lg text-primary-dark dark:text-ternary-light hover:text-secondary-dark dark:hover:text-secondary-light mb-2${i > 0 ? ' border-t-2 pt-3 border-primary-light dark:border-secondary-dark' : ''}`}
+									>
+										<Link href={link.href} aria-label={link.label}>
+											{link.label}
+										</Link>
+									</div>
+								))}
+								<div className="border-t-2 pt-3 border-primary-light dark:border-secondary-dark">
+									<Button
+										title="Hire Me"
+										onClick={showHireMeModal}
+										ariaLabel="Hire Me Button"
+										className="block text-left text-md shadow-sm rounded-sm mt-2 w-24"
+									/>
+								</div>
+							</div>
+						</motion.div>
+					)}
+				</AnimatePresence>
 
 				{/* Header links large screen */}
 				<div className="font-general-medium hidden m-0 sm:ml-4 mt-5 sm:mt-3 sm:flex p-5 sm:p-0 justify-center items-center shadow-lg sm:shadow-none">

--- a/apps/web/components/shared/AppHeader.jsx
+++ b/apps/web/components/shared/AppHeader.jsx
@@ -82,7 +82,7 @@ function AppHeader() {
 						<button
 							onClick={toggleMenu}
 							type="button"
-							className="focus:outline-none text-secondary-dark dark:text-ternary-light text-3xl"
+							className="focus:outline-none text-secondary-dark dark:text-ternary-light text-3xl relative w-8 h-8"
 							aria-label="Hamburger Menu"
 							aria-expanded={showMenu}
 						>
@@ -94,7 +94,7 @@ function AppHeader() {
 										animate={{ rotate: 0, opacity: 1 }}
 										exit={{ rotate: 90, opacity: 0 }}
 										transition={{ duration: 0.15, ease: 'easeInOut' }}
-										className="inline-flex"
+										className="absolute inset-0 flex items-center justify-center"
 									>
 										<FiX />
 									</motion.span>
@@ -105,7 +105,7 @@ function AppHeader() {
 										animate={{ rotate: 0, opacity: 1 }}
 										exit={{ rotate: -90, opacity: 0 }}
 										transition={{ duration: 0.15, ease: 'easeInOut' }}
-										className="inline-flex"
+										className="absolute inset-0 flex items-center justify-center"
 									>
 										<FiMenu />
 									</motion.span>

--- a/apps/web/components/shared/AppHeader.jsx
+++ b/apps/web/components/shared/AppHeader.jsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 import { AnimatePresence, motion } from 'framer-motion';
 import { FiSun, FiMoon, FiX, FiMenu } from 'react-icons/fi';
 import HireMeModal from '../HireMeModal';
@@ -16,9 +17,18 @@ const navLinks = [
 ];
 
 function AppHeader() {
+	const router = useRouter();
 	const [showMenu, setShowMenu] = useState(false);
 	const [showModal, setShowModal] = useState(false);
 	const [activeTheme, setTheme, mounted] = useThemeSwitcher();
+
+	// 라우트 이동이 시작될 때 모바일 메뉴를 닫는다. AnimatePresence exit
+	// 트랜지션이 페이지 전환 애니메이션과 병렬로 재생돼 자연스럽게 접힌다.
+	useEffect(() => {
+		const handleRouteChange = () => setShowMenu(false);
+		router.events.on('routeChangeStart', handleRouteChange);
+		return () => router.events.off('routeChangeStart', handleRouteChange);
+	}, [router.events]);
 
 	function toggleMenu() {
 		if (!showMenu) {

--- a/apps/web/hooks/useScrollToTop.jsx
+++ b/apps/web/hooks/useScrollToTop.jsx
@@ -1,3 +1,4 @@
+import { AnimatePresence, motion } from 'framer-motion';
 import { useState, useEffect, useCallback } from 'react';
 import { FiChevronUp } from 'react-icons/fi';
 
@@ -26,12 +27,22 @@ function useScrollToTop() {
 	}, []);
 
 	return (
-		<>
-			<FiChevronUp
-				className={`scrollToTop fixed right-12 bottom-12 h-10 w-10 p-2 rounded-full cursor-pointer bg-indigo-500 text-white shadow-lg hover:bg-indigo-600 duration-300 ${showScroll ? 'flex' : 'hidden'}`}
-				onClick={backToTop}
-			/>
-		</>
+		<AnimatePresence>
+			{showScroll && (
+				<motion.button
+					type="button"
+					onClick={backToTop}
+					aria-label="Back to top"
+					initial={{ opacity: 0, scale: 0.85 }}
+					animate={{ opacity: 1, scale: 1 }}
+					exit={{ opacity: 0, scale: 0.85 }}
+					transition={{ duration: 0.18, ease: 'easeOut' }}
+					className="scrollToTop fixed right-12 bottom-12 h-10 w-10 p-2 rounded-full cursor-pointer bg-indigo-500 text-white shadow-lg hover:bg-indigo-600 flex items-center justify-center"
+				>
+					<FiChevronUp />
+				</motion.button>
+			)}
+		</AnimatePresence>
 	);
 }
 

--- a/apps/web/pages/_app.jsx
+++ b/apps/web/pages/_app.jsx
@@ -1,18 +1,36 @@
 import '../styles/globals.css';
-import { AnimatePresence } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useRouter } from 'next/router';
 import DefaultLayout from '../components/layout/DefaultLayout';
 import UseScrollToTop from '../hooks/useScrollToTop';
 
 function MyApp({ Component, pageProps }) {
+	const router = useRouter();
+	// 어드민 라우트는 폼 편집 중 라우트 왕복이 잦아 페이지 전환 애니메이션을
+	// 태우지 않는다. 공개 페이지에만 fade + subtle y-slide 트랜지션 적용.
+	const isAdmin = router.pathname.startsWith('/admin');
+
 	return (
-		<AnimatePresence>
-			<div className=" bg-secondary-light dark:bg-primary-dark transition duration-300">
-				<DefaultLayout>
+		<div className="bg-secondary-light dark:bg-primary-dark transition duration-300">
+			<DefaultLayout>
+				{isAdmin ? (
 					<Component {...pageProps} />
-				</DefaultLayout>
-				<UseScrollToTop />
-			</div>
-		</AnimatePresence>
+				) : (
+					<AnimatePresence mode="wait" initial={false}>
+						<motion.div
+							key={router.asPath}
+							initial={{ opacity: 0, y: 8 }}
+							animate={{ opacity: 1, y: 0 }}
+							exit={{ opacity: 0, y: -8 }}
+							transition={{ duration: 0.25, ease: 'easeOut' }}
+						>
+							<Component {...pageProps} />
+						</motion.div>
+					</AnimatePresence>
+				)}
+			</DefaultLayout>
+			<UseScrollToTop />
+		</div>
 	);
 }
 


### PR DESCRIPTION
## 요약

- 이슈 #47 의 주 작업(모바일 메뉴 / 공개 페이지 전환) 과 후속 보조 인터랙션 네 건(#48 #49 #50 #51) 을 한 브랜치에 모았습니다.
- 기존에 `framer-motion` 이 설치만 돼 있고 거의 활용되지 않던 상태에서, 실제 사용자가 체감하는 지점 위주로 전환 · 등장 애니메이션을 붙였습니다.

## 변경 내용

메뉴 / 헤더
- `feat(web): 모바일 메뉴 열림·닫힘 애니메이션` — `AnimatePresence` + `motion.div` 로 height 0↔auto + opacity (0.22s) 펼침/접힘 전환. 햄버거 ↔ X 아이콘은 rotate + fade 크로스 전환. 중첩된 outer `<svg>` 제거.
- `fix(web): 햄버거/닫기 아이콘 전환 중 버튼 폭 변화로 테마 토글이 밀리는 문제` — 아이콘 span 을 `absolute inset-0` 로 쌓고 버튼을 고정 크기 `w-8 h-8` 로 고정.
- `feat(web): 모바일 메뉴 상태에서 라우트 이동 시 자동으로 메뉴 닫기` — `router.events.on('routeChangeStart')` 구독으로 페이지 이동 시 메뉴 exit 트랜지션과 페이지 전환이 병렬 재생되도록.
- `feat(web): 다크/라이트 테마 토글 아이콘 전환 애니메이션` — 해/달 아이콘에 rotate + fade 크로스 전환. `ThemeSwitchIcon` 내부 컴포넌트로 뽑아 모바일/데스크탑 공용.

페이지 전환
- `feat(web): 공개 페이지 라우트 전환 애니메이션` — `pages/_app.jsx` 에 `AnimatePresence mode=wait initial=false` + `motion.div key=asPath` 로 fade + y-slide (0.25s). `/admin/*` 은 제외.

보조 인터랙션 (#48~#51)
- `feat(web): HireMe 모달 진입·퇴장 애니메이션 (#48)` — backdrop fade 0.2s + 본문 scale 0.95↔1 0.22s, AnimatePresence 로 exit 연결.
- `feat(web): 프로젝트 카드 초기 렌더 스태거 애니메이션 (#49)` — `ProjectsGrid` 내 `staggerChildren` + `ProjectSingle` hidden/visible variants 로 fade-up. 첫 렌더에서 `_app.jsx` 의 `initial=false` 가 PresenceContext 로 내려와 차단하던 문제를 내부 `AnimatePresence` 로 우회. 값은 최종적으로 `delayChildren 0.15 / staggerChildren 0.15 / duration 0.5s` 로 튜닝.
- `feat(web): 스크롤-투-탑 버튼 페이드+스케일 등장 (#50)` — `hidden`/`flex` 클래스 토글 대신 `AnimatePresence` + `motion.button` 으로 opacity + scale 전환 (0.18s). 정식 `<button>` 으로 바꿔 `aria-label` 도 추가.
- `feat(web): 프로젝트 카드 hover lift 애니메이션 (#51)` — 내부 카드에 `whileHover { y: -4 }` (0.2s easeOut). 터치 기기 영향 없음.

## 변경 이유

- 기존 프론트는 페이지 전환 · 토글 변경이 모두 즉시 컷으로 발생해 백엔드 포트폴리오 치고도 정적인 느낌이 강했습니다. `framer-motion` 은 이미 의존성에 있고 몇몇 컴포넌트에 `motion.div` 가 남아 있었지만 `initial={false}` 등으로 사실상 비활성 상태였습니다.
- 목표는 "굵직한 두 건(메뉴 / 페이지 전환)" + "눈에 띄는 보조 인터랙션 네 건" 을 최소 코드 변경으로 연결해, 나머지 정보(프로젝트 카드 데이터, 어드민 폼 흐름 등) 에는 영향 없이 감상감만 올리는 것이었습니다.
- 어드민 (`/admin/*`) 은 폼 편집 중 깜빡임이 거슬릴 수 있어 페이지 전환 애니메이션 대상에서 제외했습니다.

## 영향 범위

- [x] `apps/web`
- [ ] `apps/api`
- [ ] `packages`
- [ ] `repo`

## 스크린샷 / 데모

- 로컬 docker compose 로 배포해 모바일·데스크탑 브라우저에서 직접 동작 확인 (텔레그램 리뷰 루프에서 스크린샷 공유).

## 테스트 / 확인

- [x] `docker compose build web` + `up -d web` 으로 재배포
- [x] `/` `/projects` `/about` `/contact` 와 `/admin/*` 이동, 햄버거 메뉴 열고 닫기, 테마 토글, HireMe 모달, 스크롤-투-탑, 카드 hover 모두 수동 확인
- [ ] 유닛 테스트는 별도 추가 없음 (전부 스타일/전환 변경)

## 리뷰 포인트

- `ProjectsGrid` 에 자체 `<AnimatePresence>` 를 감싸서 `_app.jsx` 의 `initial=false` 가 `PresenceContext` 로 내려와 첫 렌더 스태거를 차단하는 동작을 우회했습니다. 관련 디버깅 과정은 `0230481` → `4053afc` → `1e2acb2` 세 커밋에 남아 있습니다.
- `_app.jsx` 에서 `/admin/*` 을 분기해 어드민은 전환 없이 렌더합니다. 필요하다면 범위 확대/축소 가능.
- `feature/ui-animations` 에 쌓인 커밋 수가 많은데, 흐름이 자체적으로 완결돼 squash 보다 merge 로 두는 게 히스토리 읽기 좋다고 판단했습니다. 필요 시 squash 로 조정 가능.

## 참고 사항

- `#47` 본문에 언급한 후속 (B) 안(프로젝트 썸네일 shared-element) 은 이번 PR 에 포함하지 않았습니다. 필요 시 별건 이슈로.
- `framer-motion` 은 이미 의존성에 있어 추가 설치 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)