### PR TITLE
[feat] Contact 페이지 연락처 정보 DB 관리화 + 한글화 (#53)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,8 +20,11 @@
     "migration:generate": "npm run typeorm -- migration:generate -d src/database/data-source.ts",
     "migration:create": "npm run typeorm -- migration:create",
     "migration:run": "npm run typeorm -- migration:run -d src/database/data-source.ts",
+    "migration:run:prod": "node ../../node_modules/typeorm/cli.js migration:run -d dist/database/data-source.js",
     "migration:revert": "npm run typeorm -- migration:revert -d src/database/data-source.ts",
-    "migration:show": "npm run typeorm -- migration:show -d src/database/data-source.ts"
+    "migration:revert:prod": "node ../../node_modules/typeorm/cli.js migration:revert -d dist/database/data-source.js",
+    "migration:show": "npm run typeorm -- migration:show -d src/database/data-source.ts",
+    "migration:show:prod": "node ../../node_modules/typeorm/cli.js migration:show -d dist/database/data-source.js"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/apps/api/src/database/migrations/1777003970857-AddAboutContactFields.ts
+++ b/apps/api/src/database/migrations/1777003970857-AddAboutContactFields.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAboutContactFields1777003970857 implements MigrationInterface {
+  name = 'AddAboutContactFields1777003970857';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`ABOUT_PROFILE\` ADD \`address\` varchar(255) NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`ABOUT_PROFILE\` ADD \`email\` varchar(255) NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`ABOUT_PROFILE\` ADD \`phone\` varchar(50) NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`ABOUT_PROFILE\` DROP COLUMN \`phone\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`ABOUT_PROFILE\` DROP COLUMN \`email\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`ABOUT_PROFILE\` DROP COLUMN \`address\``,
+    );
+  }
+}

--- a/apps/api/src/modules/about/about.controller.spec.ts
+++ b/apps/api/src/modules/about/about.controller.spec.ts
@@ -29,6 +29,9 @@ describe('AboutController', () => {
       tagline: 'Backend Developer',
       profileImage: '/images/profile.jpeg',
       bio: ['첫 단락', '두 단락'],
+      address: null,
+      email: null,
+      phone: null,
     };
     service.get.mockResolvedValue(data);
 

--- a/apps/api/src/modules/about/about.service.spec.ts
+++ b/apps/api/src/modules/about/about.service.spec.ts
@@ -10,6 +10,9 @@ const baseProfile = (overrides: Partial<AboutProfile> = {}): AboutProfile =>
     name: 'Lagoon',
     tagline: 'Backend Developer',
     profileImage: '/images/profile.jpeg',
+    address: null,
+    email: null,
+    phone: null,
     createdAt: new Date('2026-01-01T00:00:00.000Z'),
     bios: [
       {
@@ -66,6 +69,9 @@ describe('AboutService', () => {
       tagline: 'Backend Developer',
       profileImage: '/images/profile.jpeg',
       bio: ['첫 단락', '두 번째로 보여줄 단락'],
+      address: null,
+      email: null,
+      phone: null,
     });
   });
 

--- a/apps/api/src/modules/about/admin-about.service.spec.ts
+++ b/apps/api/src/modules/about/admin-about.service.spec.ts
@@ -101,6 +101,56 @@ describe('AdminAboutService', () => {
     expect(result.tagline).toBeNull();
   });
 
+  it('upsert: address/email/phone 값과 null 모두 전달된다', async () => {
+    profileRepo.findOne.mockResolvedValue({
+      id: 1,
+      name: 'Lagoon',
+      tagline: null,
+      profileImage: '/p.jpg',
+      address: 'Seoul',
+      email: 'me@example.com',
+      phone: '+82 10-1234-5678',
+      bios: [],
+    } as never);
+
+    const payload: UpsertAboutDto = {
+      ...dto,
+      bio: [],
+      address: 'Seoul',
+      email: 'me@example.com',
+      phone: '+82 10-1234-5678',
+    };
+    const result = await service.upsert(payload);
+
+    const savedEntity = txManager.save.mock.calls[0][1] as AboutProfile;
+    expect(savedEntity.address).toBe('Seoul');
+    expect(savedEntity.email).toBe('me@example.com');
+    expect(savedEntity.phone).toBe('+82 10-1234-5678');
+    expect(result.address).toBe('Seoul');
+    expect(result.email).toBe('me@example.com');
+    expect(result.phone).toBe('+82 10-1234-5678');
+  });
+
+  it('upsert: address/email/phone 생략 시 null 로 저장', async () => {
+    profileRepo.findOne.mockResolvedValue({
+      id: 1,
+      name: 'Lagoon',
+      tagline: null,
+      profileImage: '/p.jpg',
+      address: null,
+      email: null,
+      phone: null,
+      bios: [],
+    } as never);
+
+    await service.upsert({ ...dto, bio: [] });
+
+    const savedEntity = txManager.save.mock.calls[0][1] as AboutProfile;
+    expect(savedEntity.address).toBeNull();
+    expect(savedEntity.email).toBeNull();
+    expect(savedEntity.phone).toBeNull();
+  });
+
   it('upsert: bio 는 입력 순서대로 sort_order 0..N-1 부여', async () => {
     profileRepo.findOne.mockResolvedValue({
       id: 1,

--- a/apps/api/src/modules/about/admin-about.service.ts
+++ b/apps/api/src/modules/about/admin-about.service.ts
@@ -38,6 +38,9 @@ export class AdminAboutService {
       profile.name = dto.name;
       profile.tagline = dto.tagline ?? null;
       profile.profileImage = dto.profileImage;
+      profile.address = dto.address ?? null;
+      profile.email = dto.email ?? null;
+      profile.phone = dto.phone ?? null;
       profile.bios = dto.bio.map((paragraph, idx) => {
         const bio = new AboutBio();
         bio.paragraph = paragraph;

--- a/apps/api/src/modules/about/dto/about-response.dto.ts
+++ b/apps/api/src/modules/about/dto/about-response.dto.ts
@@ -20,4 +20,13 @@ export class AboutResponseDto {
     description: 'sort_order 오름차순으로 정렬된 소개 단락들. 마크다운 허용.',
   })
   bio!: string[];
+
+  @ApiProperty({ example: 'Seoul, South Korea', nullable: true, required: false })
+  address!: string | null;
+
+  @ApiProperty({ example: 'me@example.com', nullable: true, required: false })
+  email!: string | null;
+
+  @ApiProperty({ example: '+82 10-1234-5678', nullable: true, required: false })
+  phone!: string | null;
 }

--- a/apps/api/src/modules/about/dto/upsert-about.dto.spec.ts
+++ b/apps/api/src/modules/about/dto/upsert-about.dto.spec.ts
@@ -57,4 +57,37 @@ describe('UpsertAboutDto', () => {
       'isNotEmpty',
     );
   });
+
+  it('address 는 선택 필드로 공백-only 는 null 로 정규화', async () => {
+    const dto = build({ address: '   ' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+    expect(dto.address).toBeNull();
+  });
+
+  it('email 은 형식 검증이 붙고 공백-only 는 null 로 정규화', async () => {
+    const blank = build({ email: '   ' });
+    expect(await validate(blank)).toHaveLength(0);
+    expect(blank.email).toBeNull();
+
+    const invalid = build({ email: 'not-an-email' });
+    const errors = await validate(invalid);
+    expect(errors.find((e) => e.property === 'email')?.constraints).toHaveProperty(
+      'isEmail',
+    );
+
+    const ok = build({ email: '  me@example.com  ' });
+    expect(await validate(ok)).toHaveLength(0);
+    expect(ok.email).toBe('me@example.com');
+  });
+
+  it('phone 은 형식 검증 없이 trim 만 적용, 공백-only 는 null', async () => {
+    const blank = build({ phone: '   ' });
+    expect(await validate(blank)).toHaveLength(0);
+    expect(blank.phone).toBeNull();
+
+    const ok = build({ phone: ' +82 10-1234-5678 ' });
+    expect(await validate(ok)).toHaveLength(0);
+    expect(ok.phone).toBe('+82 10-1234-5678');
+  });
 });

--- a/apps/api/src/modules/about/dto/upsert-about.dto.ts
+++ b/apps/api/src/modules/about/dto/upsert-about.dto.ts
@@ -3,6 +3,7 @@ import { Transform } from 'class-transformer';
 import {
   ArrayMaxSize,
   IsArray,
+  IsEmail,
   IsNotEmpty,
   IsOptional,
   IsString,
@@ -15,6 +16,13 @@ const trimIfString = (value: unknown): unknown =>
 const trimArray = (value: unknown): unknown =>
   Array.isArray(value) ? value.map(trimIfString) : value;
 
+// 빈 문자열·공백-only 는 null 로 정규화 (선택 필드 공통 규칙).
+const trimToNull = (value: unknown): unknown => {
+  if (typeof value !== 'string') return value;
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+};
+
 export class UpsertAboutDto {
   @ApiProperty({ maxLength: 100 })
   @Transform(({ value }) => trimIfString(value))
@@ -24,12 +32,7 @@ export class UpsertAboutDto {
   name!: string;
 
   @ApiProperty({ maxLength: 255, nullable: true, required: false })
-  @Transform(({ value }) => {
-    // 빈 문자열/공백-only 는 명시적으로 null 로 정규화 (tagline 은 null 허용)
-    if (typeof value !== 'string') return value;
-    const trimmed = value.trim();
-    return trimmed.length === 0 ? null : trimmed;
-  })
+  @Transform(({ value }) => trimToNull(value))
   @IsOptional()
   @IsString()
   @MaxLength(255)
@@ -49,4 +52,25 @@ export class UpsertAboutDto {
   @IsString({ each: true })
   @IsNotEmpty({ each: true })
   bio!: string[];
+
+  @ApiProperty({ maxLength: 255, nullable: true, required: false })
+  @Transform(({ value }) => trimToNull(value))
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  address?: string | null;
+
+  @ApiProperty({ maxLength: 255, nullable: true, required: false })
+  @Transform(({ value }) => trimToNull(value))
+  @IsOptional()
+  @IsEmail()
+  @MaxLength(255)
+  email?: string | null;
+
+  @ApiProperty({ maxLength: 50, nullable: true, required: false })
+  @Transform(({ value }) => trimToNull(value))
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  phone?: string | null;
 }

--- a/apps/api/src/modules/about/entities/about-profile.entity.ts
+++ b/apps/api/src/modules/about/entities/about-profile.entity.ts
@@ -25,6 +25,15 @@ export class AboutProfile {
   @Column({ name: 'profile_image', length: 500 })
   profileImage!: string;
 
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  address!: string | null;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  email!: string | null;
+
+  @Column({ type: 'varchar', length: 50, nullable: true })
+  phone!: string | null;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;
 

--- a/apps/api/src/modules/about/mappers/about.mapper.spec.ts
+++ b/apps/api/src/modules/about/mappers/about.mapper.spec.ts
@@ -8,6 +8,9 @@ const profile = (overrides: Partial<AboutProfile> = {}): AboutProfile =>
     name: 'Lagoon',
     tagline: 'Backend Developer',
     profileImage: '/images/profile.jpeg',
+    address: null,
+    email: null,
+    phone: null,
     createdAt: new Date('2026-01-01T00:00:00.000Z'),
     bios: [],
     ...overrides,
@@ -40,5 +43,23 @@ describe('toAboutResponseDto', () => {
     expect(dto.name).toBe('Foo');
     expect(dto.tagline).toBeNull();
     expect(dto.profileImage).toBe('/p.jpg');
+  });
+
+  it('address / email / phone 도 그대로 복사, 값이 없으면 null', () => {
+    const filled = toAboutResponseDto(
+      profile({
+        address: 'Seoul',
+        email: 'me@example.com',
+        phone: '+82 10-1234-5678',
+      }),
+    );
+    expect(filled.address).toBe('Seoul');
+    expect(filled.email).toBe('me@example.com');
+    expect(filled.phone).toBe('+82 10-1234-5678');
+
+    const blank = toAboutResponseDto(profile());
+    expect(blank.address).toBeNull();
+    expect(blank.email).toBeNull();
+    expect(blank.phone).toBeNull();
   });
 });

--- a/apps/api/src/modules/about/mappers/about.mapper.ts
+++ b/apps/api/src/modules/about/mappers/about.mapper.ts
@@ -10,5 +10,8 @@ export function toAboutResponseDto(profile: AboutProfile): AboutResponseDto {
     tagline: profile.tagline,
     profileImage: profile.profileImage,
     bio: sortedBios.map((b) => b.paragraph),
+    address: profile.address ?? null,
+    email: profile.email ?? null,
+    phone: profile.phone ?? null,
   };
 }

--- a/apps/web/components/contact/ContactDetails.jsx
+++ b/apps/web/components/contact/ContactDetails.jsx
@@ -1,42 +1,56 @@
 import { FiPhone, FiMapPin, FiMail } from 'react-icons/fi';
 
-const contacts = [
-	{
-		id: 1,
-		name: 'Your Address, Your City, Your Country',
-		icon: <FiMapPin />,
-	},
-	{
-		id: 2,
-		name: 'email@domain.com',
-		icon: <FiMail />,
-	},
-	{
-		id: 3,
-		name: '555 8888 888',
-		icon: <FiPhone />,
-	},
-];
+// address / email / phone 은 About 싱글톤에서 관리되며 값이 없는 항목은 렌더하지 않는다.
+function ContactDetails({ address, email, phone }) {
+	const entries = [
+		address && { key: 'address', icon: <FiMapPin />, label: address, href: null },
+		email && {
+			key: 'email',
+			icon: <FiMail />,
+			label: email,
+			href: `mailto:${email}`,
+		},
+		phone && {
+			key: 'phone',
+			icon: <FiPhone />,
+			label: phone,
+			href: `tel:${phone.replace(/\s+/g, '')}`,
+		},
+	].filter(Boolean);
 
-function ContactDetails() {
 	return (
 		<div className="w-full lg:w-1/2">
 			<div className="text-left max-w-xl px-6">
 				<h2 className="font-general-medium text-2xl text-primary-dark dark:text-primary-light mt-12 mb-8">
 					Contact details
 				</h2>
-				<ul>
-					{contacts.map((contact) => (
-						<li className="flex " key={contact.id}>
-							<i className="text-2xl text-neutral-500 dark:text-neutral-400 mr-4 mt-1">
-								{contact.icon}
-							</i>
-							<span className="text-lg mb-4 text-ternary-dark dark:text-ternary-light">
-								{contact.name}
-							</span>
-						</li>
-					))}
-				</ul>
+				{entries.length === 0 ? (
+					<p className="font-general-regular text-ternary-dark dark:text-ternary-light">
+						연락처 정보가 아직 등록되지 않았습니다.
+					</p>
+				) : (
+					<ul>
+						{entries.map((entry) => (
+							<li className="flex" key={entry.key}>
+								<i className="text-2xl text-neutral-500 dark:text-neutral-400 mr-4 mt-1">
+									{entry.icon}
+								</i>
+								{entry.href ? (
+									<a
+										href={entry.href}
+										className="text-lg mb-4 text-ternary-dark dark:text-ternary-light hover:text-indigo-500 dark:hover:text-indigo-400 break-all"
+									>
+										{entry.label}
+									</a>
+								) : (
+									<span className="text-lg mb-4 text-ternary-dark dark:text-ternary-light break-words">
+										{entry.label}
+									</span>
+								)}
+							</li>
+						))}
+					</ul>
+				)}
 			</div>
 		</div>
 	);

--- a/apps/web/components/contact/ContactForm.jsx
+++ b/apps/web/components/contact/ContactForm.jsx
@@ -37,13 +37,13 @@ function ContactForm() {
 			}
 			setStatus({
 				state: 'success',
-				message: 'Your message has been sent successfully.',
+				message: '메시지가 전송되었습니다.',
 			});
 			setForm({ name: '', email: '', subject: '', message: '' });
 		} catch (err) {
 			setStatus({
 				state: 'error',
-				message: err.message || 'Failed to send message.',
+				message: err.message || '메시지 전송에 실패했습니다.',
 			});
 		}
 	};
@@ -60,35 +60,35 @@ function ContactForm() {
 					</p>
 
 					<FormInput
-						inputLabel="Full Name"
+						inputLabel="이름"
 						labelFor="name"
 						inputType="text"
 						inputId="name"
 						inputName="name"
-						placeholderText="Your Name"
-						ariaLabelName="Name"
+						placeholderText="홍길동"
+						ariaLabelName="이름"
 						value={form.name}
 						onChange={handleChange}
 					/>
 					<FormInput
-						inputLabel="Email"
+						inputLabel="이메일"
 						labelFor="email"
 						inputType="email"
 						inputId="email"
 						inputName="email"
-						placeholderText="Your email"
-						ariaLabelName="Email"
+						placeholderText="you@example.com"
+						ariaLabelName="이메일"
 						value={form.email}
 						onChange={handleChange}
 					/>
 					<FormInput
-						inputLabel="Subject"
+						inputLabel="제목"
 						labelFor="subject"
 						inputType="text"
 						inputId="subject"
 						inputName="subject"
-						placeholderText="Subject"
-						ariaLabelName="Subject"
+						placeholderText="문의 제목"
+						ariaLabelName="제목"
 						value={form.subject}
 						onChange={handleChange}
 					/>
@@ -98,7 +98,7 @@ function ContactForm() {
 							className="block text-lg text-primary-dark dark:text-primary-light mb-1"
 							htmlFor="message"
 						>
-							Message
+							문의 내용
 						</label>
 						<textarea
 							className="w-full px-5 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-ternary-dark rounded-md shadow-sm text-md"
@@ -106,7 +106,7 @@ function ContactForm() {
 							name="message"
 							cols="14"
 							rows="6"
-							aria-label="Message"
+							aria-label="문의 내용"
 							value={form.message}
 							onChange={handleChange}
 							required
@@ -115,10 +115,10 @@ function ContactForm() {
 
 					<div className="mt-6">
 						<Button
-							title={status.state === 'loading' ? 'Sending...' : 'Send Message'}
+							title={status.state === 'loading' ? '보내는 중…' : '보내기'}
 							type="submit"
 							size="lg"
-							ariaLabel="Send Message"
+							ariaLabel="보내기"
 							disabled={status.state === 'loading'}
 							className="tracking-wider rounded-lg"
 						/>
@@ -146,10 +146,10 @@ function ContactForm() {
 							</svg>
 							<div className="font-general-medium">
 								<p className="text-green-800 dark:text-green-200 text-base">
-									Your message has been sent successfully
+									메시지가 전송되었습니다.
 								</p>
 								<p className="text-green-700 dark:text-green-300/80 text-sm mt-0.5">
-									We&apos;ll get back to you shortly. Thank you!
+									확인 후 빠르게 회신드리겠습니다. 감사합니다.
 								</p>
 							</div>
 						</div>
@@ -176,7 +176,7 @@ function ContactForm() {
 							</svg>
 							<div className="font-general-medium">
 								<p className="text-red-800 dark:text-red-200 text-base">
-									Failed to send
+									전송에 실패했습니다.
 								</p>
 								<p className="text-red-700 dark:text-red-300/80 text-sm mt-0.5">
 									{status.message}

--- a/apps/web/pages/admin/about.jsx
+++ b/apps/web/pages/admin/about.jsx
@@ -18,6 +18,9 @@ function toFormState(about) {
 			_key: `bio-${i}-${Math.random()}`,
 			paragraph,
 		})),
+		address: about?.address ?? '',
+		email: about?.email ?? '',
+		phone: about?.phone ?? '',
 	};
 }
 
@@ -46,6 +49,9 @@ function AdminAboutEditor({ initialAbout }) {
 				bio: form.bio
 					.map((b) => b.paragraph.trim())
 					.filter((p) => p.length > 0),
+				address: form.address.trim() || null,
+				email: form.email.trim() || null,
+				phone: form.phone.trim() || null,
 			};
 			const saved = await fetchAdmin('/api/admin/about', {
 				method: 'PUT',
@@ -106,6 +112,60 @@ function AdminAboutEditor({ initialAbout }) {
 						onChange={(url) => set('profileImage', url)}
 						previewAlt={form.name ? `${form.name} profile` : 'Profile preview'}
 						preset="profile"
+					/>
+				</AdminFormSection>
+
+				<AdminFormSection
+					title="연락처"
+					description="공개 /contact 페이지 하단 Contact details 에 노출됩니다. 각 항목은 선택이며 비워두면 해당 줄이 숨겨집니다."
+				>
+					<label
+						className="block text-lg text-primary-dark dark:text-primary-light mb-1 font-general-regular"
+						htmlFor="about-address"
+					>
+						주소
+					</label>
+					<input
+						id="about-address"
+						name="address"
+						type="text"
+						placeholder="Seoul, South Korea"
+						aria-label="Address"
+						className="w-full px-5 py-2 mb-4 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-ternary-dark rounded-md shadow-sm text-md font-general-regular"
+						value={form.address}
+						onChange={(e) => set('address', e.target.value)}
+					/>
+					<label
+						className="block text-lg text-primary-dark dark:text-primary-light mb-1 font-general-regular"
+						htmlFor="about-email"
+					>
+						이메일
+					</label>
+					<input
+						id="about-email"
+						name="email"
+						type="email"
+						placeholder="me@example.com"
+						aria-label="Email"
+						className="w-full px-5 py-2 mb-4 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-ternary-dark rounded-md shadow-sm text-md font-general-regular"
+						value={form.email}
+						onChange={(e) => set('email', e.target.value)}
+					/>
+					<label
+						className="block text-lg text-primary-dark dark:text-primary-light mb-1 font-general-regular"
+						htmlFor="about-phone"
+					>
+						전화번호
+					</label>
+					<input
+						id="about-phone"
+						name="phone"
+						type="tel"
+						placeholder="+82 10-1234-5678"
+						aria-label="Phone"
+						className="w-full px-5 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-ternary-dark rounded-md shadow-sm text-md font-general-regular"
+						value={form.phone}
+						onChange={(e) => set('phone', e.target.value)}
 					/>
 				</AdminFormSection>
 

--- a/apps/web/pages/admin/about.jsx
+++ b/apps/web/pages/admin/about.jsx
@@ -160,7 +160,7 @@ function AdminAboutEditor({ initialAbout }) {
 					<input
 						id="about-phone"
 						name="phone"
-						type="tel"
+						type="text"
 						placeholder="+82 10-1234-5678"
 						aria-label="Phone"
 						className="w-full px-5 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-ternary-dark rounded-md shadow-sm text-md font-general-regular"

--- a/apps/web/pages/contact.jsx
+++ b/apps/web/pages/contact.jsx
@@ -3,7 +3,12 @@ import ContactDetails from '../components/contact/ContactDetails';
 import ContactForm from '../components/contact/ContactForm';
 import PagesMetaHead from '../components/PagesMetaHead';
 
-function Contact() {
+const API_BASE_URL =
+	process.env.API_INTERNAL_URL || 'http://localhost:7341';
+
+const EMPTY_CONTACT = { address: null, email: null, phone: null };
+
+function Contact({ contact }) {
 	return (
 		<div>
 			<PagesMetaHead title="Contact" />
@@ -20,10 +25,41 @@ function Contact() {
 			>
 				<ContactForm />
 
-				<ContactDetails />
+				<ContactDetails
+					address={contact.address}
+					email={contact.email}
+					phone={contact.phone}
+				/>
 			</motion.div>
 		</div>
 	);
+}
+
+export async function getServerSideProps() {
+	try {
+		const res = await fetch(`${API_BASE_URL}/api/about`);
+		if (res.status === 404) {
+			// About 프로필이 세팅 전인 합법적 상태 — 연락처 섹션을 비워서 렌더
+			return { props: { contact: EMPTY_CONTACT } };
+		}
+		if (!res.ok) {
+			throw new Error(`[contact] About API returned ${res.status}`);
+		}
+		const body = await res.json();
+		const data = body?.data;
+		return {
+			props: {
+				contact: {
+					address: data?.address ?? null,
+					email: data?.email ?? null,
+					phone: data?.phone ?? null,
+				},
+			},
+		};
+	} catch (err) {
+		console.error('[contact] fetch failed', err);
+		throw err;
+	}
 }
 
 export default Contact;


### PR DESCRIPTION
## 요약

- 이슈 #53 (Contact 페이지의 주소·이메일·전화 하드코딩 제거, About 싱글톤으로 통합) 해결.
- 추가로 ContactForm 의 라벨/플레이스홀더/버튼/상태 메시지를 한글화.

Closes #53.

## 변경 내용

api
- `feat(api): AboutProfile 에 연락처 필드(address/email/phone) 추가` — 모두 nullable. 마이그레이션 `AddAboutContactFields1777003970857` 동반.
- `feat(api): About API 에 address/email/phone 필드 연결` — `UpsertAboutDto` 에 trim/null 정규화 + email `@IsEmail` 검증, `AboutResponseDto` / `toAboutResponseDto` / `AdminAboutService.upsert` 에 세 필드 반영. 유닛 테스트 보강 및 기존 spec 의 응답 shape 업데이트.
- `chore(api): migration 프로덕션 컨테이너 실행용 prod 엔트리 스크립트 추가` — `migration:run:prod` / `revert:prod` / `show:prod` 추가. 기존 ts-node 기반 `migration:run` 은 dev 전용. cleanup:uploads:prod 와 동일 패턴.

web
- `feat(web): /contact 연락처 섹션을 About API 기반으로 전환` — `pages/contact.jsx` 에 `getServerSideProps` 추가, About 정책과 동일하게 404 graceful / 5xx throw. `ContactDetails.jsx` 는 props (address/email/phone) 로 받아 렌더, mailto:/tel: 링크 자동 적용, 전부 비면 안내 문구.
- `feat(web): 어드민 About 폼에 연락처 섹션 추가` — 기존 '프로필' / 'Bio 단락' 사이에 '연락처' 섹션. AdminFormSection 재사용.
- `fix(web): 어드민 전화번호 입력을 일반 텍스트로 바꿔 하이픈 입력 허용` — type=tel 모바일 키패드 제약 해소.
- `feat(web): Contact Form 한글화` — 라벨(이름/이메일/제목/문의 내용)·플레이스홀더(홍길동/you@example.com/문의 제목)·버튼(보내기/보내는 중…)·성공·실패 메시지·`aria-label` 까지 한글로. 폼 타이틀 `Contact Form` 만 영문 유지.

## 변경 이유

- About 페이지는 이미 DB 관리로 옮겨졌지만 `/contact` 의 주소/이메일/전화는 여전히 하드코딩 placeholder ('Your Address...' 등) 였습니다. 1인 포트폴리오 규모상 별도 ContactInfo 엔티티 보다 `AboutProfile` 에 함께 두는 편이 단순하고 자연스럽다고 판단해 같은 모듈에서 처리합니다.
- 마이그레이션을 prod 컨테이너 안에서 실행할 수 있도록 별도 스크립트가 필요해 함께 정리했습니다 (`ts-node` 가 prod 이미지에 없음).
- 사이트 톤이 한글이라 ContactForm 만 영문으로 남아 있던 부분도 톤을 맞춥니다. 폼 타이틀은 디자인적인 강조 차원에서 영문 유지.

## 영향 범위

- [x] `apps/web`
- [x] `apps/api`
- [ ] `packages`
- [ ] `repo`

## 스크린샷 / 데모

- 로컬 docker compose 로 배포해 확인. `/admin/about` 에서 연락처 섹션 노출, 저장 후 `/contact` 가 즉시 반영되는 것 확인. 값이 모두 비어 있을 때 "연락처 정보가 아직 등록되지 않았습니다." 안내 노출.

## 테스트 / 확인

- [x] api 유닛 테스트 28건 (`npm test -- --testPathPatterns about`) 통과 — DTO trim/null/email, 매퍼 필드, 서비스 upsert 케이스 추가.
- [x] `migration:run:prod` 로 컨테이너 내부에서 마이그레이션 실행 성공.
- [x] `/api/about`, `/contact`, `/admin/about` 모두 200 + 한글 문자열·신규 필드 SSR 출력 확인.
- [ ] e2e 자동화는 이번 PR 범위 외.

## 리뷰 포인트

- `AboutProfile` 가 정체성 + 연락처 + bio 까지 들고 가는 모양이라 향후 SNS 링크·블로그 URL 등 항목이 더 늘어나면 `Site Settings` 싱글톤 패턴으로 분리하는 게 깔끔합니다. 본 PR 에서는 범위 외로 두고 후속 이슈로 남길 수 있습니다.
- `migration:run:prod` 는 컨테이너 안에서 실행할 때 `.env` 가 이미 주입돼 있어 별도 환경변수 명시 없이 동작합니다 (cleanup:uploads:prod 와 동일).
- ContactForm 의 폼 타이틀 `Contact Form` 만 의도적으로 영문 유지. 추후 통일하고 싶다면 별도 작업.

## 참고 사항

- 이슈 #53 은 본 PR 로 종료.
- 머지 후 dev 누적분을 release-please 로 main 까지 올릴 수 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)