### PR TITLE
[feat] Home 페이지 애니메이션/인터랙션 polish 7건

### DIFF
--- a/apps/web/components/home/ContactCTA.jsx
+++ b/apps/web/components/home/ContactCTA.jsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import Reveal from '../primitives/Reveal';
 import Eyebrow from '../primitives/Eyebrow';
+import Toast from '../primitives/Toast';
 
 // 환경변수 미설정 시 fallback. 후속 PR 에서 about.contactEmail 필드 도입 시 SSR 로 교체.
 const DEFAULT_EMAIL =
@@ -11,6 +13,19 @@ const NOTION_URL =
 
 export default function ContactCTA({ email }) {
 	const target = email || DEFAULT_EMAIL;
+	const [toastVisible, setToastVisible] = useState(false);
+
+	// mailto 기본 동작은 유지하면서 클립보드 복사 + 토스트.
+	// clipboard API 가 지원 안 되거나 실패하면 fallback 없이 silent — mailto 는 정상 동작.
+	const handleEmailClick = (e) => {
+		if (typeof navigator !== 'undefined' && navigator.clipboard) {
+			navigator.clipboard
+				.writeText(target)
+				.then(() => setToastVisible(true))
+				.catch(() => undefined);
+		}
+		// mailto 는 default 동작에 맡김 — preventDefault 안 함.
+	};
 
 	return (
 		<section
@@ -22,6 +37,7 @@ export default function ContactCTA({ email }) {
 				<Eyebrow className="mb-6">— Let&apos;s talk</Eyebrow>
 				<a
 					href={`mailto:${target}`}
+					onClick={handleEmailClick}
 					className="bold-interactive block font-general-semibold hover:opacity-80 transition-opacity break-words"
 					style={{
 						// 글자수 + 화면 너비 기반 동적 폰트로 한 줄 보장.
@@ -88,6 +104,11 @@ export default function ContactCTA({ email }) {
 					</div>
 				</div>
 			</Reveal>
+			<Toast
+				visible={toastVisible}
+				message="이메일 주소가 복사됐어요"
+				onClose={() => setToastVisible(false)}
+			/>
 		</section>
 	);
 }

--- a/apps/web/components/home/ContactCTA.jsx
+++ b/apps/web/components/home/ContactCTA.jsx
@@ -25,10 +25,12 @@ export default function ContactCTA({ email }) {
 					className="bold-interactive block font-general-semibold hover:opacity-80 transition-opacity break-words"
 					style={{
 						// 글자수 + 화면 너비 기반 동적 폰트로 한 줄 보장.
-						// 수식: (100vw - 좌우 px-5 padding 2.5rem) / 이메일 글자수 / 영문 폭 비율(≈0.55)
+						// 수식: (100vw - 좌우 padding + 안전 마진 3rem) / (이메일 글자수 + 끝 '.' 1)
+						//        / 영문 폭 비율(≈0.7)
 						//   = 한 줄에 fit 되는 fontSize. min(8rem, ...) 으로 큰 화면 cap.
-						// 0.55 는 GeneralSans-Semibold 의 평균 영문 글자 가로 비율 근사값.
-						fontSize: `min(8rem, calc((100vw - 2.5rem) / ${target.length} / 0.55))`,
+						// 비율 0.7 은 GeneralSans-Semibold 의 영문 평균 폭 + 다양한 글자 폭 차이
+						// (m/w/@ wider) 까지 고려한 보수값. 첫 시도 0.55 는 줄바꿈 발생.
+						fontSize: `min(8rem, calc((100vw - 3rem) / ${target.length + 1} / 0.7))`,
 						letterSpacing: '-0.05em',
 						lineHeight: 1,
 						color: 'var(--paper)',

--- a/apps/web/components/home/HomeProjectCard.jsx
+++ b/apps/web/components/home/HomeProjectCard.jsx
@@ -1,6 +1,12 @@
 import Link from 'next/link';
 import Image from 'next/image';
 
+// 이미지 로드 전 placeholder — Bold 톤의 ink(#070E17) 4:5 단색 SVG dataURL.
+// next/image 의 placeholder="blur" 가 자동 블러 + fade-in 처리. 외부 URL/uploads 라
+// blurDataURL 자동 생성이 안 되므로 명시.
+const INK_BLUR =
+	'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0IDUiPjxyZWN0IHdpZHRoPSI0IiBoZWlnaHQ9IjUiIGZpbGw9IiMwNzBFMTciLz48L3N2Zz4=';
+
 // 4:5 카드 — 번호 / 카테고리 / 호버 화살표 회전.
 // img src 는 /uploads/... 형태일 수 있고, 외부 URL 일 수도 있음.
 // next.config.js rewrites 가 /uploads/* 를 API 로 프록시.
@@ -56,6 +62,8 @@ export default function HomeProjectCard({ index, project }) {
 						fill
 						sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
 						style={{ objectFit: 'cover' }}
+						placeholder="blur"
+						blurDataURL={INK_BLUR}
 						className="transition-transform duration-1000 group-hover:scale-[1.06]"
 					/>
 				) : (

--- a/apps/web/components/layout/bold/BoldFooter.jsx
+++ b/apps/web/components/layout/bold/BoldFooter.jsx
@@ -1,4 +1,6 @@
-// Bold 페이지 공통 푸터. 한 줄 좌우 분할.
+import Reveal from '../../primitives/Reveal';
+
+// Bold 페이지 공통 푸터. 한 줄 좌우 분할 + 진입 시 fade reveal.
 export default function BoldFooter() {
 	const year = new Date().getFullYear();
 	return (
@@ -6,16 +8,18 @@ export default function BoldFooter() {
 			className="py-10 border-t mt-0"
 			style={{ borderColor: 'var(--line)' }}
 		>
-			<div
-				className="flex items-center justify-between text-xs gap-4"
-				style={{
-					fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
-					color: 'var(--paper-faint)',
-				}}
-			>
-				<span>© {year} SEOKHO LEE — LAGOON PORTFOLIO</span>
-				<span>BUILT IN SEOUL ·</span>
-			</div>
+			<Reveal amount={0}>
+				<div
+					className="flex items-center justify-between text-xs gap-4"
+					style={{
+						fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+						color: 'var(--paper-faint)',
+					}}
+				>
+					<span>© {year} SEOKHO LEE — LAGOON PORTFOLIO</span>
+					<span>BUILT IN SEOUL ·</span>
+				</div>
+			</Reveal>
 		</footer>
 	);
 }

--- a/apps/web/components/layout/bold/BoldHeader.jsx
+++ b/apps/web/components/layout/bold/BoldHeader.jsx
@@ -15,6 +15,10 @@ const navLinks = [
 export default function BoldHeader() {
 	const [activeTheme, setTheme, mounted] = useThemeSwitcher();
 	const [showModal, setShowModal] = useState(false);
+	// 토글 클릭 횟수 — 매 클릭마다 ◐ 아이콘이 한 바퀴 더 돈다 (180deg 가 자연).
+	const [toggleSpin, setToggleSpin] = useState(0);
+	// scrollY > 50 일 때 헤더 backdrop 강화 (hero 위에서는 얕고, 본문에서는 진해짐).
+	const [scrolled, setScrolled] = useState(false);
 
 	// showModal 변화에 따라 <html> overflow-y-hidden 동기화.
 	// unmount 시점에도 반드시 해제 (모달 열린 상태로 페이지 이동 시 lock 잔존 방지).
@@ -27,17 +31,33 @@ export default function BoldHeader() {
 		};
 	}, [showModal]);
 
+	// scroll 위치 따라 backdrop opacity 단계 토글. passive listener.
+	useEffect(() => {
+		if (typeof window === 'undefined') return undefined;
+		const update = () => setScrolled(window.scrollY > 50);
+		update();
+		window.addEventListener('scroll', update, { passive: true });
+		return () => window.removeEventListener('scroll', update);
+	}, []);
+
 	const toggleModal = () => {
 		setShowModal((v) => !v);
+	};
+
+	const handleThemeToggle = () => {
+		setTheme(activeTheme);
+		setToggleSpin((n) => n + 1);
 	};
 
 	return (
 		<>
 			<header
-				className="fixed top-0 inset-x-0 z-50 backdrop-blur-md border-b"
+				className="fixed top-0 inset-x-0 z-50 backdrop-blur-md border-b transition-[background,border-color] duration-300"
 				style={{
-					background: 'color-mix(in oklab, var(--ink) 70%, transparent)',
-					borderColor: 'var(--line)',
+					background: scrolled
+						? 'color-mix(in oklab, var(--ink) 88%, transparent)'
+						: 'color-mix(in oklab, var(--ink) 60%, transparent)',
+					borderColor: scrolled ? 'var(--line-strong)' : 'var(--line)',
 				}}
 			>
 				<nav className="max-w-[1640px] mx-auto px-6 lg:px-12 h-16 flex items-center justify-between">
@@ -77,7 +97,7 @@ export default function BoldHeader() {
 					<div className="flex items-center gap-2 sm:gap-3">
 						<button
 							type="button"
-							onClick={() => setTheme(activeTheme)}
+							onClick={handleThemeToggle}
 							aria-label="테마 전환"
 							className="bold-interactive text-xs rounded-full px-2.5 sm:px-3 py-1.5 transition"
 							style={{
@@ -89,7 +109,13 @@ export default function BoldHeader() {
 							<span className="hidden sm:inline">
 								{mounted ? (activeTheme === 'dark' ? 'LIGHT' : 'DARK') : 'DARK / LIGHT'}
 							</span>
-							<span className="sm:hidden" aria-hidden="true">◐</span>
+							<span
+								className="sm:hidden inline-block transition-transform duration-500 ease-[cubic-bezier(0.2,0.7,0.2,1)]"
+								style={{ transform: `rotate(${toggleSpin * 180}deg)` }}
+								aria-hidden="true"
+							>
+								◐
+							</span>
 						</button>
 						<button
 							type="button"

--- a/apps/web/components/primitives/PillButton.jsx
+++ b/apps/web/components/primitives/PillButton.jsx
@@ -24,7 +24,8 @@ export default function PillButton({
 		color: 'var(--paper)',
 		background: 'rgba(255, 255, 255, 0.02)',
 	};
-	const baseClass = `bold-interactive inline-flex items-center gap-2 font-general-medium text-[15px] rounded-full transition-all duration-300 ${
+	// 'bold-pill' 클래스로 hover 시 자식 svg 가 살짝 미세 이동 (globals.css 에서 정의).
+	const baseClass = `bold-interactive bold-pill inline-flex items-center gap-2 font-general-medium text-[15px] rounded-full transition-all duration-300 ${
 		isCTA
 			? 'px-[1.4rem] py-[0.85rem] hover:-translate-y-[2px]'
 			: 'px-[1.3rem] py-[0.8rem]'

--- a/apps/web/components/primitives/Toast.jsx
+++ b/apps/web/components/primitives/Toast.jsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+
+// 우상단 inline 토스트. visible 가 true 일 때 잠시 노출 후 onClose 콜백으로 자동 dismiss.
+// reduced-motion 영향 — transition 짧게라 글로벌 룰이 자동 비활성.
+export default function Toast({ visible, message, onClose, duration = 2000 }) {
+	useEffect(() => {
+		if (!visible) return undefined;
+		const t = setTimeout(() => onClose?.(), duration);
+		return () => clearTimeout(t);
+	}, [visible, duration, onClose]);
+
+	return (
+		<div
+			role="status"
+			aria-live="polite"
+			className="fixed z-[80] left-1/2 -translate-x-1/2 bottom-8 px-4 py-2.5 rounded-full text-sm pointer-events-none"
+			style={{
+				background: 'var(--paper)',
+				color: 'var(--ink)',
+				fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+				boxShadow: '0 8px 30px -10px rgba(0,0,0,0.3)',
+				opacity: visible ? 1 : 0,
+				transform: visible
+					? 'translate(-50%, 0)'
+					: 'translate(-50%, 12px)',
+				transition: 'opacity 0.2s ease, transform 0.2s ease',
+			}}
+		>
+			{message}
+		</div>
+	);
+}

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -265,6 +265,22 @@ a {
 	--line-strong: rgba(255, 255, 255, 0.16);
 }
 
+/* 앵커 클릭(#work 등) 시 즉시 점프가 아닌 부드러운 스크롤.
+ * Bold 페이지의 '작업 보기' 같은 CTA 가 자연스럽게 동작한다.
+ * reduced-motion 글로벌 룰이 scroll-behavior: auto 로 자동 override. */
+html {
+	scroll-behavior: smooth;
+}
+
+/* Bold 페이지 wrapper 의 DARK/LIGHT 전환 시 색상을 부드럽게 보간.
+ * CSS 변수 자체는 보간되지 않지만, background-color/color 의 변경은
+ * transition 대상이 되어 즉시 점프가 아닌 fade 가 일어난다. */
+.bold-root {
+	transition:
+		background-color 0.4s cubic-bezier(0.2, 0.7, 0.2, 1),
+		color 0.4s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
 /* Bold 페이지의 한국어 본문은 단어 중간이 아닌 단어 경계에서 줄바꿈되도록 한다.
  * CJK 의 default 는 글자 단위 줄바꿈 → 'word-break: keep-all' 로 단어 단위 유지.
  * 너무 긴 영문 단어 (예: URL) 가 컨테이너 폭을 넘으면 break-word 로 풀어준다. */

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -265,6 +265,16 @@ a {
 	--line-strong: rgba(255, 255, 255, 0.16);
 }
 
+/* PillButton 의 자식 svg 가 hover 시 살짝 오른쪽으로 미세 이동.
+ * 화살표 / 외부 링크 아이콘 등 모든 CTA arrow 에 일관된 micro feedback.
+ * cubic-bezier 는 다른 Bold 모션 (Reveal/WordReveal/Marquee) 과 통일. */
+.bold-pill svg {
+	transition: transform 0.3s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+.bold-pill:hover svg {
+	transform: translateX(3px);
+}
+
 /* 앵커 클릭(#work 등) 시 즉시 점프가 아닌 부드러운 스크롤.
  * Bold 페이지의 '작업 보기' 같은 CTA 가 자연스럽게 동작한다.
  * reduced-motion 글로벌 룰이 scroll-behavior: auto 로 자동 override. */


### PR DESCRIPTION
## 무엇을

Home Bold 페이지의 인터랙션 부드러움/사용성 보강. 5 commits.

### Commits

| commit | 내용 |
|---|---|
| \`becf6dc\` | 이메일 동적 폰트 폭 비율·안전 마진 보정 (PR #86 후속 fix, dev preview 확정값) |
| \`32bfcaf\` | 글로벌 smooth scroll · DARK/LIGHT 색 transition · Footer reveal (A부분 + B + I) |
| \`a7d6577\` | BoldHeader 테마 토글 아이콘 회전 · scroll-adaptive backdrop (A + C) |
| \`d95f6cc\` | PillButton arrow micro hover · ProjectCard image blur placeholder (B + D + F) |
| \`59f6f30\` | Contact 이메일 클릭 시 클립보드 복사 · 토스트 알림 (H) |

### 항목 매핑

| 키 | 영역 | 변경 |
|---|---|---|
| A | DARK/LIGHT 전환 | wrapper background-color/color transition 0.4s + 토글 ◐ 아이콘 180deg 회전 |
| B | 앵커 클릭 부드러운 스크롤 | \`html { scroll-behavior: smooth }\` 글로벌. '작업 보기' → \`#work\` 부드러운 스크롤 + PillButton arrow micro hover |
| C | Header backdrop 적응 | scroll 50px 초과 시 ink 60%→88% + border line→line-strong. transition 300ms |
| D | CTA arrow micro | \`.bold-pill svg\` hover 시 translateX(3px). cta/ghost 모두 일관 |
| F | Image blur placeholder | next/image \`placeholder='blur'\` + ink 색 SVG dataURL. 외부 URL/uploads 로드 부드러움 |
| H | 이메일 복사 + 토스트 | navigator.clipboard.writeText + Toast primitive. mailto 도 동시 동작 |
| I | Footer reveal | BoldFooter Reveal 래핑 (amount=0 즉시 trigger) |

### 보류 (별도 PR / 사용자 결정)

- **K**: 카드 클릭 시 expand 후 라우팅 (framer-motion layoutId, 시안 톤 큰 변경)
- **J**: 페이지 이동 시 ink 색 cover overlay fade (기존 motion fade+y 와 호불호)
- **E**: Marquee hover pause (사용자 결정)
- **G**: Hero 들어올 때 grain pulse (사용자 결정)

## 영향

- \`apps/web\` 전용. \`apps/api\` 변경 없음
- 신규 컴포넌트: \`primitives/Toast.jsx\` (재사용 가능 inline 토스트)
- 신규 클래스: \`.bold-pill\` (globals.css 에 svg hover micro 정의)
- 기존 컴포넌트 동작 변화 없음 — 모두 progressive enhancement

## 수동 확인 (dev 머지 후)

- [ ] DARK/LIGHT 토글 — 즉시 점프 아닌 0.4s 색 fade
- [ ] 모바일 토글 ◐ 아이콘 클릭마다 180deg 회전
- [ ] '작업 보기' 클릭 → #work 까지 부드러운 스크롤
- [ ] 페이지 스크롤 50px 후 헤더 backdrop 더 진해짐
- [ ] CTA 버튼 hover 시 화살표 살짝 오른쪽 이동
- [ ] 프로젝트 카드 이미지 로드 시 ink 색 placeholder 후 fade-in
- [ ] 큰 이메일 클릭 → mailto 열림 + 토스트 노출 + 2초 후 dismiss
- [ ] Footer 진입 시 fade reveal
- [ ] \`prefers-reduced-motion\` 시 transition/scroll/모션 비활성

Refs #87 #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)