### PR TITLE
[feat] Projects 페이지 Bold 리디자인

### DIFF
--- a/apps/api/src/modules/projects/dto/project-list-item.dto.ts
+++ b/apps/api/src/modules/projects/dto/project-list-item.dto.ts
@@ -15,4 +15,7 @@ export class ProjectListItemDto {
 
   @ApiProperty({ example: '/images/web-project-2.jpg' })
   img!: string;
+
+  @ApiProperty({ example: '2026.01 – 2026.03', description: 'Bold 리스트의 연도 stat/그룹/뱃지에 사용. web 에서 첫 4자리를 파싱.' })
+  headerPublishDate!: string;
 }

--- a/apps/api/src/modules/projects/projects.controller.spec.ts
+++ b/apps/api/src/modules/projects/projects.controller.spec.ts
@@ -26,7 +26,14 @@ describe('ProjectsController', () => {
 
   it('list: service.list 결과를 그대로 반환한다', async () => {
     const data = [
-      { id: 1, title: 'A', url: 'a', category: 'Web Application', img: '/a' },
+      {
+        id: 1,
+        title: 'A',
+        url: 'a',
+        category: 'Web Application',
+        img: '/a',
+        headerPublishDate: '2026.01',
+      },
     ];
     service.list.mockResolvedValue(data);
 

--- a/apps/api/src/modules/projects/projects.service.spec.ts
+++ b/apps/api/src/modules/projects/projects.service.spec.ts
@@ -66,6 +66,7 @@ describe('ProjectsService', () => {
         url: 'a',
         category: 'Web Application',
         img: '/img.jpg',
+        headerPublishDate: 'Jan 1, 2026',
       },
       {
         id: 2,
@@ -73,6 +74,7 @@ describe('ProjectsService', () => {
         url: 'b',
         category: 'Web Application',
         img: '/img.jpg',
+        headerPublishDate: 'Jan 1, 2026',
       },
     ]);
   });

--- a/apps/api/src/modules/projects/projects.service.ts
+++ b/apps/api/src/modules/projects/projects.service.ts
@@ -19,6 +19,7 @@ export class ProjectsService {
       url: project.url,
       category: project.category,
       img: project.thumbnailImg,
+      headerPublishDate: project.headerPublishDate,
     }));
   }
 

--- a/apps/web/components/projects/bold/BoldProjectsCTA.jsx
+++ b/apps/web/components/projects/bold/BoldProjectsCTA.jsx
@@ -1,0 +1,44 @@
+import Link from 'next/link';
+import Reveal from '../../primitives/Reveal';
+import WordReveal from '../../primitives/WordReveal';
+import Eyebrow from '../../primitives/Eyebrow';
+import PillButton from '../../primitives/PillButton';
+
+export default function BoldProjectsCTA() {
+	return (
+		<section
+			className="py-20 lg:py-28 border-t"
+			style={{ borderColor: 'var(--line)' }}
+		>
+			<Reveal className="mb-6">
+				<Eyebrow>— Have a project?</Eyebrow>
+			</Reveal>
+
+			<WordReveal
+				className="font-general-semibold"
+				style={{
+					fontSize: 'clamp(2.6rem, 11vw, 12rem)',
+					letterSpacing: '-0.04em',
+					lineHeight: 1.0,
+				}}
+				items={[{ text: '같이' }, { text: '만들어요.', accent: true }]}
+			/>
+
+			<Reveal delay={0.16} className="mt-12">
+				<PillButton href="/contact" variant="cta" ariaLabel="문의하기로 이동">
+					<span>메일로 시작하기</span>
+					<svg
+						className="w-4 h-4"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						aria-hidden="true"
+					>
+						<path d="M5 12h14M13 6l6 6-6 6" />
+					</svg>
+				</PillButton>
+			</Reveal>
+		</section>
+	);
+}

--- a/apps/web/components/projects/bold/BoldProjectsControls.jsx
+++ b/apps/web/components/projects/bold/BoldProjectsControls.jsx
@@ -1,0 +1,122 @@
+import Reveal from '../../primitives/Reveal';
+import Chip from '../../primitives/Chip';
+
+const SORT_OPTIONS = [
+	{ key: 'newest', label: '최신순' },
+	{ key: 'oldest', label: '오래된순' },
+	{ key: 'az', label: 'A → Z' },
+	{ key: 'cat', label: '카테고리' },
+];
+
+export default function BoldProjectsControls({
+	categories,
+	activeCategory,
+	onCategoryChange,
+	search,
+	onSearchChange,
+	sort,
+	onSortChange,
+	view,
+	onViewChange,
+}) {
+	return (
+		<Reveal>
+			<div
+				className="py-8 lg:py-10 border-t flex flex-col gap-5"
+				style={{ borderColor: 'var(--line)' }}
+			>
+				{/* category chips */}
+				<div className="flex flex-wrap items-center gap-2">
+					{categories.map((c) => (
+						<Chip
+							key={c.key}
+							label={c.label}
+							count={c.count}
+							active={c.key === activeCategory}
+							onClick={() => onCategoryChange(c.key)}
+						/>
+					))}
+				</div>
+
+				{/* search + sort + view toggle */}
+				<div className="flex flex-col sm:flex-row sm:items-center gap-3">
+					<input
+						type="search"
+						value={search}
+						onChange={(e) => onSearchChange(e.target.value)}
+						placeholder="제목·카테고리 검색"
+						aria-label="프로젝트 검색"
+						className="flex-1 min-w-0"
+						style={{
+							background: 'transparent',
+							border: '1px solid var(--line-strong)',
+							borderRadius: '12px',
+							color: 'var(--paper)',
+							padding: '0.65rem 1rem',
+							fontSize: '14px',
+							fontFamily: 'inherit',
+						}}
+					/>
+					<select
+						value={sort}
+						onChange={(e) => onSortChange(e.target.value)}
+						aria-label="정렬"
+						className="bold-interactive"
+						style={{
+							background: 'transparent',
+							border: '1px solid var(--line-strong)',
+							borderRadius: '12px',
+							color: 'var(--paper)',
+							padding: '0.65rem 1rem',
+							fontSize: '14px',
+							fontFamily: 'inherit',
+							cursor: 'pointer',
+						}}
+					>
+						{SORT_OPTIONS.map((o) => (
+							<option key={o.key} value={o.key} style={{ background: 'var(--ink)', color: 'var(--paper)' }}>
+								{o.label}
+							</option>
+						))}
+					</select>
+					<div className="flex items-center gap-1" role="tablist" aria-label="보기 전환">
+						<ViewToggle current={view} value="grid" onClick={onViewChange} aria-label="Grid view">
+							<svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+								<rect x="3" y="3" width="7" height="7" />
+								<rect x="14" y="3" width="7" height="7" />
+								<rect x="3" y="14" width="7" height="7" />
+								<rect x="14" y="14" width="7" height="7" />
+							</svg>
+						</ViewToggle>
+						<ViewToggle current={view} value="list" onClick={onViewChange} aria-label="List view">
+							<svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+								<path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01" />
+							</svg>
+						</ViewToggle>
+					</div>
+				</div>
+			</div>
+		</Reveal>
+	);
+}
+
+function ViewToggle({ current, value, onClick, children, ...rest }) {
+	const active = current === value;
+	return (
+		<button
+			type="button"
+			role="tab"
+			aria-selected={active}
+			onClick={() => onClick(value)}
+			className="bold-interactive inline-flex items-center justify-center w-10 h-10 rounded-full transition-all duration-300"
+			style={{
+				background: active ? 'var(--paper)' : 'transparent',
+				color: active ? 'var(--ink)' : 'var(--paper)',
+				border: `1px solid ${active ? 'var(--paper)' : 'var(--line-strong)'}`,
+			}}
+			{...rest}
+		>
+			{children}
+		</button>
+	);
+}

--- a/apps/web/components/projects/bold/BoldProjectsGrid.jsx
+++ b/apps/web/components/projects/bold/BoldProjectsGrid.jsx
@@ -1,0 +1,120 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import Reveal from '../../primitives/Reveal';
+
+export default function BoldProjectsGrid({ projects = [] }) {
+	if (!projects.length) return <EmptyState />;
+
+	return (
+		<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8 py-12 lg:py-16">
+			{projects.map((p, idx) => (
+				<Reveal key={p.id} delay={(idx % 6) * 0.06}>
+					<Link
+						href={`/projects/${p.url}`}
+						aria-label={p.title}
+						className="bold-interactive block group"
+					>
+						<div
+							className="relative overflow-hidden rounded-[18px]"
+							style={{
+								border: '1px solid var(--line-strong)',
+								aspectRatio: '4 / 5',
+								background:
+									'linear-gradient(135deg, rgba(99,102,241,0.18), rgba(99,102,241,0.04))',
+							}}
+						>
+							{p.img && (
+								<Image
+									src={p.img}
+									alt={p.title}
+									fill
+									sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+									className="transition-transform duration-700 group-hover:scale-105"
+									style={{ objectFit: 'cover' }}
+								/>
+							)}
+							{/* 하단 어둠 veil */}
+							<div
+								className="absolute inset-0 pointer-events-none"
+								style={{
+									background:
+										'linear-gradient(180deg, transparent 45%, rgba(7,14,23,0.85) 100%)',
+								}}
+								aria-hidden="true"
+							/>
+							{/* 우상단 화살표 */}
+							<div
+								className="absolute top-4 right-4 w-10 h-10 rounded-full flex items-center justify-center transition-transform duration-500 group-hover:rotate-[-45deg]"
+								style={{
+									background: 'rgba(255,255,255,0.12)',
+									backdropFilter: 'blur(6px)',
+									border: '1px solid rgba(255,255,255,0.18)',
+								}}
+								aria-hidden="true"
+							>
+								<svg
+									className="w-4 h-4"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2"
+									style={{ color: '#ffffff' }}
+								>
+									<path d="M5 12h14M13 6l6 6-6 6" />
+								</svg>
+							</div>
+							{/* 좌하단 메타 */}
+							<div className="absolute left-5 right-5 bottom-5 z-[2]">
+								<div
+									className="text-[10px] uppercase mb-2"
+									style={{
+										fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+										letterSpacing: '0.14em',
+										color: 'rgba(255,255,255,0.7)',
+									}}
+								>
+									{p.category}
+									{p.year ? ` · ${p.year}` : ''}
+								</div>
+								<div
+									className="font-general-semibold leading-tight"
+									style={{
+										fontSize: 'clamp(1.1rem, 1.6vw, 1.5rem)',
+										letterSpacing: '-0.02em',
+										color: '#ffffff',
+										wordBreak: 'keep-all',
+									}}
+								>
+									{p.title}
+								</div>
+							</div>
+						</div>
+					</Link>
+				</Reveal>
+			))}
+		</div>
+	);
+}
+
+function EmptyState() {
+	return (
+		<div
+			className="my-12 lg:my-16 py-16 rounded-[18px] text-center"
+			style={{
+				border: '1px dashed var(--line-strong)',
+				color: 'var(--paper-dim)',
+			}}
+		>
+			<div
+				className="text-xs uppercase mb-2"
+				style={{
+					fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+					letterSpacing: '0.14em',
+				}}
+			>
+				No results
+			</div>
+			<div className="text-base">조건에 맞는 프로젝트가 없어요.</div>
+		</div>
+	);
+}

--- a/apps/web/components/projects/bold/BoldProjectsHero.jsx
+++ b/apps/web/components/projects/bold/BoldProjectsHero.jsx
@@ -1,0 +1,96 @@
+import Link from 'next/link';
+import Reveal from '../../primitives/Reveal';
+import WordReveal from '../../primitives/WordReveal';
+import Eyebrow from '../../primitives/Eyebrow';
+import StatCounter from '../../primitives/StatCounter';
+
+export default function BoldProjectsHero({ totalCount, categoryCount, yearCount }) {
+	return (
+		<section className="pt-28 lg:pt-40 pb-16 lg:pb-20">
+			{/* 상단 breadcrumb */}
+			<Reveal className="flex items-center gap-3 mb-10">
+				<Link
+					href="/"
+					className="bold-interactive flex items-center gap-1.5 transition"
+					style={{
+						fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+						fontSize: '0.75rem',
+						color: 'var(--paper-faint)',
+					}}
+				>
+					<svg
+						className="w-3 h-3"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						aria-hidden="true"
+					>
+						<path d="M19 12H5M12 19l-7-7 7-7" />
+					</svg>
+					홈
+				</Link>
+				<span className="w-6 h-px" style={{ background: 'var(--line-strong)' }} />
+				<Eyebrow>All Projects — 2026</Eyebrow>
+			</Reveal>
+
+			{/* 거대 타이틀 */}
+			<WordReveal
+				className="font-general-semibold"
+				style={{
+					fontSize: 'clamp(2.6rem, 11vw, 12rem)',
+					letterSpacing: '-0.04em',
+					lineHeight: 1.0,
+				}}
+				items={[{ text: '모든' }, { br: true }, { text: '작업.', accent: true }]}
+			/>
+
+			{/* tagline */}
+			<Reveal
+				as="p"
+				delay={0.24}
+				className="mt-12 lg:mt-16 max-w-3xl font-general-semibold"
+				style={{
+					fontSize: 'clamp(1.4rem, 2.2vw, 2.4rem)',
+					lineHeight: 1.2,
+					letterSpacing: '-0.02em',
+				}}
+			>
+				직접 만들거나 함께 만든 것들. 결정의 기록.
+			</Reveal>
+
+			{/* stats — Total / Categories / Years */}
+			<div
+				className="mt-14 lg:mt-20 grid grid-cols-3 gap-6 lg:gap-12 pt-8 lg:pt-10 border-t"
+				style={{ borderColor: 'var(--line-strong)' }}
+			>
+				<StatItem label="Total" value={totalCount} delay={0.0} />
+				<StatItem label="Categories" value={categoryCount} delay={0.08} />
+				<StatItem label="Years" value={yearCount} delay={0.16} />
+			</div>
+		</section>
+	);
+}
+
+function StatItem({ label, value, delay }) {
+	return (
+		<Reveal delay={delay}>
+			<div
+				className="font-general-semibold"
+				style={{
+					fontSize: 'clamp(2rem, 5vw, 4rem)',
+					letterSpacing: '-0.05em',
+					lineHeight: 1,
+					background:
+						'linear-gradient(180deg, var(--paper) 0%, color-mix(in oklab, var(--paper) 55%, transparent) 100%)',
+					WebkitBackgroundClip: 'text',
+					backgroundClip: 'text',
+					color: 'transparent',
+				}}
+			>
+				<StatCounter end={Number(value) || 0} />
+			</div>
+			<Eyebrow className="mt-3">{label}</Eyebrow>
+		</Reveal>
+	);
+}

--- a/apps/web/components/projects/bold/BoldProjectsList.jsx
+++ b/apps/web/components/projects/bold/BoldProjectsList.jsx
@@ -1,0 +1,213 @@
+import { useRef, useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import Reveal from '../../primitives/Reveal';
+import useReducedMotion from '../../../hooks/useReducedMotion';
+
+// newest/oldest 모드일 때만 연도 그룹 헤더 노출. az/cat 모드면 그룹 안 묶고 일렬.
+const GROUPED_MODES = new Set(['newest', 'oldest']);
+
+export default function BoldProjectsList({ projects = [], sort = 'newest' }) {
+	const reduced = useReducedMotion();
+	const containerRef = useRef(null);
+	const [hover, setHover] = useState(null); // { x, y, img, title }
+
+	if (!projects.length) {
+		return (
+			<div
+				className="my-12 lg:my-16 py-16 rounded-[18px] text-center"
+				style={{
+					border: '1px dashed var(--line-strong)',
+					color: 'var(--paper-dim)',
+				}}
+			>
+				<div
+					className="text-xs uppercase mb-2"
+					style={{
+						fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+						letterSpacing: '0.14em',
+					}}
+				>
+					No results
+				</div>
+				<div className="text-base">조건에 맞는 프로젝트가 없어요.</div>
+			</div>
+		);
+	}
+
+	const grouped = GROUPED_MODES.has(sort)
+		? groupByYear(projects)
+		: [{ year: null, items: projects }];
+
+	const handleMove = (e, p) => {
+		if (reduced) return;
+		if (typeof window === 'undefined' || window.innerWidth < 768) return;
+		const rect = containerRef.current?.getBoundingClientRect();
+		if (!rect) return;
+		setHover({
+			x: e.clientX - rect.left,
+			y: e.clientY - rect.top,
+			img: p.img,
+			title: p.title,
+		});
+	};
+
+	const handleLeave = () => setHover(null);
+
+	let runningIndex = 0;
+
+	return (
+		<div
+			ref={containerRef}
+			className="relative py-12 lg:py-16"
+			onMouseLeave={handleLeave}
+		>
+			{grouped.map((group) => (
+				<div key={group.year ?? 'all'} className="mb-10 lg:mb-14 last:mb-0">
+					{group.year && (
+						<Reveal>
+							<div
+								className="flex items-baseline gap-4 pb-4 mb-2 border-b"
+								style={{ borderColor: 'var(--line-strong)' }}
+							>
+								<span
+									className="font-general-semibold"
+									style={{
+										fontSize: 'clamp(2rem, 4vw, 3rem)',
+										letterSpacing: '-0.04em',
+										lineHeight: 1,
+									}}
+								>
+									{group.year}
+								</span>
+								<span
+									className="text-xs uppercase"
+									style={{
+										fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+										letterSpacing: '0.14em',
+										color: 'var(--paper-faint)',
+									}}
+								>
+									{String(group.items.length).padStart(2, '0')} project{group.items.length === 1 ? '' : 's'}
+								</span>
+							</div>
+						</Reveal>
+					)}
+
+					{group.items.map((p) => {
+						runningIndex += 1;
+						return (
+							<Reveal key={p.id}>
+								<Link
+									href={`/projects/${p.url}`}
+									aria-label={p.title}
+									className="bold-interactive group block"
+									onMouseMove={(e) => handleMove(e, p)}
+								>
+									<div
+										className="grid items-center gap-4 py-5 lg:py-6 border-b transition-colors"
+										style={{
+											borderColor: 'var(--line)',
+											gridTemplateColumns: 'minmax(40px, 60px) 1fr auto auto 40px',
+										}}
+									>
+										<span
+											className="text-xs"
+											style={{
+												fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+												letterSpacing: '0.12em',
+												color: 'var(--paper-faint)',
+											}}
+										>
+											{String(runningIndex).padStart(2, '0')}
+										</span>
+										<span
+											className="font-general-semibold transition-transform duration-300 group-hover:translate-x-2"
+											style={{
+												fontSize: 'clamp(1.3rem, 2.2vw, 2.2rem)',
+												letterSpacing: '-0.02em',
+												lineHeight: 1.1,
+												wordBreak: 'keep-all',
+											}}
+										>
+											{p.title}
+										</span>
+										<span
+											className="hidden md:inline text-xs uppercase whitespace-nowrap"
+											style={{
+												fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+												letterSpacing: '0.12em',
+												color: 'var(--paper-dim)',
+											}}
+										>
+											{p.category}
+										</span>
+										<span
+											className="hidden md:inline text-xs whitespace-nowrap"
+											style={{
+												fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+												letterSpacing: '0.12em',
+												color: 'var(--paper-faint)',
+											}}
+										>
+											{p.year ?? '—'}
+										</span>
+										<span
+											className="inline-flex items-center justify-center w-9 h-9 rounded-full transition-transform duration-300 group-hover:rotate-[-45deg]"
+											style={{
+												border: '1px solid var(--line-strong)',
+												color: 'var(--paper)',
+											}}
+											aria-hidden="true"
+										>
+											<svg viewBox="0 0 24 24" className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2">
+												<path d="M5 12h14M13 6l6 6-6 6" />
+											</svg>
+										</span>
+									</div>
+								</Link>
+							</Reveal>
+						);
+					})}
+				</div>
+			))}
+
+			{/* mousemove 따라다니는 썸네일 (>=768px 만, reduced-motion 비활성) */}
+			{hover && (
+				<div
+					className="hidden md:block pointer-events-none absolute z-10 overflow-hidden rounded-[14px]"
+					style={{
+						left: hover.x + 24,
+						top: hover.y - 90,
+						width: 240,
+						height: 180,
+						border: '1px solid var(--line-strong)',
+						boxShadow: '0 20px 60px -20px rgba(0,0,0,0.6)',
+						background: 'var(--ink)',
+					}}
+					aria-hidden="true"
+				>
+					{hover.img && (
+						<Image
+							src={hover.img}
+							alt=""
+							fill
+							sizes="240px"
+							style={{ objectFit: 'cover' }}
+						/>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function groupByYear(projects) {
+	const map = new Map();
+	for (const p of projects) {
+		const k = p.year ?? '—';
+		if (!map.has(k)) map.set(k, []);
+		map.get(k).push(p);
+	}
+	return Array.from(map.entries()).map(([year, items]) => ({ year, items }));
+}

--- a/apps/web/components/projects/bold/BoldProjectsMarquee.jsx
+++ b/apps/web/components/projects/bold/BoldProjectsMarquee.jsx
@@ -1,0 +1,18 @@
+import Marquee from '../../primitives/Marquee';
+
+// 라군 stacks 톤 (career/profile.md 참조) — 후속에 백엔드 stacks 와 연동 검토.
+const DEFAULT_KEYWORDS = [
+	'FastAPI',
+	'Next.js',
+	'NestJS',
+	'PostgreSQL',
+	'Docker',
+	'AWS',
+	'CI/CD',
+	'AI · LLM',
+	'실험 · 개선',
+];
+
+export default function BoldProjectsMarquee({ items = DEFAULT_KEYWORDS }) {
+	return <Marquee items={items} duration={42} />;
+}

--- a/apps/web/pages/projects/index.jsx
+++ b/apps/web/pages/projects/index.jsx
@@ -1,17 +1,139 @@
+import { useMemo, useState } from 'react';
+import BoldLayout from '../../components/layout/bold/BoldLayout';
 import PagesMetaHead from '../../components/PagesMetaHead';
-import ProjectsGrid from '../../components/projects/ProjectsGrid';
+import BoldProjectsHero from '../../components/projects/bold/BoldProjectsHero';
+import BoldProjectsMarquee from '../../components/projects/bold/BoldProjectsMarquee';
+import BoldProjectsControls from '../../components/projects/bold/BoldProjectsControls';
+import BoldProjectsGrid from '../../components/projects/bold/BoldProjectsGrid';
+import BoldProjectsList from '../../components/projects/bold/BoldProjectsList';
+import BoldProjectsCTA from '../../components/projects/bold/BoldProjectsCTA';
 
-const API_BASE_URL =
-	process.env.API_INTERNAL_URL || 'http://localhost:7341';
+const API_BASE_URL = process.env.API_INTERNAL_URL || 'http://localhost:7341';
+
+// admin 의 headerPublishDate 가 'YYYY.MM – YYYY.MM' 형식이라 첫 4자리만 잘라 연도로 사용한다.
+// 형식이 깨진 row 는 빈 문자열이 되고, Years stat / 그룹 헤더에서만 제외된다.
+function parseYear(headerPublishDate) {
+	const head = (headerPublishDate ?? '').slice(0, 4);
+	return /^\d{4}$/.test(head) ? head : '';
+}
 
 function ProjectsIndex({ projects }) {
+	const decorated = useMemo(
+		() => projects.map((p) => ({ ...p, year: parseYear(p.headerPublishDate) })),
+		[projects],
+	);
+
+	const [category, setCategory] = useState('all');
+	const [search, setSearch] = useState('');
+	const [sort, setSort] = useState('newest');
+	const [view, setView] = useState('grid');
+
+	const categories = useMemo(() => buildCategories(decorated), [decorated]);
+
+	const visible = useMemo(
+		() => applyFilters(decorated, { category, search, sort }),
+		[decorated, category, search, sort],
+	);
+
+	const totalCount = decorated.length;
+	const categoryCount = useMemo(
+		() => new Set(decorated.map((p) => p.category)).size,
+		[decorated],
+	);
+	const yearCount = useMemo(
+		() => new Set(decorated.map((p) => p.year).filter(Boolean)).size,
+		[decorated],
+	);
+
 	return (
-		<div className="container mx-auto">
+		<>
 			<PagesMetaHead title="Projects" />
 
-			<ProjectsGrid projects={projects} />
-		</div>
+			<div className="container mx-auto px-6 lg:px-10">
+				<BoldProjectsHero
+					totalCount={totalCount}
+					categoryCount={categoryCount}
+					yearCount={yearCount}
+				/>
+
+				<BoldProjectsMarquee />
+
+				<BoldProjectsControls
+					categories={categories}
+					activeCategory={category}
+					onCategoryChange={setCategory}
+					search={search}
+					onSearchChange={setSearch}
+					sort={sort}
+					onSortChange={setSort}
+					view={view}
+					onViewChange={setView}
+				/>
+
+				{/* 결과 카운트 — 시안의 inline 모노스페이스 */}
+				<div
+					className="mt-6 text-xs uppercase"
+					style={{
+						fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+						letterSpacing: '0.14em',
+						color: 'var(--paper-faint)',
+					}}
+				>
+					{String(visible.length).padStart(2, '0')} / {String(totalCount).padStart(2, '0')} PROJECTS
+				</div>
+
+				{view === 'grid' ? (
+					<BoldProjectsGrid projects={visible} />
+				) : (
+					<BoldProjectsList projects={visible} sort={sort} />
+				)}
+
+				<BoldProjectsCTA />
+			</div>
+		</>
 	);
+}
+
+ProjectsIndex.getLayout = (page) => <BoldLayout>{page}</BoldLayout>;
+
+function buildCategories(projects) {
+	const counts = new Map();
+	for (const p of projects) {
+		counts.set(p.category, (counts.get(p.category) ?? 0) + 1);
+	}
+	const list = Array.from(counts.entries())
+		.sort((a, b) => a[0].localeCompare(b[0]))
+		.map(([key, count]) => ({ key, label: key, count }));
+	return [{ key: 'all', label: 'All', count: projects.length }, ...list];
+}
+
+function applyFilters(projects, { category, search, sort }) {
+	const q = search.trim().toLowerCase();
+	let list = projects.filter((p) => {
+		if (category !== 'all' && p.category !== category) return false;
+		if (!q) return true;
+		return (
+			p.title.toLowerCase().includes(q) ||
+			p.category.toLowerCase().includes(q)
+		);
+	});
+
+	switch (sort) {
+		case 'oldest':
+			list = list.sort((a, b) => (a.year || '').localeCompare(b.year || '') || a.title.localeCompare(b.title));
+			break;
+		case 'az':
+			list = list.sort((a, b) => a.title.localeCompare(b.title));
+			break;
+		case 'cat':
+			list = list.sort((a, b) => a.category.localeCompare(b.category) || a.title.localeCompare(b.title));
+			break;
+		case 'newest':
+		default:
+			list = list.sort((a, b) => (b.year || '').localeCompare(a.year || '') || a.title.localeCompare(b.title));
+			break;
+	}
+	return list;
 }
 
 export async function getServerSideProps() {


### PR DESCRIPTION
## Summary
- Projects 페이지를 Bold 시리즈 톤 (BoldLayout / 거대 타이포 / DARK·LIGHT 토글) 으로 재구성. 5페이지 시리즈 중 4번째.
- Hero stats (Total/Categories/Years), Marquee, 카테고리 chip + 검색 + 정렬 4모드 + Grid/List 뷰 토글, 결과 카운트, 4:5 카드 그리드, 연도 그룹 List view + mousemove 썸네일, Hire Me CTA.
- **백엔드 entity/migration/admin 폼 무변경**. 다만 `ProjectListItemDto` 응답에 `headerPublishDate` 한 줄만 추가 (이미 존재하는 column 노출) — 라군이 입력해온 'YYYY.MM – YYYY.MM' 형식의 첫 4자리를 web 에서 파싱해 Year 데이터로 사용.

## Section / Component (web)
| 섹션 | 컴포넌트 | 데이터 |
|---|---|---|
| Hero | `BoldProjectsHero` | projects[] 집계 (Total/Categories/Years StatCounter) |
| Marquee | `BoldProjectsMarquee` | 라군 stacks 톤 키워드 하드코딩 |
| Controls | `BoldProjectsControls` | category chip + 검색 + 정렬 select 4모드 + Grid/List 토글 |
| 결과 카운트 | inline | `00 / 00 PROJECTS` 모노스페이스 |
| Grid view | `BoldProjectsGrid` | 4:5 카드 3열, 오버레이 메타 + 화살표 |
| List view | `BoldProjectsList` | 연도 그룹 헤더 (newest/oldest), 풀폭 행, mousemove 썸네일 (>=768px + reduced-motion 비활성) |
| CTA | `BoldProjectsCTA` | WordReveal "같이 / 만들어요." + PillButton → `/contact` |

`pages/projects/index.jsx` 는 `ProjectsIndex.getLayout = (page) => <BoldLayout>{page}</BoldLayout>` 단일 적용.

## Backend (응답 DTO 1행만)
| 변경 | 파일 |
|---|---|
| `headerPublishDate` 노출 추가 | `dto/project-list-item.dto.ts` |
| 매핑 1행 추가 | `projects.service.ts` |
| spec 2개 fixture 보정 | `projects.service.spec.ts`, `projects.controller.spec.ts` |

entity / migration / admin 폼 무변경.

## Year 파싱 전략
- `headerPublishDate.slice(0, 4)` + `/^\d{4}$/` 검증
- 형식이 깨진 row 는 빈 문자열 → Years stat / List 그룹 헤더에서만 제외. 카드 노출은 정상 (year 자리에 `—`)
- 현재 DB 5건 모두 'YYYY.MM – YYYY.MM' 형식 일관 입력 중

## 정렬 모드
- `newest` / `oldest` — year + title 보조 + 연도 그룹 헤더
- `az` — title asc (그룹 없음)
- `cat` — category + title 보조 (그룹 없음)

## 보류 (후속)
- Project Detail Bold — **5페이지 시리즈 마지막 PR**
- 기존 `components/projects/{ProjectsGrid,ProjectSingle,ProjectsFilter}.jsx` — 안전 우선 보존. 후속 미사용 확정 시 일괄 삭제. RelatedProjects 는 detail 에서 계속 사용
- `year` 컬럼 명시 도입 (정합성 강제) — Project Detail 의 meta strip 정합성 요구 커지면 별도 PR
- Marquee 키워드 백엔드화 (stacks 와 연동)

## Test plan
- [ ] dev 머지 → cd-dev → `/projects` Hero stats 자동 집계 (Total 6 / Categories 3 / Years 3)
- [ ] Marquee `useReducedMotion` 시 정지
- [ ] Controls: 카테고리 chip 토글 / 검색 typeahead / 정렬 4모드 / Grid↔List 토글 정상
- [ ] 결과 카운트 (`00 / 06 PROJECTS`) 갱신
- [ ] Grid view: 4:5 카드 3열 + hover scale + 화살표 회전
- [ ] List view: 연도 그룹 헤더 (newest/oldest), mousemove 240x180 썸네일 (>=768px), 모바일 카테고리/연도 컬럼 hide
- [ ] CTA: `같이 만들어요.` + `/contact` 이동
- [ ] DARK/LIGHT 토글 / 모바일 viewport / reduced-motion 정상
- [ ] `/`, `/about`, `/contact` 무영향
- [ ] api 27 suite / 128 test pass + web lint/build 그린

Closes #95
Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)