### PR TITLE
[fix] Home Bold 시각 디테일 일괄 수정 (헤더 가독성·로고 / italic clip / marquee 점 / 카피 / About / Contact)

### DIFF
--- a/apps/web/components/home/AboutStrip.jsx
+++ b/apps/web/components/home/AboutStrip.jsx
@@ -36,11 +36,18 @@ export default function AboutStrip({ bioFirst }) {
 					>
 						기능 구현을 넘어
 						<br />
+						서비스의{' '}
 						<span style={{ color: 'var(--indigo-soft)', fontStyle: 'italic' }}>
-							서비스의 안정성과
+							안정성
 						</span>
+						과
 						<br />
-						유지보수성을 고민합니다.
+						<span style={{ color: 'var(--indigo-soft)', fontStyle: 'italic' }}>
+							유지보수성
+						</span>
+						을
+						<br />
+						고민합니다.
 					</h2>
 				</Reveal>
 				<Reveal delay={0.16} className="col-span-12 lg:col-span-7">

--- a/apps/web/components/home/ContactCTA.jsx
+++ b/apps/web/components/home/ContactCTA.jsx
@@ -22,9 +22,11 @@ export default function ContactCTA({ email }) {
 				<Eyebrow className="mb-6">— Let&apos;s talk</Eyebrow>
 				<a
 					href={`mailto:${target}`}
-					className="bold-interactive block font-general-semibold hover:opacity-80 transition-opacity break-all"
+					className="bold-interactive block font-general-semibold hover:opacity-80 transition-opacity break-words"
 					style={{
-						fontSize: 'clamp(2.6rem, 9vw, 8rem)',
+						// 모바일에서 큰 이메일이 break-all 로 어색하게 잘리던 문제를 해결.
+						// break-words 로 단어 경계 우선 + 모바일 fontSize 하한을 약간 낮춰 줄바꿈 횟수 자체를 줄임.
+						fontSize: 'clamp(2rem, 9vw, 8rem)',
 						letterSpacing: '-0.05em',
 						lineHeight: 1,
 						color: 'var(--paper)',
@@ -35,7 +37,13 @@ export default function ContactCTA({ email }) {
 				</a>
 			</Reveal>
 
-			<Reveal delay={0.08} className="grid grid-cols-12 gap-6 mt-16 lg:mt-20">
+			{/* 본문/메타 영역의 Reveal viewport amount 가 0.15 라 페이지 끝의 이 영역이
+			    trigger 안 되어 initial opacity 0 으로 잔존하던 문제. amount 0 으로 즉시 trigger. */}
+			<Reveal
+				delay={0.08}
+				amount={0}
+				className="grid grid-cols-12 gap-6 mt-16 lg:mt-20"
+			>
 				<div className="col-span-12 lg:col-span-8">
 					<p className="leading-relaxed max-w-xl" style={{ color: 'var(--paper-dim)' }}>
 						백엔드 개발자로서 더 나은 서비스를 만드는 팀에 기여하고 싶습니다.

--- a/apps/web/components/home/HomeProjects.jsx
+++ b/apps/web/components/home/HomeProjects.jsx
@@ -41,7 +41,7 @@ export default function HomeProjects({ projects = [] }) {
 			{/* 헤더 */}
 			<Reveal className="flex items-end justify-between mb-10 lg:mb-14">
 				<div>
-					<Eyebrow className="mb-4">— Selected Work, 2026</Eyebrow>
+					<Eyebrow className="mb-4">— Selected Work</Eyebrow>
 					<h2
 						className="font-general-semibold"
 						style={{
@@ -50,7 +50,7 @@ export default function HomeProjects({ projects = [] }) {
 							lineHeight: 0.88,
 						}}
 					>
-						작업들
+						Projects
 						<span style={{ color: 'var(--indigo-soft)' }}>.</span>
 					</h2>
 				</div>

--- a/apps/web/components/layout/bold/BoldHeader.jsx
+++ b/apps/web/components/layout/bold/BoldHeader.jsx
@@ -1,5 +1,8 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
+import logoLight from '../../../public/images/logo-light.svg';
+import logoDark from '../../../public/images/logo-dark.svg';
 import useThemeSwitcher from '../../../hooks/useThemeSwitcher';
 import HireMeModal from '../../HireMeModal';
 
@@ -40,26 +43,20 @@ export default function BoldHeader() {
 				<nav className="max-w-[1640px] mx-auto px-6 lg:px-12 h-16 flex items-center justify-between">
 					<Link
 						href="/"
-						className="bold-interactive flex items-center gap-3"
+						className="bold-interactive flex items-center"
 						aria-label="홈"
 					>
-						<span
-							className="w-7 h-7 rounded-md grid place-items-center"
-							style={{ background: 'var(--indigo)' }}
-						>
-							<span
-								className="text-[11px] text-white"
-								style={{ fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace' }}
-							>
-								SL
-							</span>
-						</span>
-						<span
-							className="font-general-semibold text-base"
-							style={{ letterSpacing: '-0.02em', color: 'var(--paper)' }}
-						>
-							이석호
-						</span>
+						{/* 기존 DefaultLayout 의 AppHeader 와 동일한 로고 swap 패턴.
+						    useThemeSwitcher 의 activeTheme 가 "다음 토글 값" 이라
+						    activeTheme==='dark' = 현재 light → 어두운 글자 로고(logoDark) 가 적절. */}
+						<Image
+							src={mounted && activeTheme === 'dark' ? logoDark : logoLight}
+							alt="Lagoon Portfolio"
+							className="w-28 cursor-pointer"
+							width={150}
+							height={120}
+							priority
+						/>
 					</Link>
 
 					<div className="flex items-center gap-3 sm:gap-8 text-xs sm:text-sm">

--- a/apps/web/components/primitives/Marquee.jsx
+++ b/apps/web/components/primitives/Marquee.jsx
@@ -45,7 +45,7 @@ export default function Marquee({ items = [], duration = 36, className = '' }) {
 									fontSize: '1.2rem',
 								}}
 							>
-								✦
+								·
 							</span>
 						</span>
 					))

--- a/apps/web/components/primitives/Reveal.jsx
+++ b/apps/web/components/primitives/Reveal.jsx
@@ -5,9 +5,12 @@ import useReducedMotion from '../../hooks/useReducedMotion';
 // framer-motion 의 whileInView 는 JS 모션이라 globals.css 의
 // @media (prefers-reduced-motion: reduce) 영향을 받지 않으므로
 // 여기서 직접 분기하여 plain 태그로 즉시 렌더한다.
+// amount: viewport 진입 trigger 비율 (0~1). 기본 0.15. 페이지 끝의 영역이라
+// 0.15 가 채워지기 어렵다면 호출 측에서 0 으로 줄여 즉시 trigger.
 export default function Reveal({
 	as: Tag = 'div',
 	delay = 0,
+	amount = 0.15,
 	className = '',
 	children,
 	...rest
@@ -26,7 +29,7 @@ export default function Reveal({
 		<MotionTag
 			initial={{ opacity: 0, y: 24 }}
 			whileInView={{ opacity: 1, y: 0 }}
-			viewport={{ once: true, amount: 0.15 }}
+			viewport={{ once: true, amount }}
 			transition={{ duration: 0.9, ease: [0.2, 0.7, 0.2, 1], delay }}
 			className={className}
 			{...rest}

--- a/apps/web/components/primitives/WordReveal.jsx
+++ b/apps/web/components/primitives/WordReveal.jsx
@@ -17,8 +17,14 @@ export default function WordReveal({
 		<div className={`bold-word-reveal ${className}`} style={style}>
 			{items.map((item, idx) => {
 				if (item.br) return <br key={`br-${idx}`} />;
+				// italic accent 단어의 마지막 글자가 inline-block + overflow-hidden 박스 밖으로
+				// 살짝 비져나가 잘리는 현상이 있어 paddingRight 로 박스 너비 보강.
 				const innerStyle = item.accent
-					? { color: 'var(--indigo-soft)', fontStyle: 'italic' }
+					? {
+							color: 'var(--indigo-soft)',
+							fontStyle: 'italic',
+							paddingRight: '0.1em',
+						}
 					: undefined;
 				const sep = idx < items.length - 1 && !items[idx + 1]?.br ? ' ' : '';
 

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -265,10 +265,14 @@ a {
 	--line-strong: rgba(255, 255, 255, 0.16);
 }
 
-/* BoldLayout wrapper 에 .bold-light 가 토글되어 변수 swap (DARK/LIGHT) */
+/* BoldLayout wrapper 에 .bold-light 가 토글되어 변수 swap (DARK/LIGHT).
+ * 라이트모드는 어두운 글자 + 밝은 배경이라 다크모드 톤 (60% paper-dim) 으로는 대비 부족.
+ * paper-dim 80%, paper-faint 50% 로 진하게 조정해 nav 링크 / 보조 메타 가독성 보강. */
 .bold-light {
 	--ink: #fbfaf7;
 	--paper: #0a0f17;
+	--paper-dim: color-mix(in oklab, var(--paper) 80%, transparent);
+	--paper-faint: color-mix(in oklab, var(--paper) 50%, transparent);
 	--line: rgba(13, 36, 56, 0.08);
 	--line-strong: rgba(13, 36, 56, 0.18);
 }


### PR DESCRIPTION
## 무엇을

PR #80 적용 후 dev 환경 시각 검증에서 발견된 디테일 8개 항목 일괄 fix.

### 3 commits

| commit | 내용 |
|---|---|
| \`01f4d21\` | BoldHeader 로고 자산 교체 + 라이트모드 nav 가독성 |
| \`e8da4cf\` | Hero italic clip / Marquee 구분자 / Work 카피 / About 헤드라인 |
| \`395074a\` | ContactCTA reveal trigger + 이메일 모바일 줄바꿈 |

### 항목

| # | 영역 | 변경 |
|---|---|---|
| 0-1 | 라이트모드 nav 글자 | \`--paper-dim\` 60% → 80%, \`--paper-faint\` 35% → 50% (라이트 모드만) — nav 링크/보조 메타 가독성 보강 |
| 0-2 | 헤더 아이콘 | indigo SL 박스 + '이석호' 텍스트 → 기존 \`logo-light.svg\` / \`logo-dark.svg\` swap (\`AppHeader\` 와 동일 패턴, w-28) |
| 1 | Hero '포트폴리오' 글자 잘림 | \`WordReveal\` 의 italic accent inner span 에 \`paddingRight: 0.1em\` 추가 — italic 박스 너비 보강 |
| 2 | Marquee 구분자 | \`✦\` → \`·\` (middle dot) |
| 3-1 | Work eyebrow | \`— Selected Work, 2026\` → \`— Selected Work\` |
| 3-2 | Work h2 | \`작업들.\` → \`Projects.\` |
| 4 | About 헤드라인 | 4줄 분할: \`기능 구현을 넘어 / 서비스의 안정성과 / 유지보수성을 / 고민합니다.\`. '안정성', '유지보수성' 두 단어만 indigo italic accent |
| 5-1 | 큰 이메일 모바일 줄바꿈 | \`break-all\` → \`break-words\` + 모바일 fontSize 하한 \`2.6rem\` → \`2rem\` |
| 5-2 | Contact 본문/메타 안 보임 | \`Reveal\` 에 \`amount\` prop 노출 (기본 0.15) → 호출 측에서 \`amount=0\` 으로 즉시 trigger. 페이지 끝의 영역이 0.15 viewport 교차 못 채우던 케이스 해소 |

## 왜

- 라이트모드는 그동안 거의 검증 안 된 톤 (디폴트가 light 라 사용자가 본 게 라이트). nav 안 보이는 건 critical
- italic clipping / 카피 / 줄바꿈은 사용자 직접 시각 확인 피드백
- ContactCTA 안 보임은 페이지 핵심 CTA 가 사라진 거라 가장 시급

## 영향

- \`apps/web\` 전용. \`apps/api\` / docker / CI / CD 변경 없음
- \`Reveal.amount\` prop 은 후방 호환 (기본 0.15 유지)
- \`globals.css\` 의 \`.bold-light\` 변수 진하게 변경 → Bold 페이지의 라이트 모드 paper-dim/faint 사용처 전체에 영향 (의도된 가독성 보강)

## 수동 확인 (dev 머지 후)

- [ ] **라이트모드** 토글 후 헤더 nav (Projects/About/Contact) 가독 OK
- [ ] 헤더 로고 새 svg 노출 (라이트/다크 swap)
- [ ] Hero '포트폴리오' 글자 잘림 없음
- [ ] Marquee 점 (\`·\`) 으로 구분
- [ ] Work \`— Selected Work\` + \`Projects.\`
- [ ] About 헤드라인 4줄, '안정성' / '유지보수성' 두 단어만 indigo italic
- [ ] 이메일 모바일 (375) 에서 자연스러운 줄바꿈
- [ ] Contact 본문 + GITHUB/NOTION 메타 보임
- [ ] \`prefers-reduced-motion\` 시 Reveal 즉시 표시 (모션 무관)

Refs #83 #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)