### PR TITLE
[fix] CD workflow 의 actions/checkout 이 main 옛 스크립트를 가져오던 부작용 해결

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -21,8 +21,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # workflow_run 트리거는 GITHUB_SHA/REF 가 default branch(main) tip 으로 잡혀서
+          # actions/checkout 의 default 가 main 의 옛 워크플로우/스크립트를 가져온다.
+          # CI 가 돌았던 dev 의 정확한 head_sha 로 명시해 같은 commit 의 스크립트로 동작 보장.
+          ref: ${{ github.event.workflow_run.head_sha }}
+          # 호스트 워크스페이스 보호 — runner work directory 가 호스트 워크스페이스와
+          # 겹치더라도 별도 서브디렉토리(deploy-checkout)에 체크아웃해 호스트 git 상태를 보호.
+          path: deploy-checkout
 
       - name: Deploy
+        working-directory: deploy-checkout
         env:
           DEPLOY_SHA: ${{ github.event.workflow_run.head_sha }}
         # CI 가 GHCR 에 푸시한 정확한 SHA 태그(dev-<short>)로 배포한다. deploy.sh 는 IMAGE_TAG 미설정 시 dev-latest 로 폴백.

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,8 +20,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # workflow_run 트리거는 GITHUB_SHA/REF 가 default branch tip 으로 잡혀서
+          # actions/checkout 의 default 가 의도와 다르게 동작한다 (특히
+          # cd-dev 에서 main 의 옛 워크플로우/스크립트가 체크아웃되는 케이스).
+          # CI 가 돌았던 정확한 head_sha 로 명시해 같은 commit 의 워크플로우/스크립트로 동작 보장.
+          ref: ${{ github.event.workflow_run.head_sha }}
+          # 호스트 워크스페이스 보호 — runner work directory 가 호스트 워크스페이스와
+          # 겹치더라도 별도 서브디렉토리(deploy-checkout)에 체크아웃해 호스트 git 상태를 보호.
+          path: deploy-checkout
 
       - name: Deploy
+        working-directory: deploy-checkout
         env:
           DEPLOY_SHA: ${{ github.event.workflow_run.head_sha }}
         # CI 가 GHCR 에 푸시한 정확한 SHA 태그(main-<short>)로 배포한다. deploy.sh 는 IMAGE_TAG 미설정 시 main-latest 로 폴백.


### PR DESCRIPTION
## 무엇을

\`cd.yml\` / \`cd-dev.yml\` 의 \`actions/checkout@v4\` 에 \`ref\` 와 \`path\` 명시.

\`\`\`yaml
- name: Checkout
  uses: actions/checkout@v4
  with:
    ref: \${{ github.event.workflow_run.head_sha }}
    path: deploy-checkout

- name: Deploy
  working-directory: deploy-checkout
  ...
\`\`\`

## 왜

PR #76 (deploy.sh worktree 분리) 머지 후에도 호스트 워크스페이스 reset 부작용이 재발. 진단해보니 cd-dev 의 \`actions/checkout\` 이 dev 의 새 deploy.sh 가 아니라 **main 의 옛 deploy.sh** 를 체크아웃해 실행하고 있었음.

| run | event | sha |
|---|---|---|
| CI (dev) | push | \`c0ad01e\` (dev tip) ✓ |
| CD (dev) | workflow_run | **\`044eea5\` (main tip!)** — 옛 deploy.sh |

\`workflow_run\` 트리거의 known behavior: GITHUB_SHA/REF 가 default branch (main) tip 으로 잡힘. \`ref\` 명시 없이는 \`actions/checkout\` 의 default 가 의도와 다르게 동작.

또한 self-hosted runner 의 work directory 가 호스트 워크스페이스와 겹칠 가능성에 대비해 \`path: deploy-checkout\` 으로 서브디렉토리 격리 추가.

## 적용 후 동작

| 시점 | 동작 |
|---|---|
| 이번 PR 머지 시점 | main 의 **옛 cd.yml + 옛 deploy.sh** 가 마지막 1회 실행 → 호스트 reset 1회 (불가피, 새 워크플로우가 아직 main 에 없으므로) |
| 이후 모든 CD | 새 \`cd.yml\` / \`cd-dev.yml\` 이 head_sha 명시 → 새 \`deploy.sh\` (PR #76 의 DEPLOY_DIR 분리) 가 동작 → 호스트 무영향 |

## base=main 사유

\`portfolio-pr-base-rule\` 에 따라 코드 변경은 base=dev 가 기본이나, **운영 부작용(매 CD 마다 호스트 reset)을 빨리 끊어야 하는 hot-fix 성격**. dev 검증을 거치면 dev 머지 CD 가 또 옛 워크플로우로 동작해 부작용 1회 추가 발생 후 main 머지로 또 1회 발생 → 총 2회 부작용. main 직행 시 1회로 단축.

## 영향

- CI/CD 동작 변화 없음 (정확히 의도된 동작 보장)
- prod 컨테이너 / 데이터 / dev 환경 영향 없음
- DEPLOY_DIR 부트스트랩 (\`~/.cache/portfolio-deploy\` 첫 clone) 은 이미 PR #76 의 deploy.sh 에 들어있음

## 후속

- 본 PR 머지 후 dev → main 머지 PR (Bold 적용)
- 새 cd.yml 동작 검증 (다음 dev 머지 시 cd-dev 가 호스트 무영향 확인)

Refs #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)