### PR TITLE
[fix] Home Bold 추가 시각 디테일 수정

### DIFF
--- a/apps/web/components/home/AboutStrip.jsx
+++ b/apps/web/components/home/AboutStrip.jsx
@@ -2,6 +2,15 @@ import Reveal from '../primitives/Reveal';
 import Eyebrow from '../primitives/Eyebrow';
 import PillButton from '../primitives/PillButton';
 
+// italic accent 가 다음 일반체 글자와 겹치는 현상 회피용 inline-block + paddingRight.
+// (Hero 의 WordReveal 과 같은 패턴.)
+const accentStyle = {
+	display: 'inline-block',
+	color: 'var(--indigo-soft)',
+	fontStyle: 'italic',
+	paddingRight: '0.1em',
+};
+
 export default function AboutStrip({ bioFirst }) {
 	// bio[0] 가 마크다운 헤더(`## 1. 한 줄 소개`) 로 시작할 수 있어 평문 렌더 시
 	// 헤더가 그대로 노출된다. 가벼운 분리로 `#` 시작 라인만 skip 하고 본문만 남긴다.
@@ -17,6 +26,22 @@ export default function AboutStrip({ bioFirst }) {
 		stripMarkdownHeaders(bioFirst) ||
 		'서비스의 동작 원리와 운영 구조를 함께 이해하며, 성능·안정성·운영 효율을 개선하는 백엔드 개발자입니다.';
 
+	// 디자인 컨벤션: 본문의 첫 번째 쉼표 다음에서 한 번 줄바꿈해 의미 단위를 분리한다.
+	// 라군 bio 의 "...이해하며, 성능·..." 케이스에 맞춰 자연스러운 호흡을 만든다.
+	// 다른 bio 가 들어올 경우 첫 쉼표 위치가 디자인 의도와 다를 수 있음 — 추후 어드민에서
+	// 줄바꿈을 직접 입력 가능하도록 백엔드 확장 검토.
+	const renderBody = (raw) => {
+		const idx = raw.indexOf(',');
+		if (idx < 0) return raw;
+		return (
+			<>
+				{raw.slice(0, idx + 1)}
+				<br />
+				{raw.slice(idx + 1).trimStart()}
+			</>
+		);
+	};
+
 	return (
 		<section
 			id="about"
@@ -24,7 +49,7 @@ export default function AboutStrip({ bioFirst }) {
 			style={{ borderColor: 'var(--line)' }}
 		>
 			<div className="grid grid-cols-12 gap-6 lg:gap-12">
-				<Reveal className="col-span-12 lg:col-span-5">
+				<Reveal className="col-span-12 lg:col-span-8">
 					<Eyebrow className="mb-4">— About</Eyebrow>
 					<h2
 						className="font-general-semibold"
@@ -36,47 +61,42 @@ export default function AboutStrip({ bioFirst }) {
 					>
 						기능 구현을 넘어
 						<br />
-						서비스의{' '}
-						<span style={{ color: 'var(--indigo-soft)', fontStyle: 'italic' }}>
-							안정성
-						</span>
-						과
+						서비스의 <span style={accentStyle}>안정성</span>과
 						<br />
-						<span style={{ color: 'var(--indigo-soft)', fontStyle: 'italic' }}>
-							유지보수성
-						</span>
-						을
+						<span style={accentStyle}>유지보수성</span>을
 						<br />
 						고민합니다.
 					</h2>
-				</Reveal>
-				<Reveal delay={0.16} className="col-span-12 lg:col-span-7">
 					<p
-						className="leading-relaxed"
+						className="leading-relaxed mt-10"
 						style={{
 							color: 'var(--paper-dim)',
 							fontSize: 'clamp(1rem, 1.2vw, 1.15rem)',
 							maxWidth: '56ch',
 						}}
 					>
-						{text}
+						{renderBody(text)}
 					</p>
-
-					<div className="mt-10">
-						<PillButton variant="ghost" as="link" href="/about" ariaLabel="About 더 보기">
-							<span>더 알아보기</span>
-							<svg
-								className="w-4 h-4"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2"
-								aria-hidden="true"
-							>
-								<path d="M5 12h14M13 6l6 6-6 6" />
-							</svg>
-						</PillButton>
-					</div>
+				</Reveal>
+				{/* 우측 col 은 grid row stretch 로 좌측 col 만큼 높이가 늘어나고,
+				    그 안에서 CTA 를 vertical center 로 정렬한다 (lg 이상). */}
+				<Reveal
+					delay={0.16}
+					className="col-span-12 lg:col-span-4 flex lg:items-center"
+				>
+					<PillButton variant="ghost" as="link" href="/about" ariaLabel="About 더 보기">
+						<span>더 알아보기</span>
+						<svg
+							className="w-4 h-4"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							aria-hidden="true"
+						>
+							<path d="M5 12h14M13 6l6 6-6 6" />
+						</svg>
+					</PillButton>
 				</Reveal>
 			</div>
 		</section>

--- a/apps/web/components/home/ContactCTA.jsx
+++ b/apps/web/components/home/ContactCTA.jsx
@@ -24,9 +24,11 @@ export default function ContactCTA({ email }) {
 					href={`mailto:${target}`}
 					className="bold-interactive block font-general-semibold hover:opacity-80 transition-opacity break-words"
 					style={{
-						// 모바일에서 큰 이메일이 break-all 로 어색하게 잘리던 문제를 해결.
-						// break-words 로 단어 경계 우선 + 모바일 fontSize 하한을 약간 낮춰 줄바꿈 횟수 자체를 줄임.
-						fontSize: 'clamp(2rem, 9vw, 8rem)',
+						// 글자수 + 화면 너비 기반 동적 폰트로 한 줄 보장.
+						// 수식: (100vw - 좌우 px-5 padding 2.5rem) / 이메일 글자수 / 영문 폭 비율(≈0.55)
+						//   = 한 줄에 fit 되는 fontSize. min(8rem, ...) 으로 큰 화면 cap.
+						// 0.55 는 GeneralSans-Semibold 의 평균 영문 글자 가로 비율 근사값.
+						fontSize: `min(8rem, calc((100vw - 2.5rem) / ${target.length} / 0.55))`,
 						letterSpacing: '-0.05em',
 						lineHeight: 1,
 						color: 'var(--paper)',
@@ -47,6 +49,7 @@ export default function ContactCTA({ email }) {
 				<div className="col-span-12 lg:col-span-8">
 					<p className="leading-relaxed max-w-xl" style={{ color: 'var(--paper-dim)' }}>
 						백엔드 개발자로서 더 나은 서비스를 만드는 팀에 기여하고 싶습니다.
+						<br />
 						언제든 편하게 연락 주세요.
 					</p>
 				</div>

--- a/apps/web/components/layout/bold/BoldFooter.jsx
+++ b/apps/web/components/layout/bold/BoldFooter.jsx
@@ -14,7 +14,7 @@ export default function BoldFooter() {
 				}}
 			>
 				<span>© {year} SEOKHO LEE — LAGOON PORTFOLIO</span>
-				<span>BUILT IN SEOUL ✦</span>
+				<span>BUILT IN SEOUL ·</span>
 			</div>
 		</footer>
 	);

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -265,6 +265,14 @@ a {
 	--line-strong: rgba(255, 255, 255, 0.16);
 }
 
+/* Bold 페이지의 한국어 본문은 단어 중간이 아닌 단어 경계에서 줄바꿈되도록 한다.
+ * CJK 의 default 는 글자 단위 줄바꿈 → 'word-break: keep-all' 로 단어 단위 유지.
+ * 너무 긴 영문 단어 (예: URL) 가 컨테이너 폭을 넘으면 break-word 로 풀어준다. */
+.bold-root p {
+	word-break: keep-all;
+	overflow-wrap: break-word;
+}
+
 /* BoldLayout wrapper 에 .bold-light 가 토글되어 변수 swap (DARK/LIGHT).
  * 라이트모드는 어두운 글자 + 밝은 배경이라 다크모드 톤 (60% paper-dim) 으로는 대비 부족.
  * paper-dim 80%, paper-faint 50% 로 진하게 조정해 nav 링크 / 보조 메타 가독성 보강. */


### PR DESCRIPTION
## 무엇을

PR #84 머지 후 dev 검증에서 발견된 추가 5개 항목 일괄 fix.

### 2 commits

| commit | 내용 |
|---|---|
| \`a1efb9f\` | About strip 레이아웃 재구성 + italic 겹침 + 본문 자동 줄바꿈 |
| \`3613bab\` | Contact 본문 줄바꿈·이메일 동적 폰트 + Footer 구분자 점 |

### 변경 항목

| # | 영역 | 변경 |
|---|---|---|
| 1 | About italic 글자 겹침 | accent span 에 \`display: inline-block + paddingRight: 0.1em\` (Hero WordReveal 패턴 재사용) |
| 2 | About 레이아웃 | 좌측 col(8) 헤드라인+본문 stack / 우측 col(4) CTA vertical center. 본문 첫 ',' 위치 자동 줄바꿈 |
| 3 | Contact 본문 | '. \n언제든' 위치에 \`<br/>\` 한 번 |
| 4 | 이메일 동적 폰트 | \`min(8rem, calc((100vw - 2.5rem) / target.length / 0.55))\` — 글자수+화면 너비 기반 한 줄 보장. 큰 화면은 8rem cap |
| 5 | Footer 구분자 | \`✦\` → \`·\` (Marquee 와 톤 통일) |

## 이메일 폰트 수식 검증

| 화면 | (100vw-40px)/18/0.55 | 적용 |
|---|---|---|
| 375 모바일 | 33.8px ≈ 2.1rem | **한 줄 안전** |
| 768 태블릿 | 77.6px ≈ 4.85rem | 4.85rem |
| 1440 데스크탑 | 141px (>128) | **min cap → 8rem** |

이메일 길이가 바뀌어도 자동 재계산.

## 영향

- \`apps/web\` 전용. \`apps/api\` / docker / CI / CD 변경 없음
- About stat / availability / contactEmail 등 백엔드 필드 확장은 별도 후속 PR
- 본문 첫 ',' 자동 줄바꿈은 라군 bio 에 자연스러움 — 다른 bio 케이스에는 어색할 수 있음. 향후 어드민에서 줄바꿈 직접 입력 가능하도록 백엔드 확장 검토 가능

## 수동 확인 (dev 머지 후)

- [ ] About italic 글자 겹침 없음 (안정성 / 유지보수성)
- [ ] About 본문 좌측 헤드라인 아래
- [ ] About 본문 첫 ',' 후 줄바꿈
- [ ] '더 알아보기' 우측 col vertical center
- [ ] Contact 본문 두 줄
- [ ] 이메일 모바일(375) 한 줄, 데스크탑 큰 글씨 유지
- [ ] Footer \`BUILT IN SEOUL ·\`

Closes #85
Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)