### PR TITLE
[feat] About 백엔드 확장 (availability/stats/principles/journey/stacks)

### DIFF
--- a/apps/api/src/database/database.module.ts
+++ b/apps/api/src/database/database.module.ts
@@ -17,6 +17,11 @@ import databaseConfig from '../config/database.config';
         database: config.get<string>('database.database'),
         autoLoadEntities: true,
         synchronize: config.get<boolean>('database.synchronize'),
+        // database.config.ts 에 정의된 migrations / migrationsRun 옵션을 useFactory
+        // 반환 객체에 포함시켜야 typeorm 이 인식한다 (이전엔 누락되어 컨테이너
+        // 부팅 시 pending migration 자동 실행이 동작하지 않았음).
+        migrations: config.get<string[]>('database.migrations'),
+        migrationsRun: config.get<boolean>('database.migrationsRun'),
       }),
     }),
   ],

--- a/apps/api/src/database/migrations/1779372689864-AddAboutExtendedFields.ts
+++ b/apps/api/src/database/migrations/1779372689864-AddAboutExtendedFields.ts
@@ -1,0 +1,96 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAboutExtendedFields1779372689864 implements MigrationInterface {
+  name = 'AddAboutExtendedFields1779372689864';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // ABOUT_PROFILE: Hero status (availability) + Tech Stack (stacks json) 추가.
+    await queryRunner.query(
+      `ALTER TABLE \`ABOUT_PROFILE\` ADD \`availability\` varchar(255) NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`ABOUT_PROFILE\` ADD \`stacks\` json NULL`,
+    );
+
+    // ABOUT_STAT: In Numbers 섹션 (label/value/sub + sort_order + profile_id).
+    await queryRunner.query(
+      `CREATE TABLE \`ABOUT_STAT\` (` +
+        `\`id\` int NOT NULL AUTO_INCREMENT,` +
+        `\`label\` varchar(100) NOT NULL,` +
+        `\`value\` varchar(100) NOT NULL,` +
+        `\`sub\` varchar(255) NULL,` +
+        `\`sort_order\` int NOT NULL DEFAULT '0',` +
+        `\`profile_id\` tinyint NOT NULL,` +
+        `\`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),` +
+        `PRIMARY KEY (\`id\`)` +
+        `) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`ABOUT_STAT\` ADD CONSTRAINT \`FK_about_stat_profile\` ` +
+        `FOREIGN KEY (\`profile_id\`) REFERENCES \`ABOUT_PROFILE\`(\`id\`) ` +
+        `ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+
+    // ABOUT_PRINCIPLE: Principles 섹션 (title/body + sort_order + profile_id).
+    await queryRunner.query(
+      `CREATE TABLE \`ABOUT_PRINCIPLE\` (` +
+        `\`id\` int NOT NULL AUTO_INCREMENT,` +
+        `\`title\` varchar(200) NOT NULL,` +
+        `\`body\` text NOT NULL,` +
+        `\`sort_order\` int NOT NULL DEFAULT '0',` +
+        `\`profile_id\` tinyint NOT NULL,` +
+        `\`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),` +
+        `PRIMARY KEY (\`id\`)` +
+        `) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`ABOUT_PRINCIPLE\` ADD CONSTRAINT \`FK_about_principle_profile\` ` +
+        `FOREIGN KEY (\`profile_id\`) REFERENCES \`ABOUT_PROFILE\`(\`id\`) ` +
+        `ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+
+    // ABOUT_JOURNEY: Journey 타임라인 (year string / title / role nullable / body + sort_order + profile_id).
+    await queryRunner.query(
+      `CREATE TABLE \`ABOUT_JOURNEY\` (` +
+        `\`id\` int NOT NULL AUTO_INCREMENT,` +
+        `\`year\` varchar(100) NOT NULL,` +
+        `\`title\` varchar(200) NOT NULL,` +
+        `\`role\` varchar(200) NULL,` +
+        `\`body\` text NOT NULL,` +
+        `\`sort_order\` int NOT NULL DEFAULT '0',` +
+        `\`profile_id\` tinyint NOT NULL,` +
+        `\`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),` +
+        `PRIMARY KEY (\`id\`)` +
+        `) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`ABOUT_JOURNEY\` ADD CONSTRAINT \`FK_about_journey_profile\` ` +
+        `FOREIGN KEY (\`profile_id\`) REFERENCES \`ABOUT_PROFILE\`(\`id\`) ` +
+        `ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`ABOUT_JOURNEY\` DROP FOREIGN KEY \`FK_about_journey_profile\``,
+    );
+    await queryRunner.query(`DROP TABLE \`ABOUT_JOURNEY\``);
+
+    await queryRunner.query(
+      `ALTER TABLE \`ABOUT_PRINCIPLE\` DROP FOREIGN KEY \`FK_about_principle_profile\``,
+    );
+    await queryRunner.query(`DROP TABLE \`ABOUT_PRINCIPLE\``);
+
+    await queryRunner.query(
+      `ALTER TABLE \`ABOUT_STAT\` DROP FOREIGN KEY \`FK_about_stat_profile\``,
+    );
+    await queryRunner.query(`DROP TABLE \`ABOUT_STAT\``);
+
+    await queryRunner.query(
+      `ALTER TABLE \`ABOUT_PROFILE\` DROP COLUMN \`stacks\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`ABOUT_PROFILE\` DROP COLUMN \`availability\``,
+    );
+  }
+}

--- a/apps/api/src/modules/about/about.controller.spec.ts
+++ b/apps/api/src/modules/about/about.controller.spec.ts
@@ -32,6 +32,11 @@ describe('AboutController', () => {
       address: null,
       email: null,
       phone: null,
+      availability: null,
+      stats: [],
+      principles: [],
+      journey: [],
+      stacks: [],
     };
     service.get.mockResolvedValue(data);
 

--- a/apps/api/src/modules/about/about.module.ts
+++ b/apps/api/src/modules/about/about.module.ts
@@ -7,10 +7,22 @@ import { AdminAboutController } from './admin-about.controller';
 import { AdminAboutService } from './admin-about.service';
 import { AboutProfile } from './entities/about-profile.entity';
 import { AboutBio } from './entities/about-bio.entity';
+import { AboutStat } from './entities/about-stat.entity';
+import { AboutPrinciple } from './entities/about-principle.entity';
+import { AboutJourney } from './entities/about-journey.entity';
 import { UploadsModule } from '../uploads/uploads.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([AboutProfile, AboutBio]), UploadsModule],
+  imports: [
+    TypeOrmModule.forFeature([
+      AboutProfile,
+      AboutBio,
+      AboutStat,
+      AboutPrinciple,
+      AboutJourney,
+    ]),
+    UploadsModule,
+  ],
   controllers: [AboutController, AdminAboutController],
   providers: [AboutService, AboutRepository, AdminAboutService],
 })

--- a/apps/api/src/modules/about/about.repository.spec.ts
+++ b/apps/api/src/modules/about/about.repository.spec.ts
@@ -25,14 +25,19 @@ describe('AboutRepository', () => {
     typeormRepo = module.get(getRepositoryToken(AboutProfile));
   });
 
-  it('findProfile: id=1 과 bios relation 옵션을 전달한다', async () => {
+  it('findProfile: id=1 과 bios/stats/principles/journeys relation 옵션을 전달한다', async () => {
     typeormRepo.findOne.mockResolvedValue(null);
 
     await repository.findProfile();
 
     expect(typeormRepo.findOne).toHaveBeenCalledWith({
       where: { id: 1 },
-      relations: { bios: true },
+      relations: {
+        bios: true,
+        stats: true,
+        principles: true,
+        journeys: true,
+      },
     });
   });
 });

--- a/apps/api/src/modules/about/about.repository.ts
+++ b/apps/api/src/modules/about/about.repository.ts
@@ -13,7 +13,12 @@ export class AboutRepository {
   async findProfile(): Promise<AboutProfile | null> {
     return this.repo.findOne({
       where: { id: 1 },
-      relations: { bios: true },
+      relations: {
+        bios: true,
+        stats: true,
+        principles: true,
+        journeys: true,
+      },
     });
   }
 }

--- a/apps/api/src/modules/about/about.service.spec.ts
+++ b/apps/api/src/modules/about/about.service.spec.ts
@@ -72,6 +72,12 @@ describe('AboutService', () => {
       address: null,
       email: null,
       phone: null,
+      // Bold 리디자인 후속 — 신규 필드는 빈 default 로 반환됨
+      availability: null,
+      stats: [],
+      principles: [],
+      journey: [],
+      stacks: [],
     });
   });
 

--- a/apps/api/src/modules/about/admin-about.service.ts
+++ b/apps/api/src/modules/about/admin-about.service.ts
@@ -8,6 +8,9 @@ import {
 } from '../uploads/uploads-storage.service';
 import { AboutBio } from './entities/about-bio.entity';
 import { AboutProfile } from './entities/about-profile.entity';
+import { AboutStat } from './entities/about-stat.entity';
+import { AboutPrinciple } from './entities/about-principle.entity';
+import { AboutJourney } from './entities/about-journey.entity';
 import { UpsertAboutDto } from './dto/upsert-about.dto';
 import { AboutResponseDto } from './dto/about-response.dto';
 import { toAboutResponseDto } from './mappers/about.mapper';
@@ -30,8 +33,12 @@ export class AdminAboutService {
     const previousImageUrl = previousProfile?.profileImage ?? null;
 
     await this.dataSource.transaction(async (manager) => {
-      // bio 는 전량 교체 (id=1 고정 singleton 에 묶인 자식)
+      // bio / stat / principle / journey 모두 id=1 singleton 에 묶인 자식이라
+      // 입력값으로 전량 교체. sortOrder 는 입력 순서 그대로 부여.
       await manager.delete(AboutBio, { profileId: 1 });
+      await manager.delete(AboutStat, { profileId: 1 });
+      await manager.delete(AboutPrinciple, { profileId: 1 });
+      await manager.delete(AboutJourney, { profileId: 1 });
 
       const profile = new AboutProfile();
       profile.id = 1;
@@ -41,11 +48,38 @@ export class AdminAboutService {
       profile.address = dto.address ?? null;
       profile.email = dto.email ?? null;
       profile.phone = dto.phone ?? null;
+      profile.availability = dto.availability ?? null;
+      profile.stacks = dto.stacks ?? [];
+
       profile.bios = dto.bio.map((paragraph, idx) => {
         const bio = new AboutBio();
         bio.paragraph = paragraph;
         bio.sortOrder = idx;
         return bio;
+      });
+      profile.stats = (dto.stats ?? []).map((s, idx) => {
+        const stat = new AboutStat();
+        stat.label = s.label;
+        stat.value = s.value;
+        stat.sub = s.sub ?? null;
+        stat.sortOrder = idx;
+        return stat;
+      });
+      profile.principles = (dto.principles ?? []).map((p, idx) => {
+        const principle = new AboutPrinciple();
+        principle.title = p.title;
+        principle.body = p.body;
+        principle.sortOrder = idx;
+        return principle;
+      });
+      profile.journeys = (dto.journey ?? []).map((j, idx) => {
+        const journey = new AboutJourney();
+        journey.year = j.year;
+        journey.title = j.title;
+        journey.role = j.role ?? null;
+        journey.body = j.body;
+        journey.sortOrder = idx;
+        return journey;
       });
 
       await manager.save(AboutProfile, profile);
@@ -78,7 +112,12 @@ export class AdminAboutService {
 
     const loaded = await this.profileRepo.findOne({
       where: { id: 1 },
-      relations: { bios: true },
+      relations: {
+        bios: true,
+        stats: true,
+        principles: true,
+        journeys: true,
+      },
     });
     // upsert 가 방금 끝났으니 null 일 리 없지만, 타입 만족을 위해 fallback
     if (!loaded) {

--- a/apps/api/src/modules/about/dto/about-response.dto.ts
+++ b/apps/api/src/modules/about/dto/about-response.dto.ts
@@ -1,5 +1,38 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+export class AboutStatDto {
+  @ApiProperty({ example: 'Shipped Projects' })
+  label!: string;
+
+  @ApiProperty({ example: '6' })
+  value!: string;
+
+  @ApiProperty({ example: '운영 / 외주 / 팀', nullable: true, required: false })
+  sub!: string | null;
+}
+
+export class AboutPrincipleDto {
+  @ApiProperty({ example: '원인을 끝까지 파고든다' })
+  title!: string;
+
+  @ApiProperty({ example: '증상이 아닌 원인부터 확인합니다...' })
+  body!: string;
+}
+
+export class AboutJourneyDto {
+  @ApiProperty({ example: '2026.01 — Now', description: '자유 표현 가능한 기간 라벨' })
+  year!: string;
+
+  @ApiProperty({ example: '통합 로그 시스템' })
+  title!: string;
+
+  @ApiProperty({ example: '백엔드 · 외주', nullable: true, required: false })
+  role!: string | null;
+
+  @ApiProperty({ example: '여러 보안 솔루션 로그를 통합...' })
+  body!: string;
+}
+
 export class AboutResponseDto {
   @ApiProperty({ example: 'Lagoon' })
   name!: string;
@@ -29,4 +62,20 @@ export class AboutResponseDto {
 
   @ApiProperty({ example: '+82 10-1234-5678', nullable: true, required: false })
   phone!: string | null;
+
+  // Bold 리디자인 후속 — 5개 신규 필드. 빈 값(null / []) graceful fallback.
+  @ApiProperty({ example: '신입 채용 검토 중', nullable: true, required: false })
+  availability!: string | null;
+
+  @ApiProperty({ type: [AboutStatDto], description: 'sort_order 정렬' })
+  stats!: AboutStatDto[];
+
+  @ApiProperty({ type: [AboutPrincipleDto], description: 'sort_order 정렬' })
+  principles!: AboutPrincipleDto[];
+
+  @ApiProperty({ type: [AboutJourneyDto], description: 'sort_order 정렬' })
+  journey!: AboutJourneyDto[];
+
+  @ApiProperty({ type: [String], example: ['NestJS', 'Express', 'TypeScript'] })
+  stacks!: string[];
 }

--- a/apps/api/src/modules/about/dto/upsert-about.dto.ts
+++ b/apps/api/src/modules/about/dto/upsert-about.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Transform } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import {
   ArrayMaxSize,
   IsArray,
@@ -8,6 +8,7 @@ import {
   IsOptional,
   IsString,
   MaxLength,
+  ValidateNested,
 } from 'class-validator';
 
 const trimIfString = (value: unknown): unknown =>
@@ -22,6 +23,75 @@ const trimToNull = (value: unknown): unknown => {
   const trimmed = value.trim();
   return trimmed.length === 0 ? null : trimmed;
 };
+
+// Bold 리디자인 후속 — 신규 nested DTO 4개.
+
+export class UpsertStatDto {
+  @ApiProperty({ maxLength: 100 })
+  @Transform(({ value }) => trimIfString(value))
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  label!: string;
+
+  @ApiProperty({ maxLength: 100 })
+  @Transform(({ value }) => trimIfString(value))
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  value!: string;
+
+  @ApiProperty({ maxLength: 255, nullable: true, required: false })
+  @Transform(({ value }) => trimToNull(value))
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  sub?: string | null;
+}
+
+export class UpsertPrincipleDto {
+  @ApiProperty({ maxLength: 200 })
+  @Transform(({ value }) => trimIfString(value))
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  title!: string;
+
+  @ApiProperty()
+  @Transform(({ value }) => trimIfString(value))
+  @IsString()
+  @IsNotEmpty()
+  body!: string;
+}
+
+export class UpsertJourneyDto {
+  @ApiProperty({ maxLength: 100, description: '자유 표현 — "2026.01 — Now" 등' })
+  @Transform(({ value }) => trimIfString(value))
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  year!: string;
+
+  @ApiProperty({ maxLength: 200 })
+  @Transform(({ value }) => trimIfString(value))
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  title!: string;
+
+  @ApiProperty({ maxLength: 200, nullable: true, required: false })
+  @Transform(({ value }) => trimToNull(value))
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  role?: string | null;
+
+  @ApiProperty()
+  @Transform(({ value }) => trimIfString(value))
+  @IsString()
+  @IsNotEmpty()
+  body!: string;
+}
 
 export class UpsertAboutDto {
   @ApiProperty({ maxLength: 100 })
@@ -73,4 +143,45 @@ export class UpsertAboutDto {
   @IsString()
   @MaxLength(50)
   phone?: string | null;
+
+  // Bold 리디자인 후속 — 5개 신규 필드. 모두 optional / 빈 배열 default.
+
+  @ApiProperty({ maxLength: 255, nullable: true, required: false })
+  @Transform(({ value }) => trimToNull(value))
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  availability?: string | null;
+
+  @ApiProperty({ type: [UpsertStatDto], required: false })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(20)
+  @ValidateNested({ each: true })
+  @Type(() => UpsertStatDto)
+  stats?: UpsertStatDto[];
+
+  @ApiProperty({ type: [UpsertPrincipleDto], required: false })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(20)
+  @ValidateNested({ each: true })
+  @Type(() => UpsertPrincipleDto)
+  principles?: UpsertPrincipleDto[];
+
+  @ApiProperty({ type: [UpsertJourneyDto], required: false })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(50)
+  @ValidateNested({ each: true })
+  @Type(() => UpsertJourneyDto)
+  journey?: UpsertJourneyDto[];
+
+  @ApiProperty({ type: [String], required: false })
+  @Transform(({ value }) => trimArray(value))
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(30)
+  @IsString({ each: true })
+  stacks?: string[];
 }

--- a/apps/api/src/modules/about/entities/about-journey.entity.ts
+++ b/apps/api/src/modules/about/entities/about-journey.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { AboutProfile } from './about-profile.entity';
+
+@Entity('ABOUT_JOURNEY')
+export class AboutJourney {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  // 자유 표현. "2026.01 — Now" / "2019.03 — 2025.02" 등.
+  @Column({ length: 100 })
+  year!: string;
+
+  @Column({ length: 200 })
+  title!: string;
+
+  @Column({ type: 'varchar', length: 200, nullable: true })
+  role!: string | null;
+
+  @Column({ type: 'text' })
+  body!: string;
+
+  @Column({ name: 'sort_order', type: 'int', default: 0 })
+  sortOrder!: number;
+
+  @ManyToOne(() => AboutProfile, (profile) => profile.journeys, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'profile_id' })
+  profile!: AboutProfile;
+
+  @Column({ name: 'profile_id', type: 'tinyint' })
+  profileId!: number;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+}

--- a/apps/api/src/modules/about/entities/about-principle.entity.ts
+++ b/apps/api/src/modules/about/entities/about-principle.entity.ts
@@ -1,0 +1,36 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { AboutProfile } from './about-profile.entity';
+
+@Entity('ABOUT_PRINCIPLE')
+export class AboutPrinciple {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ length: 200 })
+  title!: string;
+
+  @Column({ type: 'text' })
+  body!: string;
+
+  @Column({ name: 'sort_order', type: 'int', default: 0 })
+  sortOrder!: number;
+
+  @ManyToOne(() => AboutProfile, (profile) => profile.principles, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'profile_id' })
+  profile!: AboutProfile;
+
+  @Column({ name: 'profile_id', type: 'tinyint' })
+  profileId!: number;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+}

--- a/apps/api/src/modules/about/entities/about-profile.entity.ts
+++ b/apps/api/src/modules/about/entities/about-profile.entity.ts
@@ -7,6 +7,9 @@ import {
   PrimaryColumn,
 } from 'typeorm';
 import { AboutBio } from './about-bio.entity';
+import { AboutStat } from './about-stat.entity';
+import { AboutPrinciple } from './about-principle.entity';
+import { AboutJourney } from './about-journey.entity';
 
 // singleton: ABOUT_PROFILE 은 항상 id = 1 인 단일 row 만 허용한다.
 // 앱 레벨 컨벤션만으로는 실수 방지가 부족하므로 CHECK 제약으로 못박는다.
@@ -34,9 +37,26 @@ export class AboutProfile {
   @Column({ type: 'varchar', length: 50, nullable: true })
   phone!: string | null;
 
+  // Bold 리디자인 후속 — Hero status 한 줄, Tech Stack 단순 string 배열.
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  availability!: string | null;
+
+  // json 타입으로 단순 string[] 저장. 8개 정도라 별도 테이블 오버킬.
+  @Column({ type: 'json', nullable: true })
+  stacks!: string[] | null;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;
 
   @OneToMany(() => AboutBio, (bio) => bio.profile, { cascade: true })
   bios!: AboutBio[];
+
+  @OneToMany(() => AboutStat, (stat) => stat.profile, { cascade: true })
+  stats!: AboutStat[];
+
+  @OneToMany(() => AboutPrinciple, (p) => p.profile, { cascade: true })
+  principles!: AboutPrinciple[];
+
+  @OneToMany(() => AboutJourney, (j) => j.profile, { cascade: true })
+  journeys!: AboutJourney[];
 }

--- a/apps/api/src/modules/about/entities/about-stat.entity.ts
+++ b/apps/api/src/modules/about/entities/about-stat.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { AboutProfile } from './about-profile.entity';
+
+@Entity('ABOUT_STAT')
+export class AboutStat {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ length: 100 })
+  label!: string;
+
+  @Column({ length: 100 })
+  value!: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  sub!: string | null;
+
+  @Column({ name: 'sort_order', type: 'int', default: 0 })
+  sortOrder!: number;
+
+  @ManyToOne(() => AboutProfile, (profile) => profile.stats, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'profile_id' })
+  profile!: AboutProfile;
+
+  @Column({ name: 'profile_id', type: 'tinyint' })
+  profileId!: number;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+}

--- a/apps/api/src/modules/about/mappers/about.mapper.ts
+++ b/apps/api/src/modules/about/mappers/about.mapper.ts
@@ -5,6 +5,16 @@ export function toAboutResponseDto(profile: AboutProfile): AboutResponseDto {
   const sortedBios = [...(profile.bios ?? [])].sort(
     (a, b) => a.sortOrder - b.sortOrder,
   );
+  const sortedStats = [...(profile.stats ?? [])].sort(
+    (a, b) => a.sortOrder - b.sortOrder,
+  );
+  const sortedPrinciples = [...(profile.principles ?? [])].sort(
+    (a, b) => a.sortOrder - b.sortOrder,
+  );
+  const sortedJourneys = [...(profile.journeys ?? [])].sort(
+    (a, b) => a.sortOrder - b.sortOrder,
+  );
+
   return {
     name: profile.name,
     tagline: profile.tagline,
@@ -13,5 +23,22 @@ export function toAboutResponseDto(profile: AboutProfile): AboutResponseDto {
     address: profile.address ?? null,
     email: profile.email ?? null,
     phone: profile.phone ?? null,
+    availability: profile.availability ?? null,
+    stats: sortedStats.map((s) => ({
+      label: s.label,
+      value: s.value,
+      sub: s.sub ?? null,
+    })),
+    principles: sortedPrinciples.map((p) => ({
+      title: p.title,
+      body: p.body,
+    })),
+    journey: sortedJourneys.map((j) => ({
+      year: j.year,
+      title: j.title,
+      role: j.role ?? null,
+      body: j.body,
+    })),
+    stacks: profile.stacks ?? [],
   };
 }

--- a/apps/web/components/about/bold/AboutBrands.jsx
+++ b/apps/web/components/about/bold/AboutBrands.jsx
@@ -1,20 +1,10 @@
 import Reveal from '../../primitives/Reveal';
 import Eyebrow from '../../primitives/Eyebrow';
 
-// 시안의 'Companies' 섹션을 라군의 신입 컨텍스트에 맞게 'Tech Stack' 으로 의미 재정의.
-// 후속 PR 에서 백엔드 keywords[] 또는 stacks[] 필드 도입 시 동적화.
-const STACKS = [
-	'NestJS',
-	'Express',
-	'TypeScript',
-	'MySQL',
-	'MongoDB',
-	'Redis',
-	'Docker',
-	'Grafana / Loki',
-];
+// stacks 가 빈 배열이면 섹션 미렌더.
+export default function AboutBrands({ stacks = [] }) {
+	if (!stacks.length) return null;
 
-export default function AboutBrands() {
 	return (
 		<section
 			className="py-20 lg:py-24 border-t"
@@ -42,13 +32,13 @@ export default function AboutBrands() {
 						color: 'var(--paper-faint)',
 					}}
 				>
-					CORE · {String(STACKS.length).padStart(2, '0')}
+					CORE · {String(stacks.length).padStart(2, '0')}
 				</div>
 			</Reveal>
 
 			<div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3 lg:gap-4">
-				{STACKS.map((label, idx) => (
-					<Reveal key={label} delay={(idx % 4) * 0.06}>
+				{stacks.map((label, idx) => (
+					<Reveal key={`${label}-${idx}`} delay={(idx % 4) * 0.06}>
 						<div
 							className="bold-interactive grid place-items-center rounded-[12px] transition-all"
 							style={{

--- a/apps/web/components/about/bold/AboutCounters.jsx
+++ b/apps/web/components/about/bold/AboutCounters.jsx
@@ -2,35 +2,11 @@ import Reveal from '../../primitives/Reveal';
 import Eyebrow from '../../primitives/Eyebrow';
 import StatCounter from '../../primitives/StatCounter';
 
-// 후속 PR 에서 /api/about.stats[] 도입 시 props 로 교체. 현재는 라군 profile.md
-// 기반 하드코딩 — 신입이라 'Years of experience' 같은 시안 placeholder 는 부적합.
-const STATS = [
-	{
-		end: 6,
-		label: 'Shipped Projects',
-		sub: '운영 / 외주 / 팀 프로젝트',
-	},
-	{
-		end: 333,
-		suffix: 'ms',
-		label: 'API Response',
-		sub: '베팅덕 — Redis 큐 적용 후 (1441ms 에서 단축)',
-	},
-	{
-		end: 77,
-		suffix: '%',
-		label: 'Query Cut',
-		sub: '클래스업 — MongoDB 복합 인덱싱',
-	},
-	{
-		end: 0,
-		suffix: '건',
-		label: '야간 호출',
-		sub: '최근 운영 기간',
-	},
-];
+// stats 가 빈 배열이면 섹션 자체 미렌더 (page 가 깨지지 않게). 어드민 입력 전 케이스.
+// StatCounter 는 value 가 number 일 때 카운트업, string 일 때는 그대로 노출.
+export default function AboutCounters({ stats = [] }) {
+	if (!stats.length) return null;
 
-export default function AboutCounters() {
 	return (
 		<section
 			className="py-20 lg:py-24 border-t"
@@ -51,20 +27,11 @@ export default function AboutCounters() {
 						<span style={{ color: 'var(--indigo-soft)' }}>.</span>
 					</h2>
 				</div>
-				<div
-					className="hidden md:block text-xs"
-					style={{
-						fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
-						color: 'var(--paper-faint)',
-					}}
-				>
-					UPDATED 2026.05
-				</div>
 			</Reveal>
 
 			<div className="grid grid-cols-2 lg:grid-cols-4 gap-x-8 gap-y-10">
-				{STATS.map((stat, idx) => (
-					<Reveal key={stat.label} delay={idx * 0.08}>
+				{stats.map((stat, idx) => (
+					<Reveal key={`${stat.label}-${idx}`} delay={idx * 0.08}>
 						<div
 							className="pt-[1.4rem]"
 							style={{ borderTop: '1px solid var(--line-strong)' }}
@@ -82,19 +49,39 @@ export default function AboutCounters() {
 									color: 'transparent',
 								}}
 							>
-								<StatCounter end={stat.end} suffix={stat.suffix} />
+								<StatCounterOrText value={stat.value} />
 							</div>
 							<Eyebrow className="mt-3">{stat.label}</Eyebrow>
-							<div
-								className="text-sm mt-1"
-								style={{ color: 'var(--paper-dim)' }}
-							>
-								{stat.sub}
-							</div>
+							{stat.sub && (
+								<div
+									className="text-sm mt-1"
+									style={{ color: 'var(--paper-dim)' }}
+								>
+									{stat.sub}
+								</div>
+							)}
 						</div>
 					</Reveal>
 				))}
 			</div>
 		</section>
 	);
+}
+
+// value 가 순수 숫자(또는 '333' / '99.98' 같은 숫자 문자열) 면 카운트업,
+// 'ms' 같은 단위가 섞여 있으면 그대로 노출 (count up 으로 의미 안 맞는 케이스).
+function StatCounterOrText({ value }) {
+	const str = String(value ?? '');
+	const match = str.match(/^(-?\d+(?:\.\d+)?)(.*)$/);
+	if (match) {
+		const numeric = parseFloat(match[1]);
+		const suffix = match[2];
+		const decimals = match[1].includes('.')
+			? match[1].split('.')[1].length
+			: 0;
+		return (
+			<StatCounter end={numeric} suffix={suffix} decimals={decimals} />
+		);
+	}
+	return <span>{str}</span>;
 }

--- a/apps/web/components/about/bold/AboutCounters.jsx
+++ b/apps/web/components/about/bold/AboutCounters.jsx
@@ -68,20 +68,17 @@ export default function AboutCounters({ stats = [] }) {
 	);
 }
 
-// value 가 순수 숫자(또는 '333' / '99.98' 같은 숫자 문자열) 면 카운트업,
-// 'ms' 같은 단위가 섞여 있으면 그대로 노출 (count up 으로 의미 안 맞는 케이스).
+// value 가 순수 숫자 / 소수 ('333' / '99.98') 면 react-countup 으로 카운트업.
+// 단위·기호가 섞이면 ('333ms' / '8+ Years' / '1108ms saved' 등) admin 이 입력한
+// 형식을 그대로 보존해서 plain 으로 노출. 카운트업 + 단위 조합은 admin 의 의도
+// 형식을 깰 수 있고 (예: '333ms saved' 면 saved 까지 suffix 로 들어가 어색),
+// 단위 분리·합성 휴리스틱은 케이스마다 비결정적이라 보수적으로 처리.
 function StatCounterOrText({ value }) {
 	const str = String(value ?? '');
-	const match = str.match(/^(-?\d+(?:\.\d+)?)(.*)$/);
-	if (match) {
-		const numeric = parseFloat(match[1]);
-		const suffix = match[2];
-		const decimals = match[1].includes('.')
-			? match[1].split('.')[1].length
-			: 0;
-		return (
-			<StatCounter end={numeric} suffix={suffix} decimals={decimals} />
-		);
+	if (/^-?\d+(?:\.\d+)?$/.test(str)) {
+		const numeric = parseFloat(str);
+		const decimals = str.includes('.') ? str.split('.')[1].length : 0;
+		return <StatCounter end={numeric} decimals={decimals} />;
 	}
 	return <span>{str}</span>;
 }

--- a/apps/web/components/about/bold/AboutHero.jsx
+++ b/apps/web/components/about/bold/AboutHero.jsx
@@ -4,11 +4,12 @@ import Reveal from '../../primitives/Reveal';
 import WordReveal from '../../primitives/WordReveal';
 import Eyebrow from '../../primitives/Eyebrow';
 
-export default function AboutHero({ name, tagline, profileImage }) {
+export default function AboutHero({ name, tagline, profileImage, availability }) {
 	const displayName = name || '이석호';
 	const heroTagline =
 		tagline ||
 		'서비스의 동작 원리와 운영 구조를 함께 이해하며, 성능·안정성·운영 효율을 개선하는 백엔드 개발자입니다.';
+	const statusLabel = availability;
 
 	return (
 		<section className="pt-28 lg:pt-40 pb-16 lg:pb-24">
@@ -39,19 +40,21 @@ export default function AboutHero({ name, tagline, profileImage }) {
 					<span className="w-6 h-px" style={{ background: 'var(--line-strong)' }} />
 					<Eyebrow>About — 2026</Eyebrow>
 				</div>
-				<div className="hidden sm:flex items-center gap-2">
-					<span className="relative flex h-2 w-2">
-						<span
-							className="absolute inline-flex h-full w-full rounded-full opacity-75 animate-ping"
-							style={{ background: '#22c55e' }}
-						/>
-						<span
-							className="relative inline-flex rounded-full h-2 w-2"
-							style={{ background: '#22c55e' }}
-						/>
-					</span>
-					<Eyebrow>신입 채용 검토 중</Eyebrow>
-				</div>
+				{statusLabel && (
+					<div className="hidden sm:flex items-center gap-2">
+						<span className="relative flex h-2 w-2">
+							<span
+								className="absolute inline-flex h-full w-full rounded-full opacity-75 animate-ping"
+								style={{ background: '#22c55e' }}
+							/>
+							<span
+								className="relative inline-flex rounded-full h-2 w-2"
+								style={{ background: '#22c55e' }}
+							/>
+						</span>
+						<Eyebrow>{statusLabel}</Eyebrow>
+					</div>
+				)}
 			</Reveal>
 
 			{/* 거대 이름 + portrait */}

--- a/apps/web/components/about/bold/AboutJourney.jsx
+++ b/apps/web/components/about/bold/AboutJourney.jsx
@@ -1,41 +1,10 @@
 import Reveal from '../../primitives/Reveal';
 import Eyebrow from '../../primitives/Eyebrow';
 
-// 라군 profile.md / projects.md 기반. 후속 PR 에서 /api/about.journey[] 도입.
-const JOURNEY = [
-	{
-		year: '2026.01 — Now',
-		title: '통합 로그 시스템',
-		role: '백엔드 · 외주',
-		body: '여러 보안 솔루션 로그를 공통 스키마로 정규화하고 syslog-ng / Vector / Loki / Grafana / Teams 알림 / MCP 자연어 조회를 연결한 통합 파이프라인 구성. NestJS MCP 서버 직접 구현.',
-	},
-	{
-		year: '2025.08 — 2025.10',
-		title: '클래스업 학생앱 — 타이머 서비스',
-		role: '백엔드 · Express / MongoDB',
-		body: 'Joi 검증·전역 에러 처리·응답 형식 통일. MongoDB 복합 인덱싱으로 쿼리 77% 단축, 키셋 페이지네이션 30% 단축. WebSocket 기반 실시간 사용자 리스트.',
-	},
-	{
-		year: '2025',
-		title: '베팅덕 — 실시간 베팅 서비스',
-		role: '백엔드 · Redis 큐 / 비동기',
-		body: '베팅 종료 API 의 병목을 분석하고 Redis 기반 큐와 비동기 처리를 적용해 응답 시간을 1441ms → 333ms 로 단축.',
-	},
-	{
-		year: '2024',
-		title: 'CaTs 챗봇 · 커스텀 웹 프레임워크',
-		role: '백엔드 · 원리 학습',
-		body: 'RAG 기반 챗봇과 Node.js net 모듈 위 HTTP 파싱 / Router / Middleware 직접 구현. 라이브러리 한 줄 위의 동작 원리를 이해하기 위한 학습 프로젝트.',
-	},
-	{
-		year: '2019.03 — 2025.02',
-		title: '충북대학교 컴퓨터공학과',
-		role: '학사 · 3.76 / 4.5',
-		body: 'RLHF / TRLX 기반 학부연구 + 다수 팀 프로젝트 · 인턴 · 외주를 통해 백엔드 / 데이터 / AI 접점 경험.',
-	},
-];
+// journey 가 빈 배열이면 섹션 미렌더.
+export default function AboutJourney({ journey = [] }) {
+	if (!journey.length) return null;
 
-export default function AboutJourney() {
 	return (
 		<section
 			className="py-20 lg:py-24 border-t"
@@ -56,21 +25,12 @@ export default function AboutJourney() {
 						<span style={{ color: 'var(--indigo-soft)' }}>.</span>
 					</h2>
 				</div>
-				<div
-					className="hidden md:block text-xs"
-					style={{
-						fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
-						color: 'var(--paper-faint)',
-					}}
-				>
-					2019 → 2026
-				</div>
 			</Reveal>
 
 			<div>
-				{JOURNEY.map((row, idx) => (
+				{journey.map((row, idx) => (
 					<Reveal
-						key={row.year + row.title}
+						key={`${row.year}-${row.title}-${idx}`}
 						delay={idx * 0.06}
 						className="bold-tl-row py-[1.8rem] border-t"
 						style={{ borderColor: 'var(--line)' }}
@@ -96,12 +56,14 @@ export default function AboutJourney() {
 							>
 								{row.title}
 							</div>
-							<div
-								className="font-general-medium text-[13px] mb-3"
-								style={{ color: 'var(--paper-dim)' }}
-							>
-								{row.role}
-							</div>
+							{row.role && (
+								<div
+									className="font-general-medium text-[13px] mb-3"
+									style={{ color: 'var(--paper-dim)' }}
+								>
+									{row.role}
+								</div>
+							)}
 							<div
 								className="leading-relaxed"
 								style={{ color: 'var(--paper-dim)', maxWidth: '60ch' }}

--- a/apps/web/components/about/bold/AboutPrinciples.jsx
+++ b/apps/web/components/about/bold/AboutPrinciples.jsx
@@ -1,27 +1,10 @@
 import Reveal from '../../primitives/Reveal';
 import Eyebrow from '../../primitives/Eyebrow';
 
-// 라군 profile.md 의 핵심 강점 4개. 후속 PR 에서 /api/about.principles[] 도입.
-const PRINCIPLES = [
-	{
-		title: '원인을 끝까지 파고든다',
-		body: '문제가 생기면 겉으로 드러난 증상보다, 왜 이런 문제가 발생했는지부터 확인합니다. 다음에 또 안 일어나도록.',
-	},
-	{
-		title: '운영을 고려한 백엔드 시야',
-		body: 'API 개발에만 머물지 않고 로그, 성능, 데이터 흐름, 장애 대응, 운영 효율까지 함께 봅니다.',
-	},
-	{
-		title: '실시간성과 성능 최적화',
-		body: 'Redis, 캐시, 큐, 인덱스, 페이지네이션. 백엔드에서 자주 마주치는 성능 문제를 실제 프로젝트에서 다뤘습니다.',
-	},
-	{
-		title: '원리를 이해하고 쓴다',
-		body: '커스텀 웹 프레임워크 프로젝트에서 Node.js net 모듈 위 HTTP 파싱, Router, Middleware 까지 직접 구현. 내부 동작 원리를 이해하려 합니다.',
-	},
-];
+// principles 가 빈 배열이면 섹션 미렌더.
+export default function AboutPrinciples({ principles = [] }) {
+	if (!principles.length) return null;
 
-export default function AboutPrinciples() {
 	return (
 		<section
 			className="py-20 lg:py-24 border-t"
@@ -48,7 +31,7 @@ export default function AboutPrinciples() {
 								paddingRight: '0.1em',
 							}}
 						>
-							네 가지 원칙.
+							{principles.length}가지 원칙.
 						</span>
 					</h2>
 				</Reveal>
@@ -58,14 +41,14 @@ export default function AboutPrinciples() {
 						style={{ color: 'var(--paper-dim)' }}
 					>
 						기술은 결국 서비스를 더 잘 굴러가게 만드는 도구라고 생각합니다.
-						아래는 어떤 코드를 쓸지 고민할 때 기준으로 삼는 네 가지 원칙입니다.
+						아래는 어떤 코드를 쓸지 고민할 때 기준으로 삼는 원칙들입니다.
 					</p>
 				</Reveal>
 			</div>
 
 			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-6">
-				{PRINCIPLES.map((p, idx) => (
-					<Reveal key={p.title} delay={idx * 0.08}>
+				{principles.map((p, idx) => (
+					<Reveal key={`${p.title}-${idx}`} delay={idx * 0.08}>
 						<div
 							className="bold-interactive rounded-[18px] p-6 transition-all"
 							style={{

--- a/apps/web/pages/about.jsx
+++ b/apps/web/pages/about.jsx
@@ -15,6 +15,11 @@ const EMPTY_ABOUT = {
 	tagline: null,
 	profileImage: '/images/profile.jpeg',
 	bio: [],
+	availability: null,
+	stats: [],
+	principles: [],
+	journey: [],
+	stacks: [],
 };
 
 function About({ about }) {
@@ -25,12 +30,13 @@ function About({ about }) {
 				name={about.name}
 				tagline={about.tagline}
 				profileImage={about.profileImage}
+				availability={about.availability}
 			/>
 			<AboutBioSection bio={about.bio} />
-			<AboutCounters />
-			<AboutPrinciples />
-			<AboutJourney />
-			<AboutBrands />
+			<AboutCounters stats={about.stats} />
+			<AboutPrinciples principles={about.principles} />
+			<AboutJourney journey={about.journey} />
+			<AboutBrands stacks={about.stacks} />
 			<AboutContactCTA />
 		</>
 	);

--- a/apps/web/pages/admin/about.jsx
+++ b/apps/web/pages/admin/about.jsx
@@ -9,18 +9,46 @@ import FormInput from '../../components/reusable/FormInput';
 import { AdminApiError, fetchAdmin } from '../../lib/admin/api';
 import { requireAuth } from '../../lib/admin/requireAuth';
 
+// 신규 DynamicList 항목 key 가 고유하도록 카운터 사용 (Math.random 보다 안정).
+let __keyCounter = 0;
+const nextKey = (prefix) => `${prefix}-${++__keyCounter}-${Date.now()}`;
+
 function toFormState(about) {
 	return {
 		name: about?.name ?? '',
 		tagline: about?.tagline ?? '',
 		profileImage: about?.profileImage ?? '',
-		bio: (about?.bio ?? []).map((paragraph, i) => ({
-			_key: `bio-${i}-${Math.random()}`,
+		bio: (about?.bio ?? []).map((paragraph) => ({
+			_key: nextKey('bio'),
 			paragraph,
 		})),
 		address: about?.address ?? '',
 		email: about?.email ?? '',
 		phone: about?.phone ?? '',
+		// Bold 리디자인 후속 — 신규 5개 필드.
+		availability: about?.availability ?? '',
+		stats: (about?.stats ?? []).map((s) => ({
+			_key: nextKey('stat'),
+			label: s.label ?? '',
+			value: s.value ?? '',
+			sub: s.sub ?? '',
+		})),
+		principles: (about?.principles ?? []).map((p) => ({
+			_key: nextKey('principle'),
+			title: p.title ?? '',
+			body: p.body ?? '',
+		})),
+		journey: (about?.journey ?? []).map((j) => ({
+			_key: nextKey('journey'),
+			year: j.year ?? '',
+			title: j.title ?? '',
+			role: j.role ?? '',
+			body: j.body ?? '',
+		})),
+		stacks: (about?.stacks ?? []).map((stack) => ({
+			_key: nextKey('stack'),
+			value: stack,
+		})),
 	};
 }
 
@@ -52,6 +80,28 @@ function AdminAboutEditor({ initialAbout }) {
 				address: form.address.trim() || null,
 				email: form.email.trim() || null,
 				phone: form.phone.trim() || null,
+				availability: form.availability.trim() || null,
+				stats: form.stats
+					.filter((s) => s.label.trim() && s.value.trim())
+					.map((s) => ({
+						label: s.label.trim(),
+						value: s.value.trim(),
+						sub: s.sub.trim() || null,
+					})),
+				principles: form.principles
+					.filter((p) => p.title.trim() && p.body.trim())
+					.map((p) => ({ title: p.title.trim(), body: p.body.trim() })),
+				journey: form.journey
+					.filter((j) => j.year.trim() && j.title.trim() && j.body.trim())
+					.map((j) => ({
+						year: j.year.trim(),
+						title: j.title.trim(),
+						role: j.role.trim() || null,
+						body: j.body.trim(),
+					})),
+				stacks: form.stacks
+					.map((s) => s.value.trim())
+					.filter((v) => v.length > 0),
 			};
 			const saved = await fetchAdmin('/api/admin/about', {
 				method: 'PUT',
@@ -69,6 +119,9 @@ function AdminAboutEditor({ initialAbout }) {
 			setSubmitting(false);
 		}
 	}
+
+	const inputClass =
+		'w-full px-3 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-secondary-dark rounded-md text-sm font-general-regular';
 
 	return (
 		<AdminLayout title="About">
@@ -176,17 +229,184 @@ function AdminAboutEditor({ initialAbout }) {
 					<DynamicList
 						items={form.bio}
 						onChange={(next) => set('bio', next)}
-						emptyItem={() => ({ _key: `bio-${Date.now()}`, paragraph: '' })}
+						emptyItem={() => ({ _key: nextKey('bio'), paragraph: '' })}
 						addLabel="단락 추가"
 						renderItem={(item, _idx, onItemChange) => (
 							<textarea
-								className="w-full px-3 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-secondary-dark rounded-md text-sm font-mono"
+								className={inputClass}
 								rows={6}
 								placeholder="단락 본문 (마크다운 가능)"
 								aria-label="Bio paragraph"
 								value={item.paragraph}
 								onChange={(e) => onItemChange({ paragraph: e.target.value })}
 								required
+							/>
+						)}
+					/>
+				</AdminFormSection>
+
+				{/* === Bold 리디자인 후속 5개 섹션 === */}
+				<AdminFormSection
+					title="Hero Status (Availability)"
+					description="About 페이지 Hero 우측 상단 status 한 줄. 비워두면 'About — 2026' 만 표시됩니다."
+				>
+					<input
+						id="about-availability"
+						type="text"
+						placeholder="예: 신입 채용 검토 중"
+						aria-label="Availability"
+						className="w-full px-5 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-ternary-dark rounded-md shadow-sm text-md font-general-regular"
+						value={form.availability}
+						onChange={(e) => set('availability', e.target.value)}
+					/>
+				</AdminFormSection>
+
+				<AdminFormSection
+					title="In Numbers (Stats)"
+					description="About 의 '측정된 흔적' 섹션. label/value 가 비어있는 항목은 저장 시 자동 제거됩니다."
+				>
+					<DynamicList
+						items={form.stats}
+						onChange={(next) => set('stats', next)}
+						emptyItem={() => ({
+							_key: nextKey('stat'),
+							label: '',
+							value: '',
+							sub: '',
+						})}
+						addLabel="지표 추가"
+						renderItem={(item, _idx, onItemChange) => (
+							<div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+								<input
+									className={inputClass}
+									placeholder="Label (예: Shipped Projects)"
+									aria-label="Stat label"
+									value={item.label}
+									onChange={(e) => onItemChange({ label: e.target.value })}
+								/>
+								<input
+									className={inputClass}
+									placeholder="Value (예: 6)"
+									aria-label="Stat value"
+									value={item.value}
+									onChange={(e) => onItemChange({ value: e.target.value })}
+								/>
+								<input
+									className={inputClass}
+									placeholder="설명 (선택)"
+									aria-label="Stat sub"
+									value={item.sub}
+									onChange={(e) => onItemChange({ sub: e.target.value })}
+								/>
+							</div>
+						)}
+					/>
+				</AdminFormSection>
+
+				<AdminFormSection
+					title="Principles"
+					description="About 의 '작업을 이끄는 원칙' 섹션. title/body 둘 다 있어야 저장됩니다."
+				>
+					<DynamicList
+						items={form.principles}
+						onChange={(next) => set('principles', next)}
+						emptyItem={() => ({
+							_key: nextKey('principle'),
+							title: '',
+							body: '',
+						})}
+						addLabel="원칙 추가"
+						renderItem={(item, _idx, onItemChange) => (
+							<div className="flex flex-col gap-2">
+								<input
+									className={inputClass}
+									placeholder="원칙 제목 (예: 원인을 끝까지 파고든다)"
+									aria-label="Principle title"
+									value={item.title}
+									onChange={(e) => onItemChange({ title: e.target.value })}
+								/>
+								<textarea
+									className={inputClass}
+									rows={3}
+									placeholder="원칙 본문"
+									aria-label="Principle body"
+									value={item.body}
+									onChange={(e) => onItemChange({ body: e.target.value })}
+								/>
+							</div>
+						)}
+					/>
+				</AdminFormSection>
+
+				<AdminFormSection
+					title="Journey"
+					description="About 의 '지나온 길' 타임라인. year/title/body 셋 다 있어야 저장됩니다. year 는 '2026.01 — Now' 같은 자유 표현."
+				>
+					<DynamicList
+						items={form.journey}
+						onChange={(next) => set('journey', next)}
+						emptyItem={() => ({
+							_key: nextKey('journey'),
+							year: '',
+							title: '',
+							role: '',
+							body: '',
+						})}
+						addLabel="경력 추가"
+						renderItem={(item, _idx, onItemChange) => (
+							<div className="flex flex-col gap-2">
+								<div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+									<input
+										className={inputClass}
+										placeholder="Year (예: 2026.01 — Now)"
+										aria-label="Journey year"
+										value={item.year}
+										onChange={(e) => onItemChange({ year: e.target.value })}
+									/>
+									<input
+										className={inputClass}
+										placeholder="Title (예: 통합 로그 시스템)"
+										aria-label="Journey title"
+										value={item.title}
+										onChange={(e) => onItemChange({ title: e.target.value })}
+									/>
+								</div>
+								<input
+									className={inputClass}
+									placeholder="Role (선택, 예: 백엔드 · 외주)"
+									aria-label="Journey role"
+									value={item.role}
+									onChange={(e) => onItemChange({ role: e.target.value })}
+								/>
+								<textarea
+									className={inputClass}
+									rows={3}
+									placeholder="Body"
+									aria-label="Journey body"
+									value={item.body}
+									onChange={(e) => onItemChange({ body: e.target.value })}
+								/>
+							</div>
+						)}
+					/>
+				</AdminFormSection>
+
+				<AdminFormSection
+					title="Tech Stack"
+					description="About 의 'Tech Stack' 그리드. 한 칸에 한 항목씩 입력. 비워둔 항목은 저장 시 자동 제거."
+				>
+					<DynamicList
+						items={form.stacks}
+						onChange={(next) => set('stacks', next)}
+						emptyItem={() => ({ _key: nextKey('stack'), value: '' })}
+						addLabel="스택 추가"
+						renderItem={(item, _idx, onItemChange) => (
+							<input
+								className={inputClass}
+								placeholder="예: NestJS"
+								aria-label="Tech stack"
+								value={item.value}
+								onChange={(e) => onItemChange({ value: e.target.value })}
 							/>
 						)}
 					/>


### PR DESCRIPTION
## 무엇을

PR #90 (About UI) 의 하드코딩 데이터를 백엔드 모델로 끌어올림. DB 마이그레이션 + API + admin UI + web 동적화 일괄.

### 4 commits

| commit | 내용 |
|---|---|
| (1) | About 엔티티 확장 (availability/stacks/Stat/Principle/Journey) + migration |
| (2) | API DTO·service 가 신규 필드 처리 (전량교체 패턴 + sortOrder 정렬) |
| (3) | admin About 폼에 신규 5개 섹션 입력 (DynamicList 재사용) |
| (4) | About 페이지 5개 영역 API 데이터 동적화 (빈 값 시 섹션 미렌더) |

### 신규 백엔드 모델

| 필드 | 형태 |
|---|---|
| \`availability\` | varchar(255) null — Hero status |
| \`stacks\` | json null — Tech Stack 단순 string[] |
| \`AboutStat\` | OneToMany (label/value/sub/sortOrder) — In Numbers |
| \`AboutPrinciple\` | OneToMany (title/body/sortOrder) — Principles |
| \`AboutJourney\` | OneToMany (year/title/role/body/sortOrder) — Journey |

migration \`AddAboutExtendedFields1779372689864\` — ALTER ABOUT_PROFILE × 2 + CREATE TABLE × 3 (FK ON DELETE CASCADE). down() 도 작성. \`migrationsRun: true\` 라 api 재배포 시 자동 적용.

### API 변경

- response DTO: 5개 신규 필드 + nested DTO 3개. 모두 빈 default → 후방 호환
- upsert DTO: 5개 필드 + \`@ValidateNested @Type(...) @ArrayMaxSize\` + trim 정규화
- mapper: sortOrder 정렬 stats/principles/journeys 까지 확장
- AdminAboutService.upsert: bio 전량교체 패턴을 신규 3 OneToMany 에도 적용. 단일 transaction. availability/stacks 는 단일 컬럼이라 그대로 set
- repository.findProfile relations 에 stats/principles/journeys 추가
- spec 3개 갱신 — 27 suite / 128 test 모두 pass

### Admin UI

\`/admin/about\` 에 5개 AdminFormSection 추가. 기존 bio[] DynamicList 패턴 그대로 재사용.

- Availability — FormInput (한 줄)
- In Numbers (stats) — DynamicList object (label/value/sub 3-column grid)
- Principles — DynamicList object (title input + body textarea)
- Journey — DynamicList object (year+title 2-column / role / body)
- Tech Stack — DynamicList string

필수 필드 비어있는 row 는 저장 시 자동 제거. \`_key\` 안정화 위해 nextKey 헬퍼 도입 (Math.random 대신).

### Web 동적화

\`apps/web/components/about/bold/\` 5개 컴포넌트의 하드코딩 데이터 제거 → props 로 받기. **빈 값 시 섹션 자체 미렌더** — 어드민 입력 전 페이지 깨짐 회피. AboutCounters 는 숫자값이면 react-countup, 단위 섞인 문자열(예: '333ms')은 그대로 노출.

## 영향

- prod DB (dev/prod 공유) migration 한 번 적용. 신규 필드 모두 nullable / 빈 default — 기존 응답 + 기존 prod 코드 모두 무영향
- 본 PR dev 머지 직후 \`/about\` 의 4개 영역 (Counters/Principles/Journey/Tech Stack) 과 Hero status 가 모두 빈 값 → 섹션 미렌더. 라군이 admin 입력 후 노출

## 수동 확인 (dev 머지 후)

- [ ] api 컨테이너 부팅 로그에 \`AddAboutExtendedFields\` migration 실행 확인
- [ ] DB \`SHOW TABLES\` 로 ABOUT_STAT/PRINCIPLE/JOURNEY 존재
- [ ] \`curl https://portfolio-dev-api.llagoon.dev/api/about\` 응답에 신규 필드 (초기 null/[])
- [ ] \`/about\` 페이지 — Hero status, Counters/Principles/Journey/Brands 섹션 모두 미노출 (Hero/Bio/CTA 만)
- [ ] \`/admin/about\` 에서 5개 섹션 입력/저장/로드 동작
- [ ] About 페이지 새로고침 — 입력값으로 섹션 노출
- [ ] 일부만 입력 후 다른 섹션 비워두기 → 비운 섹션 미렌더
- [ ] DARK/LIGHT / 모바일 / reduced-motion 정상
- [ ] \`/\`, \`/projects\`, \`/contact\` 무영향

## 보류 (별도 PR)

- Home Marquee \`KEYWORDS\` 와 About \`stacks\` 통합 검토
- Home AboutStrip stats 재도입
- Project Detail 백엔드 확장

Closes #91
Refs #70 #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)