### PR TITLE
[fix] deploy.sh 가 docker-compose service env_file 디렉티브를 못 찾던 부작용 해결

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -72,6 +72,15 @@ if [ ! -f "$ENV_FILE_ABS" ]; then
   echo "=== Missing env file: $ENV_FILE_ABS ===" >&2
   exit 1
 fi
+
+# docker-compose.yml / docker-compose.dev.yml 의 service-level `env_file:` 디렉티브는
+# compose CLI 의 `--env-file` 과 다른 메커니즘이고, **compose 파일 디렉토리**(=DEPLOY_DIR)
+# 기준으로 path 를 해석한다. 따라서 `--env-file` 만 절대경로로 줘도 service env_file 은
+# DEPLOY_DIR 내부의 `.env` / `.env.dev` 를 찾고 실패한다.
+# 호스트 ORIG_PROJECT_DIR 의 실파일을 DEPLOY_DIR 에 symlink 해서 두 메커니즘 모두 만족시킨다.
+# idempotent — 매번 실행해도 동일 결과.
+ln -sf "$ENV_FILE_ABS" "$DEPLOY_DIR/$ENV_FILE"
+
 COMPOSE=(docker compose -p "$COMPOSE_PROJECT" "${COMPOSE_FILES[@]}" "${COMPOSE_PROFILES[@]}" --env-file "$ENV_FILE_ABS")
 
 echo "=== Pulling images (env=$ENV_NAME tag=$TAG) ==="


### PR DESCRIPTION
## 무엇을

\`scripts/deploy.sh\` 의 docker compose 호출 직전에 호스트 \`ORIG_PROJECT_DIR\` 의 \`.env\` / \`.env.dev\` 를 \`DEPLOY_DIR\` 에 **symlink** 하는 라인 한 줄 추가.

\`\`\`bash
ln -sf "\$ENV_FILE_ABS" "\$DEPLOY_DIR/\$ENV_FILE"
\`\`\`

\`ln -sf\` 라 idempotent — 매번 실행해도 동일 결과.

## 왜

PR #76 의 DEPLOY_DIR 분리 + ENV_FILE_ABS 절대경로 변경이 **compose CLI 의 \`--env-file\` 옵션만** 처리하고, **service-level \`env_file:\` 디렉티브**는 누락. 두 메커니즘이 별개:

| 항목 | 처리 | 경로 해석 |
|---|---|---|
| CLI \`--env-file <path>\` | compose 변수 보간 (\`\${VAR}\` syntax) | 절대/상대 OK |
| service-level \`env_file:\` (compose yml 안) | container 환경변수 inject | **compose 파일 디렉토리** 기준 상대경로 |

compose 파일이 DEPLOY_DIR 에 있으므로 service env_file \`.env.dev\` → \`DEPLOY_DIR/.env.dev\` → 파일 없음 → 에러.

### 재현 / 진단

PR #80 (Home 카피 정제) 머지 → cd-dev 자동 트리거 → **failure**.

\`\`\`
env file /home/lagoon3/.cache/portfolio-deploy/.env.dev not found: stat ... no such file or directory
\`\`\`

\`bash -x\` 트레이스:

\`\`\`
+ ENV_FILE_ABS=/home/lagoon3/.openclaw/workspace/Portfolio-Project/.env.dev   ← 정확
+ docker compose ... --env-file /home/lagoon3/.openclaw/workspace/Portfolio-Project/.env.dev pull web api
env file /home/lagoon3/.cache/portfolio-deploy/.env.dev not found             ← 다른 경로
\`\`\`

ENV_FILE_ABS 평가도, CLI \`--env-file\` 전달도 정확. service-level \`env_file:\` 가 별개 메커니즘으로 DEPLOY_DIR 기준 처리 → 에러.

상세 root cause 분석은 #81 코멘트 참조.

## 검증

- 호스트에서 \`IMAGE_TAG=dev-a7db2de bash scripts/deploy.sh dev\` 직접 실행 → ✅ 정상 pull/up
- 컨테이너 idempotent 동작 (이미 떠있는 dev-a7db2de 와 동일 이미지 → no recreate, 단순히 Running 확인)
- bash -n syntax check ✅

## 영향

- dev / prod CD 자동 배포 모두 영향. 본 fix 가 main 까지 가야 영구 해결.
- 임시 회피 (deploy.sh 우회 직접 docker compose 호출) 로 PR #80 의 카피 정제는 이미 dev 환경에 적용됨

## 작업 흐름

base=\`dev\` → dev 머지 → 다음 dev push 시 cd-dev 정상 동작 확인 → dev → main 머지 PR 머지 시 prod CD 도 정상.

Closes #81
Refs #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)