### PR TITLE
[fix] deploy.sh 가 호스트 작업 디렉토리를 reset 하던 부작용 해결

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,20 @@ PR 및 push 시 자동 실행:
 1. CI 워크플로우 성공 확인 (workflow_run)
 2. Self-hosted runner 에서 `IMAGE_TAG=<env>-<short-sha>` 로 `scripts/deploy.sh [prod|dev]` 실행
 3. `scripts/deploy.sh`:
-   - `git fetch/reset origin/main` 으로 호스트의 compose 정의 동기화 (인프라 단일 출처). dev 의 코드는 GHCR 이미지 안에 들어있으므로 호스트 git 상태와 무관
+   - **deploy 전용 디렉토리** (`~/.cache/portfolio-deploy`) 에서 `git fetch/reset origin/main` 으로 compose 정의 동기화. 첫 실행 시 자동으로 `git clone --branch main --depth 1` (호스트 운영자 setup 불필요). 호스트의 워크스페이스 디렉토리(`ORIG_PROJECT_DIR`) 의 작업 중인 git 상태는 영향받지 않는다
    - (prod 만) `DEPLOY_SHA` 가 더 이상 `origin/main` 의 tip 이 아니면 배포 중단 (stale 이미지 되감기 방지)
-   - `docker compose -p <project> ... pull web api` 로 GHCR 에서 해당 SHA 이미지만 가져오기 (mysql 은 mutable 태그 digest 변경으로 인한 재기동 회피 목적으로 pull 대상에서 제외)
+   - `docker compose -p <project> ... --env-file <ORIG_PROJECT_DIR>/.env[.dev] pull web api` 로 GHCR 에서 해당 SHA 이미지만 가져오기. `.env` / `.env.dev` 는 git tracked 가 아니므로 호스트 워크스페이스의 절대경로로 직접 참조 (mysql 은 mutable 태그 digest 변경으로 인한 재기동 회피 목적으로 pull 대상에서 제외)
    - `docker compose -p <project> ... up -d` 로 새 이미지로 web/api 컨테이너 교체. mysql (prod 만) 은 그대로 유지됨
    - mysql 자체 설정·이미지 변경이 필요한 경우 호스트에서 `docker compose --profile prod up -d mysql` 수동 호출
+
+**디렉토리 역할 분리**:
+
+| 디렉토리 | 용도 |
+|---|---|
+| `ORIG_PROJECT_DIR` (`/home/lagoon3/.openclaw/workspace/Portfolio-Project`) | 운영자 작업 (브랜치 / commit / PR). `.env`, `.env.dev` 등 환경 파일 보관 |
+| `DEPLOY_DIR` (`~/.cache/portfolio-deploy`) | deploy.sh 가 매번 `git reset --hard origin/main` 으로 sync. compose 정의 단일 출처. 운영자가 직접 손댈 일 없음 |
+
+docker named volume (`mysql_data`, `uploads`) 과 compose project name 은 디렉토리 위치와 무관하게 동작하므로 분리에 따른 컨테이너 / 데이터 영향 없음.
 
 #### dev 환경 특징
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,7 +2,13 @@
 set -euo pipefail
 
 ENV_NAME="${1:-prod}"
-PROJECT_DIR="/home/lagoon3/.openclaw/workspace/Portfolio-Project"
+# 호스트 운영자 디렉토리 — .env / .env.dev 등 비공개 환경 파일이 위치.
+# self-hosted runner 가 호스트의 다른 작업 (브랜치 작업, cherry-pick, rebase 등)
+# 을 reset 으로 망가뜨리지 않도록 deploy 작업은 별도 디렉토리에서 수행한다.
+ORIG_PROJECT_DIR="/home/lagoon3/.openclaw/workspace/Portfolio-Project"
+# deploy 전용 작업 디렉토리 — 첫 실행 시 clone, 이후 매번 origin/main 으로 reset.
+DEPLOY_DIR="${HOME}/.cache/portfolio-deploy"
+DEPLOY_REPO_URL="https://github.com/LLagoon3/Portfolio-Project.git"
 DEPLOY_SHA="${DEPLOY_SHA:-}"
 
 case "$ENV_NAME" in
@@ -26,12 +32,20 @@ case "$ENV_NAME" in
     ;;
 esac
 
-cd "$PROJECT_DIR"
+# deploy 디렉토리 부트스트랩 — 호스트 운영자 setup 불필요, 첫 실행이 자동 셋업.
+if [ ! -d "$DEPLOY_DIR/.git" ]; then
+  echo "=== First-time setup: cloning into $DEPLOY_DIR ==="
+  mkdir -p "$(dirname "$DEPLOY_DIR")"
+  git clone --branch main --depth 1 "$DEPLOY_REPO_URL" "$DEPLOY_DIR"
+fi
+
+cd "$DEPLOY_DIR"
 
 # compose 정의는 항상 main 기준으로 동기화 (인프라 단일 출처).
-# dev 환경의 코드는 GHCR 이미지(dev-<sha>) 안에 들어있으므로 호스트 git 상태와 무관.
+# 이 reset 은 DEPLOY_DIR 안에서만 일어나므로 호스트 ORIG_PROJECT_DIR 의
+# 진행 중인 git 작업은 영향을 받지 않는다.
 echo "=== Syncing compose files from main (env=$ENV_NAME) ==="
-git fetch origin main
+git fetch --depth 1 origin main
 git reset --hard origin/main
 
 # stale SHA 가드는 prod 에만 적용.
@@ -51,7 +65,14 @@ TAG="${IMAGE_TAG:-${TAG_PREFIX}-latest}"
 export WEB_IMAGE_TAG="$TAG"
 export API_IMAGE_TAG="$TAG"
 
-COMPOSE=(docker compose -p "$COMPOSE_PROJECT" "${COMPOSE_FILES[@]}" "${COMPOSE_PROFILES[@]}" --env-file "$ENV_FILE")
+# .env / .env.dev 는 git tracked 가 아니므로 DEPLOY_DIR 에는 없다.
+# 호스트 ORIG_PROJECT_DIR 의 파일을 절대경로로 직접 참조.
+ENV_FILE_ABS="${ORIG_PROJECT_DIR}/${ENV_FILE}"
+if [ ! -f "$ENV_FILE_ABS" ]; then
+  echo "=== Missing env file: $ENV_FILE_ABS ===" >&2
+  exit 1
+fi
+COMPOSE=(docker compose -p "$COMPOSE_PROJECT" "${COMPOSE_FILES[@]}" "${COMPOSE_PROFILES[@]}" --env-file "$ENV_FILE_ABS")
 
 echo "=== Pulling images (env=$ENV_NAME tag=$TAG) ==="
 # mysql 은 mutable 태그(mysql:8.0) 라 매 pull 마다 digest 가 바뀔 수 있고,


### PR DESCRIPTION
## 무엇을

\`scripts/deploy.sh\` 가 별도 deploy 전용 디렉토리(\`~/.cache/portfolio-deploy\`)에서 동작하도록 분리. 호스트 워크스페이스(\`/home/lagoon3/.openclaw/workspace/Portfolio-Project\`) 의 git 상태를 더 이상 건드리지 않는다.

| 디렉토리 | 용도 |
|---|---|
| \`ORIG_PROJECT_DIR\` | 운영자 작업 (브랜치 / commit / PR), \`.env\` / \`.env.dev\` 보관 |
| \`DEPLOY_DIR\` (\`~/.cache/portfolio-deploy\`) | deploy.sh 가 매번 \`git reset --hard origin/main\` 으로 sync. 운영자가 직접 손댈 일 없음 |

## 왜

\`deploy.sh\` 가 호스트 working tree 를 \`git reset --hard origin/main\` 하던 의존성 때문에, 호스트에서 진행 중인 다른 브랜치 작업이 main/dev 머지 CD 가 트리거되는 순간 일제히 reset 되는 부작용이 있었다.

**실제 발생 사례**: PR #73 (revert) 머지 CD 가 PR #74 작업용 cherry-pick 5 commits (\`277fdfd\`) 를 \`origin/main\`(\`044eea5\`) 로 reset 시킴 → \`git reflog\` 로 SHA 찾아서 force push 복구. 이번 PR 작업 중에도 같은 패턴 반복 위험이 있었음.

## 변경 사항

### \`scripts/deploy.sh\`

- \`DEPLOY_DIR\` 도입. 첫 실행 시 자동으로 \`git clone --branch main --depth 1\` (호스트 운영자 setup 불필요)
- 이후 매번 \`cd DEPLOY_DIR && git fetch --depth 1 origin main && git reset --hard origin/main\`
- \`compose --env-file\` 옵션을 \`ORIG_PROJECT_DIR\` 의 \`.env\` / \`.env.dev\` 절대경로로 변경 (git tracked 가 아니라 \`DEPLOY_DIR\` 에는 없음)
- env 파일 부재 시 명확한 에러 메시지 + 비정상 종료

### \`README.md\` CD 섹션

- 디렉토리 역할 분리표 추가
- deploy 흐름 설명에 \`DEPLOY_DIR\` 도입 명시

## 영향 / 검증

- docker named volume (\`mysql_data\`, \`uploads\`) 과 compose project name (\`portfolio-project\` / \`portfolio-dev\`) 은 호스트 디렉토리 위치와 무관 → 컨테이너 / 데이터 동작 변화 없음
- 첫 dev/prod CD 실행 시 \`DEPLOY_DIR\` 부트스트랩 (clone) 한 번 발생, 이후 동일
- dev 머지 후 cd-dev 가 새 \`deploy.sh\` 사용 → 호스트 working tree 무영향 확인
- main 머지 후 prod CD 도 동일

## 작업 흐름

base=\`dev\` → 머지 → cd-dev 자동 → 호스트 \`ORIG_PROJECT_DIR\` reset 발생하지 않음 확인 → main 머지 PR → prod CD 도 동일.

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)