### PR TITLE
[fix] dev api 가 prod mysql 컨테이너에 직접 접근하도록 네트워크 join

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,13 +11,14 @@ services:
     # 이게 없으면 dev 컨테이너에도 prod 의 .env (CORS_ORIGIN 등) 가 inject 되어 .env.dev 가 무시된다.
     env_file: !override
       - .env.dev
-    # prod 의 default 네트워크에 external join 하여 prod mysql 컨테이너에 직접 통신한다.
-    # 이전엔 extra_hosts 로 host gateway 의 3307 을 가리켰으나 호스트 환경에서 ETIMEDOUT 발생.
+    # shared-db: prod mysql 만 좁게 공유하는 네트워크 (prod compose 가 만든 portfolio-project_shared-db).
+    # prod 의 default 네트워크 전체를 공유하면 dev api 가 hostname `api` 로 같이 등록되어
+    # prod web 의 DNS 가 비결정적으로 dev api 로 라우팅될 수 있어 mysql 만 한 단계 격리한다.
     networks:
       - default
-      - prod_portfolio
+      - shared-db
     environment:
-      # prod 의 compose 서비스명. prod_portfolio 네트워크에서 DNS 로 해석됨.
+      # mysql 컨테이너의 compose 서비스명. shared-db 네트워크에서 DNS 로 해석됨.
       DB_HOST: mysql
       # prod 컨테이너 내부 포트(3306). 3307 은 호스트 노출용이라 컨테이너 간 통신엔 안 씀.
       DB_PORT: "3306"
@@ -29,9 +30,9 @@ volumes:
     external: true
     name: portfolio-project_uploads
 
-# dev api 가 prod mysql 컨테이너에 접근하기 위한 external 네트워크 정의.
-# portfolio-project_default 는 prod compose project (portfolio-project) 가 만든 기본 네트워크.
+# dev api 가 prod mysql 컨테이너에만 좁게 접근하기 위한 external 네트워크.
+# portfolio-project_shared-db 는 prod compose (portfolio-project) 의 top-level networks 에 정의된 shared-db.
 networks:
-  prod_portfolio:
+  shared-db:
     external: true
-    name: portfolio-project_default
+    name: portfolio-project_shared-db

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,13 +11,16 @@ services:
     # 이게 없으면 dev 컨테이너에도 prod 의 .env (CORS_ORIGIN 등) 가 inject 되어 .env.dev 가 무시된다.
     env_file: !override
       - .env.dev
-    # prod mysql 컨테이너에는 dev 네트워크가 join 하지 않는다.
-    # 호스트 게이트웨이로 접근해 prod 가 외부로 노출한 3307 포트를 사용한다.
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+    # prod 의 default 네트워크에 external join 하여 prod mysql 컨테이너에 직접 통신한다.
+    # 이전엔 extra_hosts 로 host gateway 의 3307 을 가리켰으나 호스트 환경에서 ETIMEDOUT 발생.
+    networks:
+      - default
+      - prod_portfolio
     environment:
-      DB_HOST: host.docker.internal
-      DB_PORT: "3307"
+      # prod 의 compose 서비스명. prod_portfolio 네트워크에서 DNS 로 해석됨.
+      DB_HOST: mysql
+      # prod 컨테이너 내부 포트(3306). 3307 은 호스트 노출용이라 컨테이너 간 통신엔 안 씀.
+      DB_PORT: "3306"
 
 # dev api 가 DB row 에서 참조하는 업로드 파일을 그대로 서빙하도록 prod 의 uploads 볼륨을 external 로 마운트한다.
 # base 의 익명 `uploads:` 볼륨을 덮어쓴다.
@@ -25,3 +28,10 @@ volumes:
   uploads:
     external: true
     name: portfolio-project_uploads
+
+# dev api 가 prod mysql 컨테이너에 접근하기 위한 external 네트워크 정의.
+# portfolio-project_default 는 prod compose project (portfolio-project) 가 만든 기본 네트워크.
+networks:
+  prod_portfolio:
+    external: true
+    name: portfolio-project_default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,11 @@ services:
       TZ: Asia/Seoul
     volumes:
       - mysql_data:/var/lib/mysql
+    # default: prod web/api 의 기존 접근 경로 유지
+    # shared-db: dev 스택이 external join 해서 mysql 에만 접근하기 위한 좁은 공유 네트워크
+    networks:
+      - default
+      - shared-db
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       interval: 10s
@@ -65,3 +70,9 @@ services:
 volumes:
   mysql_data:
   uploads:
+
+# dev 스택이 prod mysql 만 좁게 공유하기 위한 네트워크.
+# prod 의 default 네트워크 전체를 공유하면 dev api 가 hostname `api` 로 같이 등록되어
+# prod web 의 DNS 가 비결정적으로 dev api 로 라우팅될 위험이 있으므로 mysql 만 한 단계 격리.
+networks:
+  shared-db:


### PR DESCRIPTION
## 요약

- PR #64 머지 후 첫 dev 기동에서 dev api 가 \`Error: connect ETIMEDOUT (mysql2)\` 로 mysql 연결 실패 → SIGKILL(137).
- 본 호스트 환경에서는 \`extra_hosts: host.docker.internal:host-gateway\` 경로가 동작하지 않음 (방화벽 또는 prod mysql publish 가 docker bridge gateway 차단).
- prod 의 default 네트워크에 dev api 가 external join 해서 mysql 컨테이너에 컨테이너 간 직접 통신.

Closes #65

## 변경 내용 (\`docker-compose.dev.yml\` 만 수정)

| 항목 | 변경 전 | 변경 후 |
|---|---|---|
| api networks | dev_default 단독 | \`[default, prod_portfolio]\` |
| api environment.DB_HOST | \`host.docker.internal\` | \`mysql\` (prod compose 서비스명) |
| api environment.DB_PORT | \`3307\` (호스트 노출 포트) | \`3306\` (컨테이너 내부 포트) |
| api extra_hosts | \`host.docker.internal:host-gateway\` | (제거) |
| 파일 끝 networks | (없음) | \`prod_portfolio: external = portfolio-project_default\` |

\`profiles: [\"prod\"]\` 으로 dev compose 가 mysql 서비스를 별도 기동하지 않는 동작은 그대로 유지된다.

## 변경 이유

- 호스트 환경에서 \`host.docker.internal\` 게이트웨이 방식이 동작하지 않아 dev api 가 mysql 에 연결 못 함.
- prod 네트워크 external join 방식은 #63 의 \"리스크 / 보류\" 항목에 후속으로 명시돼 있었고, 본 시점에 자연스럽게 적용.
- 부수 효과: prod mysql 의 호스트 노출 포트(3307) 가 향후 닫혀도 본 방식은 영향 없음 → 보안 강화와 호환.

## 영향 범위

- [ ] \`apps/web\`
- [ ] \`apps/api\`
- [ ] \`packages\`
- [x] \`repo\` (compose dev overlay)

## 스크린샷 / 데모

없음.

## 테스트 / 확인

- [x] \`docker compose -p portfolio-dev -f docker-compose.yml -f docker-compose.dev.yml --env-file .env.dev config api\` → \`networks: [default, prod_portfolio]\`, \`DB_HOST=mysql\`, \`DB_PORT=3306\`, extra_hosts 사라짐 확인
- [x] \`docker network inspect portfolio-project_default\` → mysql 컨테이너(172.21.0.2) 가 해당 네트워크에 join 중 — dev api 가 hostname \`mysql\` 로 해석 가능
- [ ] (머지 후) 호스트에서 정상 흐름 재진입 → dev api 가 mysql 연결 성공 + dev web 이 dev api 라우트

## 리뷰 포인트

- \`networks: [default, prod_portfolio]\` 명시 — default 를 빠뜨리면 dev web ↔ dev api 통신이 끊김. 둘 다 명시 필요.
- \`DB_PORT=3306\` 으로의 변경 — 컨테이너 간 통신은 mysql 의 내부 포트. 3307 은 호스트 publish 용.
- mysql \`profiles: [\"prod\"]\` 는 유지 → dev compose 가 mysql 서비스를 별도 기동하지 않고 prod mysql 컨테이너를 공유하는 구조.

## 머지 후 호스트 작업 (사용자 직접)

1. \`.env.dev\` 의 임시 우회 항목 \`WEB_API_INTERNAL_URL\` 제거 (이 항목이 dev web 을 prod api 로 우회시키고 있었음 — dev api 가 살아나면 불필요)
2. 사용자가 임시로 띄운 우회 컨테이너 정리:
   \`\`\`bash
   # 이름이 portfolio-project-dev-* 로 떠 있는 컨테이너들 정리
   docker compose -p portfolio-project-dev down 2>/dev/null || true
   \`\`\`
3. 정상 흐름 재배포:
   \`\`\`bash
   bash scripts/deploy.sh dev
   \`\`\`
4. 검증:
   - \`docker compose -p portfolio-dev ps\` 에 web/api UP
   - dev api 컨테이너 로그에서 \`Nest application successfully started\` 확인
   - \`https://portfolio-dev.llagoon.dev\` 응답 정상 + 페이지의 데이터(프로젝트/About)가 prod 데이터와 동일

## 참고 사항

- 본 PR 머지 시 prod CD 가 1회 트리거 → prod 무영향 (compose dev overlay 만 수정).
- 본 변경은 dev api 도 prod mysql 컨테이너를 공유하므로 #63 의 \"prod DB 공유 → 쓰기 반영\" 결정과 일관.