### PR TITLE
[fix] 배포 시 mysql 컨테이너 불필요한 재기동 회피

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,9 @@ PR 및 push 시 자동 실행:
 3. `scripts/deploy.sh`:
    - `git fetch/reset` 으로 호스트의 compose 파일·.env 동기화 (호스트는 더 이상 `docker build` 를 수행하지 않음 — compose 정의를 읽기 위한 동기화 목적)
    - `DEPLOY_SHA` 가 더 이상 `origin/main` 의 tip 이 아니면 배포 중단 (늦게 끝난 이전 커밋 CI 로 stale 이미지 되감기 방지)
-   - `docker compose pull` 로 GHCR 에서 해당 SHA 이미지 가져오기
-   - `docker compose up -d` 로 새 이미지로 컨테이너 교체
+   - `docker compose pull web api` 로 GHCR 에서 해당 SHA 이미지만 가져오기 (mysql 은 mutable 태그 digest 변경으로 인한 재기동 회피 목적으로 pull 대상에서 제외)
+   - `docker compose up -d` 로 새 이미지로 web/api 컨테이너 교체. mysql 은 image/config 변경이 없으므로 그대로 유지됨
+   - mysql 자체 설정·이미지 변경이 필요한 경우 호스트에서 수동으로 `docker compose up -d mysql` 호출
 
 #### 최초 GHCR 전환 시 확인 사항
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -37,7 +37,10 @@ export WEB_IMAGE_TAG="$TAG"
 export API_IMAGE_TAG="$TAG"
 
 echo "=== Pulling images (tag=$TAG) ==="
-docker compose pull
+# mysql 은 mutable 태그(mysql:8.0) 라 매 pull 마다 digest 가 바뀔 수 있고,
+# 그러면 뒤이은 up -d 가 mysql 까지 recreate 한다. web/api 만 명시적으로 pull 한다.
+# mysql 자체 설정/이미지 변경 시에는 수동으로 `docker compose up -d mysql` 호출 필요.
+docker compose pull web api
 
 echo "=== Restarting containers ==="
 docker compose up -d


### PR DESCRIPTION
## 요약

- PR #59 머지 후 첫 GHCR 기반 배포에서 web/api 와 함께 mysql 컨테이너도 같이 재기동되는 현상 발견.
- 원인: \`docker compose pull\` 이 mutable 태그(mysql:8.0) 의 digest 를 매번 새로 가져와 \`up -d\` 단계에서 mysql 까지 recreate.
- 해결: pull 을 web/api 로만 명시. mysql 은 image/config 변경 없음으로 유지됨.

Closes #60

## 변경 내용

- \`scripts/deploy.sh\`: \`docker compose pull\` → \`docker compose pull web api\`. 의도와 보충 주석 포함.
- \`README.md\`: CD 단계 설명에 web/api 만 pull 한다는 점과 mysql 수동 갱신 절차 추가.

## 변경 이유

- prod DB 가 매 배포마다 재기동되는 건 바람직하지 않음 (잠깐의 연결 끊김, healthcheck 통과 전 요청 실패 가능성, 메모리 캐시 손실).
- web/api 와 달리 mysql 은 GHCR 전환의 영향 범위가 아닌데도 사이드 이펙트로 재기동됨.

## 영향 범위

- [ ] \`apps/web\`
- [ ] \`apps/api\`
- [ ] \`packages\`
- [x] \`repo\` (배포 스크립트 + README)

## 스크린샷 / 데모

없음 (배포 스크립트 1줄 변경 + 문서).

## 테스트 / 확인

- [x] \`bash -n scripts/deploy.sh\` 구문 통과
- [ ] (머지 후) prod 배포 1회 트리거 → \`docker ps\` 의 portfolio-project-mysql-1 \`Status\` 가 직전 시간(분 단위) 그대로 유지되는지 확인 (web/api 만 \`Up < 1 minute\` 로 갱신)

## 리뷰 포인트

- mysql 자체 설정/이미지 변경 시에는 호스트에서 \`docker compose up -d mysql\` 을 수동 호출해야 한다는 점이 README 에 추가됨 — 운영 절차로 받아들일 수 있는지.
- 대안 후보(\`mysql:8.0@sha256:...\` digest pin) 는 본 PR 에 미포함. 보안 패치 시 수동 갱신 부담 때문. 향후 필요해지면 별도 이슈로.

## 참고 사항

- 본 PR 머지 시 prod CD 가 1회 실행되어 web/api 만 새 이미지로 교체되고 mysql 은 보존되는지 확인 가능.