### PR TITLE
[chore] dev 환경 분리 배포 구축

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,0 +1,27 @@
+name: CD (dev)
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    branches:
+      - dev
+    types:
+      - completed
+
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, portfolio]
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy
+        env:
+          DEPLOY_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: bash scripts/deploy.sh dev

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -15,7 +15,8 @@ concurrency:
 jobs:
   deploy:
     runs-on: [self-hosted, portfolio]
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # push 이벤트(= dev 브랜치 머지)로 발생한 CI 성공만 배포 대상. PR/그 외 트리거로 도는 CI 완료는 무시한다.
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -115,8 +115,32 @@ PR 및 push 시 자동 실행:
 
 ### CD (Self-hosted Runner)
 
-`main` 브랜치에 push 시 CI 통과 후 자동 배포:
+`main` / `dev` 브랜치에 push 시 CI 통과 후 각각 prod / dev 스택으로 자동 배포된다.
 
-1. CI 워크플로우 성공 확인
-2. Self-hosted runner에서 `scripts/deploy.sh` 실행
-3. Docker Compose로 컨테이너 재빌드 및 재시작
+| 환경 | 트리거 브랜치 | 워크플로우 | 작업 디렉터리 | compose project | env-file | 포트(web/api) |
+|------|---------------|------------|---------------|------------------|----------|----------------|
+| prod | `main` | `.github/workflows/cd.yml` | `Portfolio-Project` | `portfolio-project` (`--profile prod`) | `.env` | 7340 / 7341 |
+| dev | `dev` | `.github/workflows/cd-dev.yml` | `Portfolio-Project-dev` | `portfolio-dev` (override: `docker-compose.dev.yml`) | `.env.dev` | 7350 / 7351 |
+
+배포 흐름은 동일하다:
+
+1. CI 워크플로우 성공 확인 (workflow_run)
+2. Self-hosted runner 에서 `scripts/deploy.sh [prod|dev]` 실행
+3. 인자에 따라 작업 디렉터리/브랜치/compose 옵션이 분기되어 컨테이너 재빌드 및 재시작
+
+#### dev 환경 특징
+
+- **prod DB 공유**: dev api 는 `extra_hosts` 로 호스트 게이트웨이를 통해 prod mysql(노출 포트 3307)에 접근한다. dev 에서의 모든 쓰기(어드민 로그인 시도, 콘텐츠 수정, 연락 폼 제출)는 prod 데이터에 그대로 반영된다.
+- **uploads 볼륨 공유**: dev api 는 prod 의 `portfolio-project_uploads` 볼륨을 external 로 마운트하여 동일 파일을 서빙한다.
+- **외부 도메인**: `portfolio-dev.llagoon.dev` (웹) / `portfolio-dev-api.llagoon.dev` (API). 외부 라우팅(리버스 프록시/터널)은 호스트 측에서 별도 설정.
+- **mysql 자동 기동 제외**: `docker-compose.yml` 의 mysql 서비스에 `profiles: ["prod"]` 가 부여되어 dev 스택은 mysql 을 띄우지 않는다. prod 배포 시에도 `--profile prod` 가 명시되어 기존 동작은 유지된다.
+
+#### dev 환경 최초 셋업 (호스트, 1회)
+
+```bash
+git clone <repo-url> /home/lagoon3/.openclaw/workspace/Portfolio-Project-dev
+cd /home/lagoon3/.openclaw/workspace/Portfolio-Project-dev && git checkout dev
+# .env.dev 작성 (prod .env 기반: WEB_PORT=7350, API_PORT=7351, CORS_ORIGIN 에 dev 도메인 2개 포함)
+```
+
+수동 배포: `bash scripts/deploy.sh dev`

--- a/README.md
+++ b/README.md
@@ -40,11 +40,15 @@ npm run api:dev      # API 개발 서버 (localhost:7341)
 
 ### Docker (전체 실행)
 
+mysql 서비스에는 `prod` 프로파일이 부여되어 있으므로 web/api/mysql 을 함께 띄우려면 `--profile prod` 를 명시한다 (미명시 시 mysql 은 기동되지 않음).
+
 ```bash
-docker compose up -d   # web + api + mysql 전체 실행
-docker compose ps      # 컨테이너 상태 확인
-docker compose down    # 전체 종료
+docker compose --profile prod --env-file .env up -d   # web + api + mysql 전체 실행
+docker compose ps                                     # 컨테이너 상태 확인
+docker compose --profile prod down                    # 전체 종료
 ```
+
+> Docker Compose v2.20+ 가 필요하다. `docker-compose.dev.yml` 이 사용하는 `!override` YAML 태그가 구버전에서는 인식되지 않는다.
 
 ## 주요 스크립트
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,22 @@
+services:
+  web:
+    # !override 로 base 의 ports 리스트를 누적하지 않고 완전 교체한다. (compose 의 list merge 기본 동작은 concat)
+    ports: !override
+      - "${WEB_PORT:-7350}:7340"
+
+  api:
+    ports: !override
+      - "${API_PORT:-7351}:7341"
+    # prod mysql 컨테이너에는 dev 네트워크가 join 하지 않는다. 호스트 게이트웨이로 접근해 prod 가 외부로 노출한 3307 포트를 사용한다.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      DB_HOST: host.docker.internal
+      DB_PORT: "3307"
+
+# dev api 가 DB row 에서 참조하는 업로드 파일을 그대로 서빙하도록 prod 의 uploads 볼륨을 그대로 마운트한다.
+# base 의 `uploads:` 익명 볼륨을 external 로 덮어쓴다.
+volumes:
+  uploads:
+    external: true
+    name: portfolio-project_uploads

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,10 +41,15 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
+        # dev 프로파일에서는 mysql 서비스가 비활성화되므로, 의존성 검증을 건너뛰도록 required: false 로 둔다.
+        # prod 프로파일에서는 mysql 이 존재하므로 healthcheck 대기 동작은 그대로 유지된다.
+        required: false
     restart: unless-stopped
 
   mysql:
     image: mysql:8.0
+    # dev 스택은 prod mysql 컨테이너를 공유한다. 기본 프로파일에서 제외하여 dev compose 가 mysql 을 별도로 띄우지 않게 한다.
+    profiles: ["prod"]
     ports:
       - "${DB_PORT:-3307}:3306"
     environment:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,28 +1,55 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PROJECT_DIR="/home/lagoon3/.openclaw/workspace/Portfolio-Project"
+ENV_NAME="${1:-prod}"
+
+case "$ENV_NAME" in
+  prod)
+    PROJECT_DIR="/home/lagoon3/.openclaw/workspace/Portfolio-Project"
+    BRANCH="main"
+    COMPOSE_PROJECT="portfolio-project"
+    COMPOSE_FILES=(-f docker-compose.yml)
+    COMPOSE_PROFILES=(--profile prod)
+    ENV_FILE=".env"
+    ;;
+  dev)
+    PROJECT_DIR="/home/lagoon3/.openclaw/workspace/Portfolio-Project-dev"
+    BRANCH="dev"
+    COMPOSE_PROJECT="portfolio-dev"
+    COMPOSE_FILES=(-f docker-compose.yml -f docker-compose.dev.yml)
+    COMPOSE_PROFILES=()
+    ENV_FILE=".env.dev"
+    ;;
+  *)
+    echo "usage: deploy.sh [prod|dev]" >&2
+    exit 1
+    ;;
+esac
+
 DEPLOY_SHA="${DEPLOY_SHA:-}"
 
+echo "=== Deploying $ENV_NAME (project=$COMPOSE_PROJECT dir=$PROJECT_DIR) ==="
 cd "$PROJECT_DIR"
 
 echo "=== Fetching latest changes ==="
-git fetch origin main
+git fetch origin "$BRANCH"
 
 if [ -n "$DEPLOY_SHA" ]; then
   echo "=== Checking out exact SHA: $DEPLOY_SHA ==="
   git checkout "$DEPLOY_SHA"
 else
-  echo "=== Resetting to origin/main ==="
-  git reset --hard origin/main
+  echo "=== Resetting to origin/$BRANCH ==="
+  git reset --hard "origin/$BRANCH"
 fi
 
+COMPOSE=(docker compose -p "$COMPOSE_PROJECT" "${COMPOSE_FILES[@]}" "${COMPOSE_PROFILES[@]}" --env-file "$ENV_FILE")
+
 echo "=== Building and restarting containers ==="
-docker compose build --no-cache
-docker compose up -d
+"${COMPOSE[@]}" build --no-cache
+"${COMPOSE[@]}" up -d
 
 echo "=== Cleaning up dangling images ==="
 docker image prune -f
 
 echo "=== Deploy complete ==="
-docker compose ps
+"${COMPOSE[@]}" ps


### PR DESCRIPTION
## 요약

- `dev` 브랜치 머지 결과를 사전 검증할 수 있도록, 동일 호스트에 prod 와 격리된 dev 스택을 자동 배포하는 파이프라인을 구성한다.
- 외부 도메인은 `portfolio-dev.llagoon.dev` (웹) / `portfolio-dev-api.llagoon.dev` (API). 외부 라우팅은 호스트 측에서 별도 설정.
- dev 스택은 prod mysql 과 uploads 볼륨을 공유한다. dev 에서의 모든 쓰기가 prod 데이터에 그대로 반영되는 점은 의도된 결정.

Closes #56

## 변경 내용

- `docker-compose.yml`: mysql 서비스에 `profiles: ["prod"]` 부여, api 의 mysql 의존성에 `required: false` 추가.
- `docker-compose.dev.yml` (신규): web/api 포트 7350/7351 로 재매핑(`!override`), api 는 `extra_hosts` 로 호스트 게이트웨이를 통해 prod mysql 3307 에 접근, uploads 볼륨은 `portfolio-project_uploads` external 마운트.
- `scripts/deploy.sh`: 첫 번째 인자(prod|dev) 로 작업 디렉터리/브랜치/compose project/env-file 분기. 모든 docker compose 호출에 `-p`, `--env-file` 일관 적용.
- `.github/workflows/cd-dev.yml` (신규): `workflow_run` 트리거(CI 성공, branches: [dev]), concurrency `deploy-dev`, 동일 self-hosted 러너 라벨 재사용.
- `README.md`: CI/CD 섹션을 prod/dev 두 트랙 비교표로 정리, dev 환경 특징·최초 셋업·수동 배포 명령 추가.

## 변경 이유

- 지금까지 `dev` 브랜치 머지 시 사전 검증할 자동 환경이 없어, prod 머지 전 결합 동작 확인이 수동에 의존하고 있었음.
- 사용자 결정 사항: DB 는 prod 공유(쓰기 반영 수용), 리버스 프록시는 호스트 측에서 별도 설정, 자체 도메인은 `portfolio-dev(.api).llagoon.dev` 사용, 러너 라벨은 기존 재사용 + concurrency 로 prod 와 분리.

## 영향 범위

- [ ] `apps/web`
- [ ] `apps/api`
- [ ] `packages`
- [x] `repo` (compose / 배포 스크립트 / GH Actions / README)

## 스크린샷 / 데모

없음 (인프라/스크립트 변경).

## 테스트 / 확인

- [x] `docker compose --profile prod --env-file .env config` — prod 가 web/api/mysql 3 서비스로 정상 구성됨
- [x] `docker compose -f docker-compose.yml -f docker-compose.dev.yml --env-file .env config` — dev 가 web/api 2 서비스로 정상 구성됨, mysql 미포함
- [x] dev 의 published 포트가 7350/7351 만 매핑됨 (7340/7341 미노출, base 와 누적되지 않음)
- [x] dev api 의 환경변수 `DB_HOST=host.docker.internal`, `DB_PORT=3307` 정상 주입
- [x] `bash -n scripts/deploy.sh` 구문 통과, 잘못된 인자에 usage 출력 후 비정상 종료
- [ ] (머지 후) prod 무영향 확인: `docker compose -p portfolio-project ps`
- [ ] (머지 후) dev 최초 배포 트리거 + 외부 도메인 응답 확인

## 리뷰 포인트

- `docker-compose.yml` 의 `required: false` 추가가 prod 동작에 영향 없는지 (--profile prod 시 mysql 이 선택되므로 healthcheck 대기는 그대로 유지됨).
- `docker-compose.dev.yml` 의 `!override` 디렉티브 사용 — compose 리스트 누적 동작을 회피하기 위한 의도적 선택.
- `scripts/deploy.sh` 의 인자 없는 호출이 기존처럼 prod 로 동작하므로 기존 cd.yml 변경 불필요.

## 참고 사항

- **호스트 측 사전 작업 필요 (PR 머지 전)**:
  1. `/home/lagoon3/.openclaw/workspace/Portfolio-Project-dev` 디렉터리 클론
  2. `.env.dev` 작성 (포트, prod 와 동일 DB/JWT/관리자 값, CORS_ORIGIN 에 dev 도메인 2개 포함)
  3. 외부 도메인 라우팅 설정 (리버스 프록시 또는 터널)
- 본 PR 에서 `.gitignore` 는 손대지 않음 — 기존 `.env.*` 규칙으로 `.env.dev` 자동 제외됨.
- prod `.env` 의 `CORS_ORIGIN` 에는 dev 도메인을 추가하지 않음 (dev → prod API 직접 호출은 의도된 시나리오 아님).
- prod mysql 호스트 노출 포트(3307) 가 닫히면 dev 의 `host.docker.internal` 접근은 동작하지 않게 됨 → 향후 prod 네트워크 external join 방식으로 전환 필요. 후속 작업.
- README 에 적힌 "런타임 자동 마이그레이션" 동작이 실제 코드(`apps/api/src/database/database.module.ts`)와 불일치하는 별개 이슈 발견 — 본 PR 범위 밖, 별도 이슈 분리 권고.