### PR TITLE
[fix] Contact Bold UI 마무리 (구분선 + Toast 줄바꿈)

### DIFF
--- a/apps/web/components/contact/bold/BoldContactForm.jsx
+++ b/apps/web/components/contact/bold/BoldContactForm.jsx
@@ -73,10 +73,7 @@ export default function BoldContactForm() {
 	};
 
 	return (
-		<section
-			className="py-16 lg:py-20 border-t"
-			style={{ borderColor: 'var(--line)' }}
-		>
+		<section className="py-0">
 			<Reveal>
 				<Eyebrow className="mb-6">— Send a message</Eyebrow>
 				<form onSubmit={handleSubmit} className="flex flex-col gap-5">
@@ -178,7 +175,7 @@ export default function BoldContactForm() {
 			</Reveal>
 			<Toast
 				visible={toastVisible}
-				message="메시지가 전송됐어요. 곧 회신드릴게요."
+				message={'메시지가 전송됐어요.\n곧 회신드릴게요.'}
 				onClose={() => setToastVisible(false)}
 			/>
 		</section>

--- a/apps/web/components/primitives/Toast.jsx
+++ b/apps/web/components/primitives/Toast.jsx
@@ -13,12 +13,13 @@ export default function Toast({ visible, message, onClose, duration = 2000 }) {
 		<div
 			role="status"
 			aria-live="polite"
-			className="fixed z-[80] left-1/2 -translate-x-1/2 bottom-8 px-4 py-2.5 rounded-full text-sm pointer-events-none"
+			className="fixed z-[80] left-1/2 -translate-x-1/2 bottom-8 px-4 py-2.5 rounded-2xl text-sm pointer-events-none text-center"
 			style={{
 				background: 'var(--paper)',
 				color: 'var(--ink)',
 				fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
 				boxShadow: '0 8px 30px -10px rgba(0,0,0,0.3)',
+				whiteSpace: 'pre-line',
 				opacity: visible ? 1 : 0,
 				transform: visible
 					? 'translate(-50%, 0)'

--- a/apps/web/pages/contact.jsx
+++ b/apps/web/pages/contact.jsx
@@ -24,7 +24,7 @@ function Contact({ contact }) {
 				<BoldContactBigEmail email={contact.email} />
 
 				<section
-					className="grid grid-cols-1 lg:grid-cols-12 gap-10 lg:gap-16 py-16 lg:py-20 border-t"
+					className="grid grid-cols-1 lg:grid-cols-12 gap-10 lg:gap-16 py-16 lg:py-20 border-t border-b"
 					style={{ borderColor: 'var(--line)' }}
 				>
 					<div className="lg:col-span-7">


### PR DESCRIPTION
## Summary
PR #94 머지 직전 dev-preview 에서 확인 완료한 시각 수정이 push 누락으로 합류 못 한 fix 후속.

- `BoldContactForm`: 자체 `border-t` 제거 → BigEmail/Form 사이 구분선이 grid section + Form 양쪽에 걸려 2줄로 보이던 문제 해결
- `pages/contact.jsx` grid section: `border-b` 추가 → 메시지 보내기 버튼 아래 footer 사이 구분선 노출
- `Toast`: `whiteSpace: pre-line` + `text-center` + `rounded-2xl`. "메시지가 전송됐어요. \n 곧 회신드릴게요." 2줄 메시지 지원

## Test plan
- [ ] dev 머지 → cd-dev → `/contact` BigEmail ↔ Form 사이 구분선 1줄
- [ ] Form/Sidebar grid 하단 구분선 노출
- [ ] 메시지 보내기 → Toast 2줄 (가운데 정렬)
- [ ] DARK/LIGHT 토글 정상

Closes #96
Refs #93 #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)