### PR TITLE
[feat] About 페이지 Bold 리디자인 (UI 우선)

### DIFF
--- a/apps/web/components/about/bold/AboutBioSection.jsx
+++ b/apps/web/components/about/bold/AboutBioSection.jsx
@@ -1,0 +1,59 @@
+import ReactMarkdown from 'react-markdown';
+import Reveal from '../../primitives/Reveal';
+import Eyebrow from '../../primitives/Eyebrow';
+
+// bio[] 의 각 단락을 ReactMarkdown 으로 단락 보존 렌더.
+// Home 의 stripMarkdownHeaders 와 다른 처리 — About 은 마크다운 헤더 / 강조 / 리스트
+// 모두 시각화 필요.
+export default function AboutBioSection({ bio = [] }) {
+	return (
+		<section
+			className="py-20 lg:py-24 border-t"
+			style={{ borderColor: 'var(--line)' }}
+		>
+			<div className="grid grid-cols-12 gap-6 lg:gap-12">
+				<Reveal className="col-span-12 lg:col-span-4">
+					<div className="lg:sticky lg:top-28">
+						<Eyebrow className="mb-3">— Bio</Eyebrow>
+						<h2
+							className="font-general-semibold"
+							style={{
+								fontSize: 'clamp(1.8rem, 3vw, 2.6rem)',
+								letterSpacing: '-0.04em',
+								lineHeight: 1,
+							}}
+						>
+							코드를 쓰지만,
+							<br />
+							<span
+								style={{
+									display: 'inline-block',
+									color: 'var(--indigo-soft)',
+									fontStyle: 'italic',
+									paddingRight: '0.1em',
+								}}
+							>
+								팀의 시간을
+							</span>
+							<br />
+							벌어줍니다.
+						</h2>
+					</div>
+				</Reveal>
+				<Reveal delay={0.08} className="col-span-12 lg:col-span-8">
+					<div className="bold-prose">
+						{bio.length === 0 ? (
+							<p style={{ color: 'var(--paper-dim)' }}>
+								자기소개가 아직 등록되지 않았습니다.
+							</p>
+						) : (
+							bio.map((paragraph, idx) => (
+								<ReactMarkdown key={idx}>{paragraph}</ReactMarkdown>
+							))
+						)}
+					</div>
+				</Reveal>
+			</div>
+		</section>
+	);
+}

--- a/apps/web/components/about/bold/AboutBrands.jsx
+++ b/apps/web/components/about/bold/AboutBrands.jsx
@@ -1,0 +1,89 @@
+import Reveal from '../../primitives/Reveal';
+import Eyebrow from '../../primitives/Eyebrow';
+
+// 시안의 'Companies' 섹션을 라군의 신입 컨텍스트에 맞게 'Tech Stack' 으로 의미 재정의.
+// 후속 PR 에서 백엔드 keywords[] 또는 stacks[] 필드 도입 시 동적화.
+const STACKS = [
+	'NestJS',
+	'Express',
+	'TypeScript',
+	'MySQL',
+	'MongoDB',
+	'Redis',
+	'Docker',
+	'Grafana / Loki',
+];
+
+export default function AboutBrands() {
+	return (
+		<section
+			className="py-20 lg:py-24 border-t"
+			style={{ borderColor: 'var(--line)' }}
+		>
+			<Reveal className="flex items-end justify-between mb-10 lg:mb-14">
+				<div>
+					<Eyebrow className="mb-3">— Tech Stack</Eyebrow>
+					<h2
+						className="font-general-semibold"
+						style={{
+							fontSize: 'clamp(1.8rem, 3.6vw, 2.8rem)',
+							letterSpacing: '-0.04em',
+							lineHeight: 0.88,
+						}}
+					>
+						실제로 다뤄본 도구들
+						<span style={{ color: 'var(--indigo-soft)' }}>.</span>
+					</h2>
+				</div>
+				<div
+					className="hidden md:block text-xs"
+					style={{
+						fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+						color: 'var(--paper-faint)',
+					}}
+				>
+					CORE · {String(STACKS.length).padStart(2, '0')}
+				</div>
+			</Reveal>
+
+			<div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3 lg:gap-4">
+				{STACKS.map((label, idx) => (
+					<Reveal key={label} delay={(idx % 4) * 0.06}>
+						<div
+							className="bold-interactive grid place-items-center rounded-[12px] transition-all"
+							style={{
+								aspectRatio: '5 / 2',
+								border: '1px solid var(--line)',
+								transitionProperty: 'border-color, background',
+								transitionDuration: '0.3s',
+							}}
+							onMouseEnter={(e) => {
+								e.currentTarget.style.borderColor = 'var(--line-strong)';
+								e.currentTarget.style.background = 'rgba(255,255,255,0.02)';
+								const lbl = e.currentTarget.querySelector('span');
+								if (lbl) lbl.style.color = 'var(--paper)';
+							}}
+							onMouseLeave={(e) => {
+								e.currentTarget.style.borderColor = 'var(--line)';
+								e.currentTarget.style.background = 'transparent';
+								const lbl = e.currentTarget.querySelector('span');
+								if (lbl) lbl.style.color = 'var(--paper-faint)';
+							}}
+						>
+							<span
+								className="font-general-semibold transition-colors"
+								style={{
+									fontSize: 'clamp(1rem, 1.4vw, 1.4rem)',
+									letterSpacing: '0.04em',
+									color: 'var(--paper-faint)',
+								}}
+							>
+								{label}
+							</span>
+						</div>
+					</Reveal>
+				))}
+			</div>
+		</section>
+	);
+}

--- a/apps/web/components/about/bold/AboutContactCTA.jsx
+++ b/apps/web/components/about/bold/AboutContactCTA.jsx
@@ -1,0 +1,78 @@
+import Reveal from '../../primitives/Reveal';
+import Eyebrow from '../../primitives/Eyebrow';
+import PillButton from '../../primitives/PillButton';
+
+const NOTION_RESUME_URL =
+	'https://dear-sawfish-e55.notion.site/15fd6568ef4b80509953d6e7648258dd?source=copy_link';
+
+export default function AboutContactCTA() {
+	return (
+		<section
+			className="py-24 lg:py-32 border-t"
+			style={{ borderColor: 'var(--line)' }}
+		>
+			<div className="grid grid-cols-12 gap-6 items-end">
+				<Reveal className="col-span-12 lg:col-span-8">
+					<Eyebrow className="mb-6">— Let&apos;s talk</Eyebrow>
+					<PillButton
+						as="link"
+						href="/contact"
+						variant="ghost"
+						className="block !rounded-none !border-0 !bg-transparent !p-0 hover:!translate-y-0"
+						ariaLabel="Contact 페이지로 이동"
+					>
+						<span
+							className="font-general-semibold hover:opacity-80 transition-opacity"
+							style={{
+								fontSize: 'clamp(2.4rem, 8vw, 7rem)',
+								letterSpacing: '-0.05em',
+								lineHeight: 1,
+							}}
+						>
+							함께 일해
+							<br />
+							<span style={{ color: 'var(--indigo-soft)' }}>볼까요?</span>
+						</span>
+					</PillButton>
+				</Reveal>
+				<Reveal
+					delay={0.08}
+					className="col-span-12 lg:col-span-4 lg:text-right flex flex-wrap gap-3 lg:justify-end"
+				>
+					<PillButton variant="cta" as="link" href="/contact" ariaLabel="Contact Me">
+						<span>Contact Me</span>
+						<svg
+							className="w-4 h-4"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							aria-hidden="true"
+						>
+							<path d="M7 17L17 7M9 7h8v8" />
+						</svg>
+					</PillButton>
+					<PillButton
+						variant="ghost"
+						href={NOTION_RESUME_URL}
+						target="_blank"
+						rel="noopener noreferrer"
+						ariaLabel="이력서 보기 (새 탭)"
+					>
+						<span>이력서 보기</span>
+						<svg
+							className="w-4 h-4"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							aria-hidden="true"
+						>
+							<path d="M7 17L17 7M9 7h8v8" />
+						</svg>
+					</PillButton>
+				</Reveal>
+			</div>
+		</section>
+	);
+}

--- a/apps/web/components/about/bold/AboutCounters.jsx
+++ b/apps/web/components/about/bold/AboutCounters.jsx
@@ -1,0 +1,100 @@
+import Reveal from '../../primitives/Reveal';
+import Eyebrow from '../../primitives/Eyebrow';
+import StatCounter from '../../primitives/StatCounter';
+
+// 후속 PR 에서 /api/about.stats[] 도입 시 props 로 교체. 현재는 라군 profile.md
+// 기반 하드코딩 — 신입이라 'Years of experience' 같은 시안 placeholder 는 부적합.
+const STATS = [
+	{
+		end: 6,
+		label: 'Shipped Projects',
+		sub: '운영 / 외주 / 팀 프로젝트',
+	},
+	{
+		end: 333,
+		suffix: 'ms',
+		label: 'API Response',
+		sub: '베팅덕 — Redis 큐 적용 후 (1441ms 에서 단축)',
+	},
+	{
+		end: 77,
+		suffix: '%',
+		label: 'Query Cut',
+		sub: '클래스업 — MongoDB 복합 인덱싱',
+	},
+	{
+		end: 0,
+		suffix: '건',
+		label: '야간 호출',
+		sub: '최근 운영 기간',
+	},
+];
+
+export default function AboutCounters() {
+	return (
+		<section
+			className="py-20 lg:py-24 border-t"
+			style={{ borderColor: 'var(--line)' }}
+		>
+			<Reveal className="flex items-end justify-between mb-10 lg:mb-14">
+				<div>
+					<Eyebrow className="mb-3">— In numbers</Eyebrow>
+					<h2
+						className="font-general-semibold"
+						style={{
+							fontSize: 'clamp(2rem, 4vw, 3.4rem)',
+							letterSpacing: '-0.04em',
+							lineHeight: 0.88,
+						}}
+					>
+						측정된 흔적
+						<span style={{ color: 'var(--indigo-soft)' }}>.</span>
+					</h2>
+				</div>
+				<div
+					className="hidden md:block text-xs"
+					style={{
+						fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+						color: 'var(--paper-faint)',
+					}}
+				>
+					UPDATED 2026.05
+				</div>
+			</Reveal>
+
+			<div className="grid grid-cols-2 lg:grid-cols-4 gap-x-8 gap-y-10">
+				{STATS.map((stat, idx) => (
+					<Reveal key={stat.label} delay={idx * 0.08}>
+						<div
+							className="pt-[1.4rem]"
+							style={{ borderTop: '1px solid var(--line-strong)' }}
+						>
+							<div
+								className="font-general-semibold"
+								style={{
+									fontSize: 'clamp(3rem, 7vw, 5.5rem)',
+									letterSpacing: '-0.05em',
+									lineHeight: 1,
+									background:
+										'linear-gradient(180deg, var(--paper) 0%, color-mix(in oklab, var(--paper) 55%, transparent) 100%)',
+									WebkitBackgroundClip: 'text',
+									backgroundClip: 'text',
+									color: 'transparent',
+								}}
+							>
+								<StatCounter end={stat.end} suffix={stat.suffix} />
+							</div>
+							<Eyebrow className="mt-3">{stat.label}</Eyebrow>
+							<div
+								className="text-sm mt-1"
+								style={{ color: 'var(--paper-dim)' }}
+							>
+								{stat.sub}
+							</div>
+						</div>
+					</Reveal>
+				))}
+			</div>
+		</section>
+	);
+}

--- a/apps/web/components/about/bold/AboutHero.jsx
+++ b/apps/web/components/about/bold/AboutHero.jsx
@@ -1,0 +1,137 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import Reveal from '../../primitives/Reveal';
+import WordReveal from '../../primitives/WordReveal';
+import Eyebrow from '../../primitives/Eyebrow';
+
+export default function AboutHero({ name, tagline, profileImage }) {
+	const displayName = name || '이석호';
+	const heroTagline =
+		tagline ||
+		'서비스의 동작 원리와 운영 구조를 함께 이해하며, 성능·안정성·운영 효율을 개선하는 백엔드 개발자입니다.';
+
+	return (
+		<section className="pt-28 lg:pt-40 pb-16 lg:pb-24">
+			{/* 상단 breadcrumb + status row */}
+			<Reveal className="flex items-center justify-between mb-10">
+				<div className="flex items-center gap-3">
+					<Link
+						href="/"
+						className="bold-interactive flex items-center gap-1.5 transition"
+						style={{
+							fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+							fontSize: '0.75rem',
+							color: 'var(--paper-faint)',
+						}}
+					>
+						<svg
+							className="w-3 h-3"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							aria-hidden="true"
+						>
+							<path d="M19 12H5M12 19l-7-7 7-7" />
+						</svg>
+						홈
+					</Link>
+					<span className="w-6 h-px" style={{ background: 'var(--line-strong)' }} />
+					<Eyebrow>About — 2026</Eyebrow>
+				</div>
+				<div className="hidden sm:flex items-center gap-2">
+					<span className="relative flex h-2 w-2">
+						<span
+							className="absolute inline-flex h-full w-full rounded-full opacity-75 animate-ping"
+							style={{ background: '#22c55e' }}
+						/>
+						<span
+							className="relative inline-flex rounded-full h-2 w-2"
+							style={{ background: '#22c55e' }}
+						/>
+					</span>
+					<Eyebrow>신입 채용 검토 중</Eyebrow>
+				</div>
+			</Reveal>
+
+			{/* 거대 이름 + portrait */}
+			<div className="grid grid-cols-12 gap-6 lg:gap-12 items-end">
+				<div className="col-span-12 lg:col-span-8">
+					<WordReveal
+						className="font-general-semibold"
+						style={{
+							fontSize: 'clamp(2.6rem, 10.5vw, 11rem)',
+							letterSpacing: '-0.04em',
+							lineHeight: 0.88,
+						}}
+						items={[
+							{ text: '안녕,' },
+							{ text: '저는' },
+							{ br: true },
+							{ text: displayName, accent: true },
+							{ text: '입니다.' },
+						]}
+					/>
+				</div>
+				<Reveal delay={0.16} className="col-span-12 lg:col-span-4">
+					<div
+						className="relative rounded-[18px] overflow-hidden"
+						style={{
+							border: '1px solid var(--line-strong)',
+							aspectRatio: '4 / 5',
+							background:
+								'linear-gradient(135deg, rgba(99,102,241,0.25), rgba(99,102,241,0.04))',
+							boxShadow: '0 30px 80px -20px rgba(0,0,0,0.6)',
+						}}
+					>
+						{profileImage ? (
+							<Image
+								src={profileImage}
+								alt={`${displayName} 프로필`}
+								fill
+								sizes="(min-width: 1024px) 33vw, 80vw"
+								style={{ objectFit: 'cover' }}
+								priority
+							/>
+						) : null}
+						{/* 하단 어둠 veil */}
+						<div
+							className="absolute inset-0 pointer-events-none"
+							style={{
+								background:
+									'linear-gradient(180deg, transparent 60%, rgba(7,14,23,0.5))',
+							}}
+							aria-hidden="true"
+						/>
+						<div
+							className="absolute left-[14px] right-[14px] bottom-[14px] z-[2] flex items-end justify-between"
+							style={{
+								fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+								fontSize: '10px',
+								letterSpacing: '0.12em',
+								color: 'rgba(255,255,255,0.85)',
+							}}
+						>
+							<span>SEOUL · KST</span>
+							<span>BACKEND</span>
+						</div>
+					</div>
+				</Reveal>
+			</div>
+
+			{/* 큰 tagline */}
+			<Reveal
+				as="p"
+				delay={0.24}
+				className="mt-12 lg:mt-16 max-w-3xl font-general-semibold"
+				style={{
+					fontSize: 'clamp(1.4rem, 2.2vw, 2.4rem)',
+					lineHeight: 1.2,
+					letterSpacing: '-0.02em',
+				}}
+			>
+				{heroTagline}
+			</Reveal>
+		</section>
+	);
+}

--- a/apps/web/components/about/bold/AboutHero.jsx
+++ b/apps/web/components/about/bold/AboutHero.jsx
@@ -60,15 +60,18 @@ export default function AboutHero({ name, tagline, profileImage }) {
 					<WordReveal
 						className="font-general-semibold"
 						style={{
+							// 큰 글씨에서 lineHeight 0.88 은 한국어 자모가 윗줄 / 아랫줄 사이 겹쳐 보임.
+							// 1.0 으로 늘려 여백 확보 (Bold 톤 유지하면서 가독성 우선).
 							fontSize: 'clamp(2.6rem, 10.5vw, 11rem)',
 							letterSpacing: '-0.04em',
-							lineHeight: 0.88,
+							lineHeight: 1.0,
 						}}
 						items={[
-							{ text: '안녕,' },
-							{ text: '저는' },
+							{ text: '안녕하세요,' },
 							{ br: true },
-							{ text: displayName, accent: true },
+							{ text: '개발자' },
+							// noSep: '이석호' + '입니다.' 사이 공백 없이 자연스러운 한국어 결합.
+							{ text: displayName, accent: true, noSep: true },
 							{ text: '입니다.' },
 						]}
 					/>

--- a/apps/web/components/about/bold/AboutJourney.jsx
+++ b/apps/web/components/about/bold/AboutJourney.jsx
@@ -1,0 +1,119 @@
+import Reveal from '../../primitives/Reveal';
+import Eyebrow from '../../primitives/Eyebrow';
+
+// 라군 profile.md / projects.md 기반. 후속 PR 에서 /api/about.journey[] 도입.
+const JOURNEY = [
+	{
+		year: '2026.01 — Now',
+		title: '통합 로그 시스템',
+		role: '백엔드 · 외주',
+		body: '여러 보안 솔루션 로그를 공통 스키마로 정규화하고 syslog-ng / Vector / Loki / Grafana / Teams 알림 / MCP 자연어 조회를 연결한 통합 파이프라인 구성. NestJS MCP 서버 직접 구현.',
+	},
+	{
+		year: '2025.08 — 2025.10',
+		title: '클래스업 학생앱 — 타이머 서비스',
+		role: '백엔드 · Express / MongoDB',
+		body: 'Joi 검증·전역 에러 처리·응답 형식 통일. MongoDB 복합 인덱싱으로 쿼리 77% 단축, 키셋 페이지네이션 30% 단축. WebSocket 기반 실시간 사용자 리스트.',
+	},
+	{
+		year: '2025',
+		title: '베팅덕 — 실시간 베팅 서비스',
+		role: '백엔드 · Redis 큐 / 비동기',
+		body: '베팅 종료 API 의 병목을 분석하고 Redis 기반 큐와 비동기 처리를 적용해 응답 시간을 1441ms → 333ms 로 단축.',
+	},
+	{
+		year: '2024',
+		title: 'CaTs 챗봇 · 커스텀 웹 프레임워크',
+		role: '백엔드 · 원리 학습',
+		body: 'RAG 기반 챗봇과 Node.js net 모듈 위 HTTP 파싱 / Router / Middleware 직접 구현. 라이브러리 한 줄 위의 동작 원리를 이해하기 위한 학습 프로젝트.',
+	},
+	{
+		year: '2019.03 — 2025.02',
+		title: '충북대학교 컴퓨터공학과',
+		role: '학사 · 3.76 / 4.5',
+		body: 'RLHF / TRLX 기반 학부연구 + 다수 팀 프로젝트 · 인턴 · 외주를 통해 백엔드 / 데이터 / AI 접점 경험.',
+	},
+];
+
+export default function AboutJourney() {
+	return (
+		<section
+			className="py-20 lg:py-24 border-t"
+			style={{ borderColor: 'var(--line)' }}
+		>
+			<Reveal className="flex items-end justify-between mb-10 lg:mb-14">
+				<div>
+					<Eyebrow className="mb-3">— Journey</Eyebrow>
+					<h2
+						className="font-general-semibold"
+						style={{
+							fontSize: 'clamp(2rem, 4.5vw, 3.6rem)',
+							letterSpacing: '-0.04em',
+							lineHeight: 0.88,
+						}}
+					>
+						지나온 길
+						<span style={{ color: 'var(--indigo-soft)' }}>.</span>
+					</h2>
+				</div>
+				<div
+					className="hidden md:block text-xs"
+					style={{
+						fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+						color: 'var(--paper-faint)',
+					}}
+				>
+					2019 → 2026
+				</div>
+			</Reveal>
+
+			<div>
+				{JOURNEY.map((row, idx) => (
+					<Reveal
+						key={row.year + row.title}
+						delay={idx * 0.06}
+						className="bold-tl-row py-[1.8rem] border-t"
+						style={{ borderColor: 'var(--line)' }}
+					>
+						<div
+							className="text-xs"
+							style={{
+								fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+								letterSpacing: '0.1em',
+								color: 'var(--indigo-soft)',
+								paddingTop: '0.4rem',
+							}}
+						>
+							{row.year}
+						</div>
+						<div>
+							<div
+								className="font-general-semibold mb-[0.35rem]"
+								style={{
+									fontSize: 'clamp(1.1rem, 1.6vw, 1.5rem)',
+									letterSpacing: '-0.02em',
+								}}
+							>
+								{row.title}
+							</div>
+							<div
+								className="font-general-medium text-[13px] mb-3"
+								style={{ color: 'var(--paper-dim)' }}
+							>
+								{row.role}
+							</div>
+							<div
+								className="leading-relaxed"
+								style={{ color: 'var(--paper-dim)', maxWidth: '60ch' }}
+							>
+								{row.body}
+							</div>
+						</div>
+					</Reveal>
+				))}
+				{/* 마지막 row 아래 보더 */}
+				<div style={{ borderBottom: '1px solid var(--line)' }} />
+			</div>
+		</section>
+	);
+}

--- a/apps/web/components/about/bold/AboutPrinciples.jsx
+++ b/apps/web/components/about/bold/AboutPrinciples.jsx
@@ -1,0 +1,112 @@
+import Reveal from '../../primitives/Reveal';
+import Eyebrow from '../../primitives/Eyebrow';
+
+// 라군 profile.md 의 핵심 강점 4개. 후속 PR 에서 /api/about.principles[] 도입.
+const PRINCIPLES = [
+	{
+		title: '원인을 끝까지 파고든다',
+		body: '문제가 생기면 겉으로 드러난 증상보다, 왜 이런 문제가 발생했는지부터 확인합니다. 다음에 또 안 일어나도록.',
+	},
+	{
+		title: '운영을 고려한 백엔드 시야',
+		body: 'API 개발에만 머물지 않고 로그, 성능, 데이터 흐름, 장애 대응, 운영 효율까지 함께 봅니다.',
+	},
+	{
+		title: '실시간성과 성능 최적화',
+		body: 'Redis, 캐시, 큐, 인덱스, 페이지네이션. 백엔드에서 자주 마주치는 성능 문제를 실제 프로젝트에서 다뤘습니다.',
+	},
+	{
+		title: '원리를 이해하고 쓴다',
+		body: '커스텀 웹 프레임워크 프로젝트에서 Node.js net 모듈 위 HTTP 파싱, Router, Middleware 까지 직접 구현. 내부 동작 원리를 이해하려 합니다.',
+	},
+];
+
+export default function AboutPrinciples() {
+	return (
+		<section
+			className="py-20 lg:py-24 border-t"
+			style={{ borderColor: 'var(--line)' }}
+		>
+			<div className="grid grid-cols-12 gap-6 lg:gap-12 mb-10 lg:mb-14">
+				<Reveal className="col-span-12 lg:col-span-5">
+					<Eyebrow className="mb-3">— Principles</Eyebrow>
+					<h2
+						className="font-general-semibold"
+						style={{
+							fontSize: 'clamp(2rem, 4.5vw, 3.6rem)',
+							letterSpacing: '-0.04em',
+							lineHeight: 1,
+						}}
+					>
+						작업을 이끄는
+						<br />
+						<span
+							style={{
+								display: 'inline-block',
+								color: 'var(--indigo-soft)',
+								fontStyle: 'italic',
+								paddingRight: '0.1em',
+							}}
+						>
+							네 가지 원칙.
+						</span>
+					</h2>
+				</Reveal>
+				<Reveal delay={0.16} className="col-span-12 lg:col-span-7 lg:pt-8">
+					<p
+						className="leading-relaxed max-w-xl"
+						style={{ color: 'var(--paper-dim)' }}
+					>
+						기술은 결국 서비스를 더 잘 굴러가게 만드는 도구라고 생각합니다.
+						아래는 어떤 코드를 쓸지 고민할 때 기준으로 삼는 네 가지 원칙입니다.
+					</p>
+				</Reveal>
+			</div>
+
+			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-6">
+				{PRINCIPLES.map((p, idx) => (
+					<Reveal key={p.title} delay={idx * 0.08}>
+						<div
+							className="bold-interactive rounded-[18px] p-6 transition-all"
+							style={{
+								border: '1px solid var(--line)',
+								background: 'rgba(255,255,255,0.02)',
+								transitionProperty: 'border-color, transform',
+								transitionDuration: '0.4s',
+								transitionTimingFunction: 'cubic-bezier(0.2,0.7,0.2,1)',
+							}}
+							onMouseEnter={(e) => {
+								e.currentTarget.style.transform = 'translateY(-4px)';
+								e.currentTarget.style.borderColor = 'var(--line-strong)';
+							}}
+							onMouseLeave={(e) => {
+								e.currentTarget.style.transform = 'translateY(0)';
+								e.currentTarget.style.borderColor = 'var(--line)';
+							}}
+						>
+							<div
+								className="mb-4 text-xs"
+								style={{
+									fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+									letterSpacing: '0.12em',
+									color: 'var(--indigo-soft)',
+								}}
+							>
+								{String(idx + 1).padStart(2, '0')}
+							</div>
+							<div className="font-general-semibold text-xl lg:text-2xl mb-3">
+								{p.title}
+							</div>
+							<p
+								className="text-sm leading-relaxed"
+								style={{ color: 'var(--paper-dim)' }}
+							>
+								{p.body}
+							</p>
+						</div>
+					</Reveal>
+				))}
+			</div>
+		</section>
+	);
+}

--- a/apps/web/components/primitives/WordReveal.jsx
+++ b/apps/web/components/primitives/WordReveal.jsx
@@ -26,7 +26,12 @@ export default function WordReveal({
 							paddingRight: '0.1em',
 						}
 					: undefined;
-				const sep = idx < items.length - 1 && !items[idx + 1]?.br ? ' ' : '';
+				// 다음 단어와 공백 분리. 단 noSep 가 true 면 공백 없이 직접 붙임
+				// (예: '이석호' + '입니다' 처럼 한국어 토씨와 함께 가는 경우).
+				const sep =
+					idx < items.length - 1 && !items[idx + 1]?.br && !item.noSep
+						? ' '
+						: '';
 
 				if (reduced) {
 					return (

--- a/apps/web/components/primitives/WordReveal.jsx
+++ b/apps/web/components/primitives/WordReveal.jsx
@@ -47,11 +47,14 @@ export default function WordReveal({
 						className="inline-block overflow-hidden align-bottom pb-[0.04em]"
 						style={innerStyle}
 					>
+						{/* hero 영역 전용이라 viewport 감지(whileInView) 대신 mount 즉시 animate.
+						    router 전환 시 부모 motion.div (fade) 가 opacity 0 → 1 로 가는 동안
+						    IntersectionObserver 가 visible 판단 실패 + once: true 로 평생
+						    trigger 안 되던 버그 회피. */}
 						<motion.span
 							className="inline-block"
 							initial={{ y: '105%' }}
-							whileInView={{ y: 0 }}
-							viewport={{ once: true, amount: 0.4 }}
+							animate={{ y: 0 }}
 							transition={{
 								duration: 0.9,
 								ease: [0.2, 0.7, 0.2, 1],

--- a/apps/web/pages/about.jsx
+++ b/apps/web/pages/about.jsx
@@ -1,11 +1,14 @@
-import { motion } from 'framer-motion';
-import AboutClients from '../components/about/AboutClients';
-import AboutCounter from '../components/about/AboutCounter';
-import AboutMeBio from '../components/about/AboutMeBio';
+import BoldLayout from '../components/layout/bold/BoldLayout';
 import PagesMetaHead from '../components/PagesMetaHead';
+import AboutHero from '../components/about/bold/AboutHero';
+import AboutBioSection from '../components/about/bold/AboutBioSection';
+import AboutCounters from '../components/about/bold/AboutCounters';
+import AboutPrinciples from '../components/about/bold/AboutPrinciples';
+import AboutJourney from '../components/about/bold/AboutJourney';
+import AboutBrands from '../components/about/bold/AboutBrands';
+import AboutContactCTA from '../components/about/bold/AboutContactCTA';
 
-const API_BASE_URL =
-	process.env.API_INTERNAL_URL || 'http://localhost:7341';
+const API_BASE_URL = process.env.API_INTERNAL_URL || 'http://localhost:7341';
 
 const EMPTY_ABOUT = {
 	name: '',
@@ -14,52 +17,26 @@ const EMPTY_ABOUT = {
 	bio: [],
 };
 
-// 나중에 다시 활용할 수 있게 about 하위 섹션들은 삭제하지 않고 토글로 숨김 처리.
-const SHOW_ABOUT_COUNTER = false;
-const SHOW_ABOUT_CLIENTS = false;
-
 function About({ about }) {
 	return (
-		<div>
+		<>
 			<PagesMetaHead title="About Me" />
-
-			<motion.div
-				initial={false}
-				animate={{ opacity: 1, delay: 1 }}
-				exit={{ opacity: 0 }}
-				className="container mx-auto"
-			>
-				<AboutMeBio
-					name={about.name}
-					tagline={about.tagline}
-					profileImage={about.profileImage}
-					bio={about.bio}
-				/>
-			</motion.div>
-
-			{SHOW_ABOUT_COUNTER && (
-				<motion.div
-					initial={false}
-					animate={{ opacity: 1, delay: 1 }}
-					exit={{ opacity: 0 }}
-				>
-					<AboutCounter />
-				</motion.div>
-			)}
-
-			{SHOW_ABOUT_CLIENTS && (
-				<motion.div
-					initial={false}
-					animate={{ opacity: 1, delay: 1 }}
-					exit={{ opacity: 0 }}
-					className="container mx-auto"
-				>
-					<AboutClients />
-				</motion.div>
-			)}
-		</div>
+			<AboutHero
+				name={about.name}
+				tagline={about.tagline}
+				profileImage={about.profileImage}
+			/>
+			<AboutBioSection bio={about.bio} />
+			<AboutCounters />
+			<AboutPrinciples />
+			<AboutJourney />
+			<AboutBrands />
+			<AboutContactCTA />
+		</>
 	);
 }
+
+About.getLayout = (page) => <BoldLayout>{page}</BoldLayout>;
 
 export async function getServerSideProps() {
 	try {

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -291,6 +291,72 @@ html {
 		color 0.4s cubic-bezier(0.2, 0.7, 0.2, 1);
 }
 
+/* About Bio 섹션의 마크다운 prose 스타일.
+ * ReactMarkdown 이 렌더하는 p / strong / h3 / ul / li 에 적용. */
+.bold-prose {
+	color: color-mix(in oklab, var(--paper) 78%, transparent);
+	line-height: 1.7;
+	font-size: clamp(1rem, 1.05vw, 1.1rem);
+}
+.bold-prose p {
+	margin: 0 0 1.1rem;
+}
+.bold-prose p:last-child {
+	margin-bottom: 0;
+}
+.bold-prose strong {
+	color: var(--paper);
+	font-weight: 600;
+}
+.bold-prose h1,
+.bold-prose h2,
+.bold-prose h3,
+.bold-prose h4 {
+	font-family: 'GeneralSans-Semibold', sans-serif;
+	color: var(--paper);
+	margin: 1.5rem 0 0.5rem;
+}
+.bold-prose h3 {
+	font-size: 1.25rem;
+}
+.bold-prose ul,
+.bold-prose ol {
+	padding-left: 0;
+	list-style: none;
+	margin: 0.4rem 0 1.1rem;
+}
+.bold-prose li {
+	position: relative;
+	padding-left: 1.5rem;
+	margin: 0.4rem 0;
+}
+.bold-prose li::before {
+	content: '';
+	position: absolute;
+	left: 0;
+	top: 0.7em;
+	width: 16px;
+	height: 1px;
+	background: var(--indigo-soft);
+}
+.bold-prose a {
+	color: var(--indigo-soft);
+	text-decoration: underline;
+}
+
+/* About Journey 타임라인 row — 좌 130px year / 우 내용. 모바일 stack. */
+.bold-tl-row {
+	display: grid;
+	grid-template-columns: 130px 1fr;
+	gap: 28px;
+}
+@media (max-width: 768px) {
+	.bold-tl-row {
+		grid-template-columns: 1fr;
+		gap: 8px;
+	}
+}
+
 /* Bold 페이지의 한국어 본문은 단어 중간이 아닌 단어 경계에서 줄바꿈되도록 한다.
  * CJK 의 default 는 글자 단위 줄바꿈 → 'word-break: keep-all' 로 단어 단위 유지.
  * 너무 긴 영문 단어 (예: URL) 가 컨테이너 폭을 넘으면 break-word 로 풀어준다. */


### PR DESCRIPTION
## 무엇을

5페이지 Bold 시리즈 두 번째 페이지. \`/about\` 을 Bold 7개 섹션으로 재구성. 백엔드 변경 없이 UI 만 — 후속 PR 에서 stats/principles/journey 백엔드 확장.

### 2 commits

| commit | 내용 |
|---|---|
| (commit 1) | About Bold 7개 섹션 컴포넌트 신규 + globals.css 의 .bold-prose / .bold-tl-row |
| \`0db86df\` | About 페이지 BoldLayout 채택 + 7개 섹션 렌더 |

### 7개 섹션 (시안 \`About v2 - Bold.html\` 기반)

| # | 섹션 | 데이터 |
|---|---|---|
| 1 | Hero | breadcrumb + 신입 채용 검토 status + WordReveal '안녕, 저는 / 이석호입니다.' + 4:5 portrait + 큰 tagline. api: name/tagline/profileImage |
| 2 | Bio | sticky 좌측 헤딩 ('코드를 쓰지만 / 팀의 시간을 / 벌어줍니다') + 우측 ReactMarkdown bio[] |
| 3 | Counters | 4개 stat. **하드코딩** — 6 Shipped Projects / 333ms API Response / 77% Query Cut / 0 야간 호출 (라군 실제 수치) |
| 4 | Principles | 01~04 원칙 카드. **하드코딩** — 원인 파고들기 / 운영 시야 / 성능 최적화 / 원리 이해 (라군 profile.md 기반) |
| 5 | Journey | 좌 130px year / 우 내용 stack 타임라인. **하드코딩** — 통합 로그 / 클래스업 / 베팅덕 / CaTs · 커스텀 프레임워크 / 충북대 |
| 6 | Tech Stack | 시안의 'Companies' 를 신입 컨텍스트 'Tech Stack' 으로 의미 재정의. **하드코딩** 8개 도구 |
| 7 | CTA | '함께 일해볼까요?' 큰 타이포 + Contact Me + Notion 이력서 새 탭 |

### 기술
- BoldLayout 채택 (Page.getLayout 패턴, Home 과 동일)
- 기존 primitives 재사용 (Reveal/WordReveal/Eyebrow/PillButton/StatCounter)
- ReactMarkdown 으로 bio[] 단락 보존 렌더 (Home AboutStrip 의 stripMarkdownHeaders 와 다른 처리)
- 기존 \`components/about/*\` (AboutMeBio 등) 보존 — 후속 PR 미사용 확정 시 삭제
- globals.css 의 \`.bold-prose\` (마크다운 prose) + \`.bold-tl-row\` (Journey grid) 신규

## 영향

- \`apps/web\` 전용. \`apps/api\` 변경 없음
- \`/about\` 만 BoldLayout 사용. \`/\` 는 이미 Bold, \`/projects\` / \`/contact\` 는 기존 DefaultLayout 유지 (getLayout fallback)
- 신규 컴포넌트 7개 — 모두 \`components/about/bold/\` 격리

## 수동 확인 (dev 머지 후)

- [ ] \`/about\` Hero — breadcrumb / status / WordReveal / portrait / tagline
- [ ] Bio sticky 좌측 헤딩 + 우측 마크다운 단락 (api 의 bio[] 5단락 모두)
- [ ] Counters 4개 — react-countup 카운트업
- [ ] Principles 4개 — 01~04 카드 hover translateY
- [ ] Journey 5개 row — 좌 year / 우 내용. 모바일 stack
- [ ] Tech Stack 8개 그리드 hover
- [ ] CTA — Contact Me 내부 라우팅 + Notion 이력서 새 탭
- [ ] DARK/LIGHT 토글 (PR #88 의 0.4s fade transition 정상)
- [ ] 모바일 viewport (375/768/1280)
- [ ] \`prefers-reduced-motion\` 정상
- [ ] \`/\`, \`/projects\`, \`/contact\` 기존 디자인 유지 (getLayout fallback)

## 의도적 보류 (후속 PR)

- DB 마이그레이션: \`ABOUT_PROFILE\` 에 \`availability\`/\`stats[]\`/\`principles[]\` JSON + \`ABOUT_JOURNEY\` 테이블
- API DTO 확장: \`about-response.dto.ts\`
- admin UI 확장: DynamicList 로 principles/journey 관리
- About 페이지가 동적 데이터 사용 (하드코딩 제거)
- 기존 \`components/about/*\` 미사용 확정 시 삭제
- 디폴트 다크 모드 강제 전환 (5페이지 완료 후)

Closes #89
Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)