### PR TITLE
[fix] about 페이지 불필요 섹션 숨김 처리

### DIFF
--- a/apps/web/pages/about.jsx
+++ b/apps/web/pages/about.jsx
@@ -14,8 +14,9 @@ const EMPTY_ABOUT = {
 	bio: [],
 };
 
-// 나중에 다시 활용할 수 있게 통계 섹션은 삭제하지 않고 토글로 숨김 처리.
+// 나중에 다시 활용할 수 있게 about 하위 섹션들은 삭제하지 않고 토글로 숨김 처리.
 const SHOW_ABOUT_COUNTER = false;
+const SHOW_ABOUT_CLIENTS = false;
 
 function About({ about }) {
 	return (
@@ -46,14 +47,16 @@ function About({ about }) {
 				</motion.div>
 			)}
 
-			<motion.div
-				initial={false}
-				animate={{ opacity: 1, delay: 1 }}
-				exit={{ opacity: 0 }}
-				className="container mx-auto"
-			>
-				<AboutClients />
-			</motion.div>
+			{SHOW_ABOUT_CLIENTS && (
+				<motion.div
+					initial={false}
+					animate={{ opacity: 1, delay: 1 }}
+					exit={{ opacity: 0 }}
+					className="container mx-auto"
+				>
+					<AboutClients />
+				</motion.div>
+			)}
 		</div>
 	);
 }

--- a/apps/web/pages/about.jsx
+++ b/apps/web/pages/about.jsx
@@ -14,6 +14,9 @@ const EMPTY_ABOUT = {
 	bio: [],
 };
 
+// 나중에 다시 활용할 수 있게 통계 섹션은 삭제하지 않고 토글로 숨김 처리.
+const SHOW_ABOUT_COUNTER = false;
+
 function About({ about }) {
 	return (
 		<div>
@@ -33,14 +36,15 @@ function About({ about }) {
 				/>
 			</motion.div>
 
-			{/** Counter without paddings */}
-			<motion.div
-				initial={false}
-				animate={{ opacity: 1, delay: 1 }}
-				exit={{ opacity: 0 }}
-			>
-				<AboutCounter />
-			</motion.div>
+			{SHOW_ABOUT_COUNTER && (
+				<motion.div
+					initial={false}
+					animate={{ opacity: 1, delay: 1 }}
+					exit={{ opacity: 0 }}
+				>
+					<AboutCounter />
+				</motion.div>
+			)}
 
 			<motion.div
 				initial={false}


### PR DESCRIPTION
## 변경 내용
- /about 페이지의 통계 섹션을 토글로 숨김 처리
- /about 페이지의 브랜드 섹션("Some of the brands I worked with")을 토글로 숨김 처리
- 두 섹션 모두 삭제하지 않고 나중에 다시 활성화할 수 있게 유지

## 변경 파일
- `apps/web/pages/about.jsx`

## 확인 사항
- `npm run lint -w apps/web`
- `npm run build -w apps/web`
- Docker web 컨테이너 재빌드 및 재배포 후 `/about` 확인

## 비고
- `SHOW_ABOUT_COUNTER`, `SHOW_ABOUT_CLIENTS` 값을 `true`로 바꾸면 다시 노출할 수 있습니다.