### PR TITLE
[chore] CI/CD 를 GHCR 이미지 빌드·푸시 기반으로 전환

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,4 +24,7 @@ jobs:
       - name: Deploy
         env:
           DEPLOY_SHA: ${{ github.event.workflow_run.head_sha }}
-        run: bash scripts/deploy.sh
+        # CI 가 GHCR 에 푸시한 정확한 SHA 태그(main-<short>)로 배포한다. deploy.sh 는 IMAGE_TAG 미설정 시 main-latest 로 폴백.
+        run: |
+          export IMAGE_TAG="main-${DEPLOY_SHA:0:7}"
+          bash scripts/deploy.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,51 @@ jobs:
 
   docker-build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [web, api]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build web image
-        run: docker build -f apps/web/Dockerfile .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Build api image
-        run: docker build -f apps/api/Dockerfile .
+      # fork PR 에서는 GITHUB_TOKEN 이 read-only 라 push 가 불가하다. push 이벤트일 때만 로그인한다.
+      - name: Log in to GHCR
+        if: ${{ github.event_name == 'push' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/llagoon3/portfolio-${{ matrix.image }}
+          # 불변 SHA 태그(롤백용) + push 시 브랜치 latest 알리아스
+          tags: |
+            type=sha,prefix=${{ github.ref_name }}-,format=short
+            type=raw,value=${{ github.ref_name }}-latest,enable=${{ github.event_name == 'push' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/${{ matrix.image }}/Dockerfile
+          # PR 트리거는 빌드 검증만, push(main/dev) 만 GHCR 푸시
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,scope=${{ matrix.image }},mode=max
+          # Next.js rewrites 가 build 시점에 평가되므로 web 이미지에 baked 된다. prod/dev 모두 동일 값.
+          build-args: |
+            API_INTERNAL_URL=http://api:7341

--- a/README.md
+++ b/README.md
@@ -133,8 +133,16 @@ PR 및 push 시 자동 실행:
 2. Self-hosted runner 에서 `IMAGE_TAG=main-<short-sha>` 로 `scripts/deploy.sh` 실행
 3. `scripts/deploy.sh`:
    - `git fetch/reset` 으로 호스트의 compose 파일·.env 동기화 (호스트는 더 이상 `docker build` 를 수행하지 않음 — compose 정의를 읽기 위한 동기화 목적)
+   - `DEPLOY_SHA` 가 더 이상 `origin/main` 의 tip 이 아니면 배포 중단 (늦게 끝난 이전 커밋 CI 로 stale 이미지 되감기 방지)
    - `docker compose pull` 로 GHCR 에서 해당 SHA 이미지 가져오기
    - `docker compose up -d` 로 새 이미지로 컨테이너 교체
+
+#### 최초 GHCR 전환 시 확인 사항
+
+GHCR 패키지는 **첫 push 시 레포 visibility 와 동일하게 생성**된다. 본 레포는 public 이므로 패키지도 public 으로 자동 생성될 것이 기대된다. 다만 첫 main push 직후 다음을 한 번 확인하여, runner 호스트의 `docker compose pull` 이 무인증으로 동작하는지 보장한다.
+
+- GitHub 저장소 페이지 → **Packages** 탭 → `portfolio-web` / `portfolio-api` visibility 가 `public` 인지 확인
+- private 으로 생성되었다면 패키지 설정에서 visibility 를 `public` 으로 변경하거나, runner 호스트에서 `docker login ghcr.io -u <user> -p <token>` 으로 인증 설정 필요
 
 ### 롤백 절차
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,16 @@ npm run api:dev      # API 개발 서버 (localhost:7341)
 
 ### Docker (전체 실행)
 
+web/api 이미지는 GHCR(`ghcr.io/llagoon3/portfolio-{web,api}`) 에 push 된 이미지를 그대로 pull 해 사용한다. 레포가 public 이므로 `docker login` 은 불필요.
+
 ```bash
-docker compose up -d   # web + api + mysql 전체 실행
+docker compose pull    # GHCR 에서 web/api 이미지 가져오기
+docker compose up -d   # web + api + mysql 전체 실행 (mysql 은 mysql:8.0 그대로)
 docker compose ps      # 컨테이너 상태 확인
 docker compose down    # 전체 종료
 ```
+
+로컬에서 직접 소스 변경분으로 시험하려면 `docker compose up -d --build` 대신 일시적으로 `docker-compose.override.yml` 에 `build:` 블록을 따로 정의하거나, 단발성으로 `docker build -f apps/<web|api>/Dockerfile -t <local-tag> .` 후 compose 의 image 를 override 하면 된다.
 
 ## 주요 스크립트
 
@@ -111,12 +116,33 @@ PR 및 push 시 자동 실행:
 
 - **web-check**: lint + build
 - **api-check**: lint + build + test (Jest)
-- **docker-build**: web/api Docker 이미지 빌드 검증
+- **docker-build**: web/api Docker 이미지 빌드 (matrix). `main`/`dev` push 트리거에서는 빌드 후 **GHCR 로 push** 까지 수행하고, PR 트리거에서는 빌드 검증만 한다.
+
+이미지는 `ghcr.io/llagoon3/portfolio-{web,api}` 에 다음 태그로 push 된다.
+
+| 태그 | 용도 | 예시 |
+|------|------|------|
+| `<branch>-<short-sha>` | 불변. 롤백/특정 배포 재현용 | `main-abc1234`, `dev-def5678` |
+| `<branch>-latest` | 알리아스. 가장 최근 빌드를 가리킴 | `main-latest`, `dev-latest` |
 
 ### CD (Self-hosted Runner)
 
-`main` 브랜치에 push 시 CI 통과 후 자동 배포:
+`main` 브랜치에 push 시 CI 통과 후 자동 배포된다.
 
-1. CI 워크플로우 성공 확인
-2. Self-hosted runner에서 `scripts/deploy.sh` 실행
-3. Docker Compose로 컨테이너 재빌드 및 재시작
+1. CI 워크플로우 성공 확인 (workflow_run)
+2. Self-hosted runner 에서 `IMAGE_TAG=main-<short-sha>` 로 `scripts/deploy.sh` 실행
+3. `scripts/deploy.sh`:
+   - `git fetch/reset` 으로 호스트의 compose 파일·.env 동기화 (호스트는 더 이상 `docker build` 를 수행하지 않음 — compose 정의를 읽기 위한 동기화 목적)
+   - `docker compose pull` 로 GHCR 에서 해당 SHA 이미지 가져오기
+   - `docker compose up -d` 로 새 이미지로 컨테이너 교체
+
+### 롤백 절차
+
+이미지는 GHCR 에 영구 보존되므로 환경변수만 바꿔 즉시 복귀 가능.
+
+```bash
+# self-hosted runner 호스트에서 직접 실행
+IMAGE_TAG=main-<old-short-sha> bash scripts/deploy.sh
+```
+
+복귀 후 정상 확인되면 다음 main push 가 자동으로 `main-latest` 로 다시 끌어올린다.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,6 @@
 services:
   web:
-    build:
-      context: .
-      dockerfile: apps/web/Dockerfile
-      args:
-        API_INTERNAL_URL: "${WEB_API_INTERNAL_URL:-http://api:7341}"
+    image: "ghcr.io/llagoon3/portfolio-web:${WEB_IMAGE_TAG:-main-latest}"
     ports:
       - "${WEB_PORT:-7340}:7340"
     environment:
@@ -16,9 +12,7 @@ services:
     restart: unless-stopped
 
   api:
-    build:
-      context: .
-      dockerfile: apps/api/Dockerfile
+    image: "ghcr.io/llagoon3/portfolio-api:${API_IMAGE_TAG:-main-latest}"
     ports:
       - "${API_PORT:-7341}:7341"
     # admin 쪽 env 는 .env 값이 bcrypt($$)/난수(공백 포함) 등을 포함할 수 있어

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,23 +2,33 @@
 set -euo pipefail
 
 PROJECT_DIR="/home/lagoon3/.openclaw/workspace/Portfolio-Project"
+BRANCH="main"
 DEPLOY_SHA="${DEPLOY_SHA:-}"
 
 cd "$PROJECT_DIR"
 
-echo "=== Fetching latest changes ==="
-git fetch origin main
+# 호스트는 더 이상 docker build 를 수행하지 않는다. 그러나 docker-compose.yml / .env 가
+# 호스트에 있어야 docker compose 가 읽을 수 있으므로, git fetch/reset 으로 동기화는 유지한다.
+echo "=== Syncing compose files & .env from git ==="
+git fetch origin "$BRANCH"
 
 if [ -n "$DEPLOY_SHA" ]; then
   echo "=== Checking out exact SHA: $DEPLOY_SHA ==="
   git checkout "$DEPLOY_SHA"
 else
-  echo "=== Resetting to origin/main ==="
-  git reset --hard origin/main
+  echo "=== Resetting to origin/$BRANCH ==="
+  git reset --hard "origin/$BRANCH"
 fi
 
-echo "=== Building and restarting containers ==="
-docker compose build --no-cache
+# CD 가 IMAGE_TAG 를 명시 전달하면 그 SHA 태그로 배포(롤백/검증), 미전달 시 main-latest 알리아스로 폴백.
+TAG="${IMAGE_TAG:-main-latest}"
+export WEB_IMAGE_TAG="$TAG"
+export API_IMAGE_TAG="$TAG"
+
+echo "=== Pulling images (tag=$TAG) ==="
+docker compose pull
+
+echo "=== Restarting containers ==="
 docker compose up -d
 
 echo "=== Cleaning up dangling images ==="

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -12,6 +12,17 @@ cd "$PROJECT_DIR"
 echo "=== Syncing compose files & .env from git ==="
 git fetch origin "$BRANCH"
 
+# 늦게 끝난 이전 커밋의 CI 가 최신 배포 이후 도착해 stale 이미지로 되감기는 상황 방지.
+# CD 가 전달한 DEPLOY_SHA 가 더 이상 origin/$BRANCH 의 tip 이 아니면 배포 중단.
+# 수동 롤백(DEPLOY_SHA 미설정 + IMAGE_TAG 지정) 경로는 이 가드와 충돌하지 않는다.
+if [ -n "$DEPLOY_SHA" ]; then
+  LATEST_SHA="$(git rev-parse "origin/$BRANCH")"
+  if [ "$DEPLOY_SHA" != "$LATEST_SHA" ]; then
+    echo "=== Skip stale deploy: DEPLOY_SHA=$DEPLOY_SHA origin/$BRANCH=$LATEST_SHA ===" >&2
+    exit 0
+  fi
+fi
+
 if [ -n "$DEPLOY_SHA" ]; then
   echo "=== Checking out exact SHA: $DEPLOY_SHA ==="
   git checkout "$DEPLOY_SHA"


### PR DESCRIPTION
## 요약

- 호스트가 직접 `docker compose build` 하는 구조를 **CI 가 이미지를 GHCR 로 push → 호스트는 pull 만** 하는 구조로 전환한다.
- prod 만 적용. dev 환경 도입은 GHCR 머지 후 후속 PR.
- 이미지: `ghcr.io/llagoon3/portfolio-{web,api}` (레포 public 이라 pull 무인증).
- 태그: `<branch>-<short-sha>` 불변 + `<branch>-latest` 알리아스.

Closes #58

## 변경 내용

- `.github/workflows/ci.yml`: `docker-build` 잡을 matrix(`web`, `api`) 로 확장. `docker/setup-buildx-action`, `docker/login-action` (push 시), `docker/metadata-action` (SHA + latest 태그), `docker/build-push-action@v6` 도입. PR 트리거는 build 만, push 트리거만 GHCR push. `type=gha` 캐시 (scope per image). `API_INTERNAL_URL` build-arg 명시.
- `docker-compose.yml`: web/api `build:` 제거 → `image: ghcr.io/llagoon3/portfolio-{web,api}:${...IMAGE_TAG:-main-latest}` 로 전환. mysql 무변경.
- `scripts/deploy.sh`: `docker compose build --no-cache` 제거, `docker compose pull` 추가. `IMAGE_TAG` 환경변수로 SHA 태그 받아 `WEB_IMAGE_TAG/API_IMAGE_TAG` export. 미설정 시 `main-latest` 폴백. `git fetch/reset` 은 compose/.env 동기화 목적으로 유지.
- `.github/workflows/cd.yml`: deploy 스텝이 `IMAGE_TAG=main-${DEPLOY_SHA:0:7}` 로 export 후 `deploy.sh` 호출.
- `README.md`: Docker 실행 / CI / CD / 롤백 절차 갱신. 이미지 태그 규칙 표 추가.

## 변경 이유

- 호스트가 빌드를 함께 책임지는 기존 구조 위에 dev 환경을 얹으려다 보니 별도 디렉토리 분리·`!override` 같은 우회 설계가 누적되었다 (이전 PR #57 의 검토에서 명확해짐). 근본 원인은 배포 메커니즘 자체.
- GHCR 기반으로 전환하면: 호스트 빌드 부하 0, 롤백이 환경변수 변경 즉시 가능, 향후 dev 환경 추가가 단순 compose override + 이미지 태그 분기로 끝남.

## 영향 범위

- [ ] `apps/web`
- [ ] `apps/api`
- [ ] `packages`
- [x] `repo` (CI/CD workflow, compose, deploy 스크립트, README)

## 스크린샷 / 데모

없음 (인프라/스크립트 변경).

## 테스트 / 확인

- [x] `docker compose --env-file .env config --images` 가 GHCR 이미지 참조 출력 (`ghcr.io/llagoon3/portfolio-{web,api}:main-latest`)
- [x] `bash -n scripts/deploy.sh` 구문 통과
- [ ] (CI) 본 PR 의 docker-build matrix 잡이 build 만 수행하고 GHCR push 단계 skip 됨 확인
- [ ] (머지 후) main push 트리거 CI 에서 `ghcr.io/llagoon3/portfolio-{web,api}:main-<sha>` / `main-latest` 가 push 되는지 확인 (GitHub Packages 탭)
- [ ] (머지 후) prod CD 1회 실행 후 컨테이너가 GHCR 이미지로 교체되고 외부 도메인 정상 응답 확인
- [ ] (머지 후) 롤백 시연: `IMAGE_TAG=main-<old-sha> bash scripts/deploy.sh` → 다시 latest 복귀

## 리뷰 포인트

- `ci.yml` 의 `if: ${{ github.event_name == 'push' }}` 가드가 fork PR 의 `GITHUB_TOKEN` read-only 제약을 피하기 위한 의도임.
- `docker-compose.yml` 의 `${WEB_IMAGE_TAG:-main-latest}` 폴백 — `IMAGE_TAG` 미설정 시에도 deploy.sh 가 동작하도록 안전망.
- `deploy.sh` 가 `git fetch/reset` 을 유지하는 이유: compose 파일·.env 가 호스트 git 디렉토리에 있어야 함. 완전 git 무의존은 후속 작업.
- `cd.yml` 의 `${DEPLOY_SHA:0:7}` — `docker/metadata-action` 의 `format=short` 기본값(7자) 와 맞춤.

## 참고 사항

- **머지 직후 모니터링 권장**: 첫 GHCR 기반 prod 배포가 실제로 도는 시점. 실패 시 호스트 git 디렉토리에 이전 빌드 산출물이 그대로 있어 `git checkout <prev-sha> && docker compose up -d --build` 로 즉시 수동 복귀 가능 (단, 본 PR 머지 이후 디렉토리에는 build: 블록이 없으므로 일시적으로 override 필요).
- **`API_INTERNAL_URL` build-time baked**: 향후 dev 환경의 internal URL 이 다르게 필요해지면 web 이미지 2종 빌드 필요. 현재는 prod/dev 모두 `http://api:7341` 공유라 무관.
- **PR #57 유산 (uploads external 공유, extra_hosts 로 prod mysql 접근, mysql profile 분리)**: 본 PR 에 미포함. dev 환경 후속 PR 에서 GHCR 구조 위에 재구성 예정.
- **이전 이슈/PR 정리**: 이슈 #56 닫음 → #58 에 흡수. PR #57 닫음.