### PR TITLE
[fix] Home 페이지 카피·메타데이터 실제 정보 반영

### DIFF
--- a/apps/web/components/home/AboutStrip.jsx
+++ b/apps/web/components/home/AboutStrip.jsx
@@ -1,14 +1,6 @@
 import Reveal from '../primitives/Reveal';
 import Eyebrow from '../primitives/Eyebrow';
-import StatCounter from '../primitives/StatCounter';
 import PillButton from '../primitives/PillButton';
-
-// stat[] 필드가 API 에 없어 임시 하드코딩. 후속 PR 에서 about.stats[] 도입 시 교체.
-const STATS = [
-	{ end: 8, suffix: '', accent: '+', label: 'Years' },
-	{ end: 14, suffix: '', accent: null, label: 'Shipped' },
-	{ end: 99.98, decimals: 2, suffix: '', accent: '%', label: 'Avg Uptime' },
-];
 
 export default function AboutStrip({ bioFirst }) {
 	// bio[0] 가 마크다운 헤더(`## 1. 한 줄 소개`) 로 시작할 수 있어 평문 렌더 시
@@ -23,7 +15,7 @@ export default function AboutStrip({ bioFirst }) {
 
 	const text =
 		stripMarkdownHeaders(bioFirst) ||
-		'백엔드와 운영 인프라를 중심으로 일합니다. 잘 짠 코드가 아니라 잘 굴러가는 시스템을 만드는 일에 집중하고, 야간 알람이 사라진 새벽이 가장 큰 보상이라고 믿습니다.';
+		'서비스의 동작 원리와 운영 구조를 함께 이해하며, 성능·안정성·운영 효율을 개선하는 백엔드 개발자입니다.';
 
 	return (
 		<section
@@ -42,13 +34,13 @@ export default function AboutStrip({ bioFirst }) {
 							lineHeight: 1,
 						}}
 					>
-						코드를 쓰지만,
+						기능 구현을 넘어
 						<br />
 						<span style={{ color: 'var(--indigo-soft)', fontStyle: 'italic' }}>
-							팀의 시간을
+							서비스의 안정성과
 						</span>
 						<br />
-						벌어줍니다.
+						유지보수성을 고민합니다.
 					</h2>
 				</Reveal>
 				<Reveal delay={0.16} className="col-span-12 lg:col-span-7">
@@ -62,33 +54,6 @@ export default function AboutStrip({ bioFirst }) {
 					>
 						{text}
 					</p>
-
-					<div className="grid grid-cols-3 gap-6 lg:gap-10 mt-10">
-						{STATS.map((stat) => (
-							<div
-								key={stat.label}
-								className="pt-[1.4rem]"
-								style={{ borderTop: '1px solid var(--line-strong)' }}
-							>
-								<div
-									className="font-general-semibold"
-									style={{
-										fontSize: 'clamp(2.2rem, 4vw, 3.4rem)',
-										letterSpacing: '-0.04em',
-										lineHeight: 1,
-									}}
-								>
-									<StatCounter
-										end={stat.end}
-										decimals={stat.decimals || 0}
-										suffix={stat.suffix}
-										accentSuffix={stat.accent}
-									/>
-								</div>
-								<Eyebrow className="mt-3">{stat.label}</Eyebrow>
-							</div>
-						))}
-					</div>
 
 					<div className="mt-10">
 						<PillButton variant="ghost" as="link" href="/about" ariaLabel="About 더 보기">

--- a/apps/web/components/home/AboutStrip.jsx
+++ b/apps/web/components/home/AboutStrip.jsx
@@ -11,8 +11,18 @@ const STATS = [
 ];
 
 export default function AboutStrip({ bioFirst }) {
+	// bio[0] 가 마크다운 헤더(`## 1. 한 줄 소개`) 로 시작할 수 있어 평문 렌더 시
+	// 헤더가 그대로 노출된다. 가벼운 분리로 `#` 시작 라인만 skip 하고 본문만 남긴다.
+	// 코드 블록 안의 `#` 까지 영향받지만 라군 bio 에 해당 케이스 없음 — 필요 시 react-markdown 도입.
+	const stripMarkdownHeaders = (raw) =>
+		(raw || '')
+			.split('\n')
+			.filter((line) => !line.trim().startsWith('#'))
+			.join('\n')
+			.trim();
+
 	const text =
-		bioFirst ||
+		stripMarkdownHeaders(bioFirst) ||
 		'백엔드와 운영 인프라를 중심으로 일합니다. 잘 짠 코드가 아니라 잘 굴러가는 시스템을 만드는 일에 집중하고, 야간 알람이 사라진 새벽이 가장 큰 보상이라고 믿습니다.';
 
 	return (

--- a/apps/web/components/home/ContactCTA.jsx
+++ b/apps/web/components/home/ContactCTA.jsx
@@ -1,10 +1,13 @@
-import Link from 'next/link';
 import Reveal from '../primitives/Reveal';
 import Eyebrow from '../primitives/Eyebrow';
 
 // 환경변수 미설정 시 fallback. 후속 PR 에서 about.contactEmail 필드 도입 시 SSR 로 교체.
 const DEFAULT_EMAIL =
-	process.env.NEXT_PUBLIC_CONTACT_EMAIL || 'hi@example.com';
+	process.env.NEXT_PUBLIC_CONTACT_EMAIL || 'choonarm3@gmail.com';
+
+const GITHUB_URL = 'https://github.com/LLagoon3';
+const NOTION_URL =
+	'https://dear-sawfish-e55.notion.site/15fd6568ef4b80509953d6e7648258dd?source=copy_link';
 
 export default function ContactCTA({ email }) {
 	const target = email || DEFAULT_EMAIL;
@@ -35,8 +38,8 @@ export default function ContactCTA({ email }) {
 			<Reveal delay={0.08} className="grid grid-cols-12 gap-6 mt-16 lg:mt-20">
 				<div className="col-span-12 lg:col-span-8">
 					<p className="leading-relaxed max-w-xl" style={{ color: 'var(--paper-dim)' }}>
-						새로운 협업, 기술 컨설팅, 또는 그냥 커피 한 잔. 답장은 영업일 기준
-						24시간 안에 드립니다.
+						백엔드 개발자로서 더 나은 서비스를 만드는 팀에 기여하고 싶습니다.
+						언제든 편하게 연락 주세요.
 					</p>
 				</div>
 				<div
@@ -47,24 +50,28 @@ export default function ContactCTA({ email }) {
 					}}
 				>
 					<div className="flex items-center justify-between">
-						<span>EMAIL</span>
+						<span>GITHUB</span>
 						<a
-							href={`mailto:${target}`}
+							href={GITHUB_URL}
+							target="_blank"
+							rel="noopener noreferrer"
 							className="bold-interactive transition-colors hover:text-[color:var(--paper)]"
 							style={{ color: 'var(--paper-dim)' }}
 						>
-							{target}
+							@LLagoon3
 						</a>
 					</div>
 					<div className="flex items-center justify-between">
-						<span>CONTACT</span>
-						<Link
-							href="/contact"
+						<span>NOTION</span>
+						<a
+							href={NOTION_URL}
+							target="_blank"
+							rel="noopener noreferrer"
 							className="bold-interactive transition-colors hover:text-[color:var(--paper)]"
 							style={{ color: 'var(--paper-dim)' }}
 						>
-							폼으로 보내기 ↗
-						</Link>
+							이력서 ↗
+						</a>
 					</div>
 				</div>
 			</Reveal>

--- a/apps/web/components/home/HomeHero.jsx
+++ b/apps/web/components/home/HomeHero.jsx
@@ -25,7 +25,7 @@ export default function HomeHero({ tagline }) {
 							style={{ background: '#22c55e' }}
 						/>
 					</span>
-					<Eyebrow>새 협업 가능 · 2026 Q3</Eyebrow>
+					<Eyebrow>신입 채용 검토 중</Eyebrow>
 				</div>
 				<div className="hidden sm:block">
 					<Eyebrow>서울, 한국 · KST</Eyebrow>
@@ -43,8 +43,7 @@ export default function HomeHero({ tagline }) {
 				items={[
 					{ text: '이석호' },
 					{ br: true },
-					{ text: '포트폴리오' },
-					{ text: '2026.', accent: true },
+					{ text: '포트폴리오', accent: true },
 				]}
 			/>
 

--- a/apps/web/components/home/KeywordMarquee.jsx
+++ b/apps/web/components/home/KeywordMarquee.jsx
@@ -1,25 +1,20 @@
 import Reveal from '../primitives/Reveal';
 import Marquee from '../primitives/Marquee';
 
-// 고정 키워드 + 프로젝트 카테고리 unique 를 mix.
-const BASE_KEYWORDS = [
-	'Backend Architecture',
+// 라군의 실제 스택 / 관심 영역. 영문 통일 (시안 톤 유지).
+const KEYWORDS = [
 	'Realtime Systems',
-	'Distributed Data',
-	'Developer Experience',
-	'API Design',
+	'Performance Optimization',
 	'Observability',
+	'Operations Automation',
+	'Redis & Caching',
+	'MCP & AI Integration',
 ];
 
-export default function KeywordMarquee({ projects = [] }) {
-	const categorySet = Array.from(
-		new Set(projects.map((p) => p.category).filter(Boolean))
-	);
-	const items = [...BASE_KEYWORDS, ...categorySet];
-
+export default function KeywordMarquee() {
 	return (
 		<Reveal>
-			<Marquee items={items} duration={36} />
+			<Marquee items={KEYWORDS} duration={36} />
 		</Reveal>
 	);
 }

--- a/apps/web/pages/index.jsx
+++ b/apps/web/pages/index.jsx
@@ -30,7 +30,7 @@ export default function Home({ projects, about }) {
 		<>
 			<PagesMetaHead title="Home" />
 			<HomeHero tagline={about?.tagline} />
-			<KeywordMarquee projects={featured} />
+			<KeywordMarquee />
 			<HomeProjects projects={featured} />
 			<AboutStrip bioFirst={bioFirst} />
 			<ContactCTA />


### PR DESCRIPTION
## 무엇을

Bold Home 의 시안 placeholder 카피·메타데이터를 라군의 실제 정체성에 맞게 일괄 교체.

### 2 commits

| commit | 내용 |
|---|---|
| \`11d4752\` | \`fix(web): Home About strip 의 bio 마크다운 헤더 라인 노출 제거\` |
| \`bf64a4f\` | \`fix(web): Home 페이지 카피와 보조 메타를 라군 실제 정보로 교체\` |

### 변경 항목

| 영역 | 변경 |
|---|---|
| **Hero status** | \`새 협업 가능 · 2026 Q3\` → \`신입 채용 검토 중\` |
| **거대 이름** | \`이석호 / 포트폴리오 / 2026.\` → \`이석호 / 포트폴리오\` (포트폴리오 indigo-soft italic accent, "2026." 제거) |
| **Tagline** | 그대로 (\`/api/about.tagline\` = "Backend Developer") |
| **Marquee** | 영문 6개 only — \`Realtime Systems / Performance Optimization / Observability / Operations Automation / Redis & Caching / MCP & AI Integration\`. 카테고리 mix 로직 제거 |
| **Work 섹션** | 변경 없음 |
| **About headline** | \`기능 구현을 넘어 / 서비스의 안정성과 (indigo italic) / 유지보수성을 고민합니다.\` |
| **About 본문** | \`bio[0]\` 의 \`#\` 라인 skip → 본문만 노출 (\`## 1. 한 줄 소개\` 가 raw 로 보이던 부작용 해결) |
| **About stat** | 섹션 자체 제거 (\`8+ Years / 14 Shipped / 99.98% Uptime\` 모두 임시 placeholder, 신입에 거짓 수치였음) |
| **Contact 이메일** | \`hi@example.com\` → \`choonarm3@gmail.com\` |
| **Contact 본문** | \`백엔드 개발자로서 더 나은 서비스를 만드는 팀에 기여하고 싶습니다. 언제든 편하게 연락 주세요.\` |
| **보조 메타** | EMAIL / CONTACT(폼) → \`GITHUB @LLagoon3\` / \`NOTION 이력서 ↗\` (둘 다 새 탭) |
| **Footer** | 변경 없음 (이미 영문) |

## 왜

PR #78 머지로 Bold Home 이 prod 에 적용된 상태에서 시안 placeholder 가 그대로 노출되어 라군 정체성과 어긋남. 특히 \`bio[0]\` 의 \`## 1. 한 줄 소개\` 가 본문에 raw 노출되는 문제와 임시 stat 의 거짓 수치(8+ Years 등) 가 우선 시급.

## 영향

- \`apps/web\` 전용. \`apps/api\` / docker / CI / CD 변경 없음
- 새 패키지 / 새 컴포넌트 없음 — 기존 primitives (Reveal / WordReveal / Marquee / Eyebrow / PillButton) 와 \`WordReveal.accent\` prop 그대로 재사용
- \`StatCounter\` 는 다른 페이지에서 미사용 (Home stat 제거 후 prefix 만 import 제거)

## 수동 확인 (dev 머지 후)

- [ ] \`portfolio-dev.llagoon.dev\` Hero status / 거대 이름 / tagline
- [ ] Marquee 6개 영문 키워드 만
- [ ] About 헤드라인 + 본문 (마크다운 헤더 없음) + stat 안 보임
- [ ] Contact 큰 이메일 \`choonarm3@gmail.com\` + 본문 + GITHUB/NOTION 메타 (새 탭)
- [ ] DARK/LIGHT 토글 / 모바일 viewport
- [ ] \`/about\`, \`/projects\`, \`/contact\` 기존 디자인 유지

## 의도적 보류 (별도 PR)

- \`/api/about\` 에 \`availability\` / \`stats[]\` / \`contactEmail\` / \`keywords[]\` 필드 확장 — 어드민에서 직접 입력 가능하도록. About 페이지 Bold 와 묶어 후속 PR
- 미참조 \`Stoman-Resume.pdf\` cleanup — 외부 직접 링크 회피 차원 잔존
- 디폴트 다크 모드 강제 전환 — 5페이지 완료 후

Closes #79
Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)