### PR TITLE
[style] Contact·Projects·Home Hero 카피 + Marquee 갱신 + Home 잘림 해결 + About CTA italic 통일

### DIFF
--- a/apps/web/components/about/bold/AboutBrands.jsx
+++ b/apps/web/components/about/bold/AboutBrands.jsx
@@ -21,7 +21,27 @@ export default function AboutBrands({ stacks = [] }) {
 							lineHeight: 0.88,
 						}}
 					>
-						문제를 해결하며 사용한 기술들
+						<span
+							style={{
+								display: 'inline-block',
+								color: 'var(--indigo-soft)',
+								fontStyle: 'italic',
+								paddingRight: '0.1em',
+							}}
+						>
+							문제를
+						</span>{' '}
+						해결하며 사용한{' '}
+						<span
+							style={{
+								display: 'inline-block',
+								color: 'var(--indigo-soft)',
+								fontStyle: 'italic',
+								paddingRight: '0.1em',
+							}}
+						>
+							기술들
+						</span>
 						<span style={{ color: 'var(--indigo-soft)' }}>.</span>
 					</h2>
 				</div>

--- a/apps/web/components/about/bold/AboutBrands.jsx
+++ b/apps/web/components/about/bold/AboutBrands.jsx
@@ -21,17 +21,7 @@ export default function AboutBrands({ stacks = [] }) {
 							lineHeight: 0.88,
 						}}
 					>
-						<span
-							style={{
-								display: 'inline-block',
-								color: 'var(--indigo-soft)',
-								fontStyle: 'italic',
-								paddingRight: '0.1em',
-							}}
-						>
-							문제를
-						</span>{' '}
-						해결하며 사용한{' '}
+						문제를 해결하며 사용한{' '}
 						<span
 							style={{
 								display: 'inline-block',

--- a/apps/web/components/about/bold/AboutContactCTA.jsx
+++ b/apps/web/components/about/bold/AboutContactCTA.jsx
@@ -29,12 +29,16 @@ export default function AboutContactCTA() {
 								lineHeight: 1,
 							}}
 						>
-							<span style={{ color: 'var(--indigo-soft)' }}>
+							<span
+								style={{
+									color: 'var(--indigo-soft)',
+									fontStyle: 'italic',
+								}}
+							>
 								함께할{' '}
 								<span
 									style={{
 										display: 'inline-block',
-										fontStyle: 'italic',
 										paddingRight: '0.1em',
 									}}
 								>

--- a/apps/web/components/about/bold/AboutCounters.jsx
+++ b/apps/web/components/about/bold/AboutCounters.jsx
@@ -23,7 +23,17 @@ export default function AboutCounters({ stats = [] }) {
 							lineHeight: 0.88,
 						}}
 					>
-						수치로 남긴 결과
+						<span
+							style={{
+								display: 'inline-block',
+								color: 'var(--indigo-soft)',
+								fontStyle: 'italic',
+								paddingRight: '0.1em',
+							}}
+						>
+							수치로
+						</span>{' '}
+						남긴 결과
 						<span style={{ color: 'var(--indigo-soft)' }}>.</span>
 					</h2>
 				</div>

--- a/apps/web/components/about/bold/AboutJourney.jsx
+++ b/apps/web/components/about/bold/AboutJourney.jsx
@@ -21,6 +21,7 @@ export default function AboutJourney({ journey = [] }) {
 							lineHeight: 0.88,
 						}}
 					>
+						문제를 해결해 온{' '}
 						<span
 							style={{
 								display: 'inline-block',
@@ -29,9 +30,8 @@ export default function AboutJourney({ journey = [] }) {
 								paddingRight: '0.1em',
 							}}
 						>
-							문제를
-						</span>{' '}
-						해결해 온 과정
+							과정
+						</span>
 						<span style={{ color: 'var(--indigo-soft)' }}>.</span>
 					</h2>
 				</div>

--- a/apps/web/components/about/bold/AboutJourney.jsx
+++ b/apps/web/components/about/bold/AboutJourney.jsx
@@ -21,7 +21,17 @@ export default function AboutJourney({ journey = [] }) {
 							lineHeight: 0.88,
 						}}
 					>
-						문제를 해결해 온 과정
+						<span
+							style={{
+								display: 'inline-block',
+								color: 'var(--indigo-soft)',
+								fontStyle: 'italic',
+								paddingRight: '0.1em',
+							}}
+						>
+							문제를
+						</span>{' '}
+						해결해 온 과정
 						<span style={{ color: 'var(--indigo-soft)' }}>.</span>
 					</h2>
 				</div>

--- a/apps/web/components/contact/bold/BoldContactHero.jsx
+++ b/apps/web/components/contact/bold/BoldContactHero.jsx
@@ -30,7 +30,7 @@ export default function BoldContactHero() {
 					홈
 				</Link>
 				<span className="w-6 h-px" style={{ background: 'var(--line-strong)' }} />
-				<Eyebrow>Contact — 2026</Eyebrow>
+				<Eyebrow>Contact</Eyebrow>
 			</Reveal>
 
 			{/* 거대 이름 */}
@@ -41,7 +41,12 @@ export default function BoldContactHero() {
 					letterSpacing: '-0.04em',
 					lineHeight: 1.0,
 				}}
-				items={[{ text: '같이' }, { br: true }, { text: '일해요.', accent: true }]}
+				items={[
+					{ text: '함께할', accent: true },
+					{ text: '기회를', accent: true },
+					{ br: true },
+					{ text: '기다립니다.' },
+				]}
 			/>
 
 			{/* tagline */}

--- a/apps/web/components/home/HomeHero.jsx
+++ b/apps/web/components/home/HomeHero.jsx
@@ -38,12 +38,15 @@ export default function HomeHero({ tagline }) {
 				style={{
 					fontSize: 'clamp(2.6rem, 12vw, 13.5rem)',
 					letterSpacing: '-0.05em',
-					lineHeight: 0.88,
+					// 0.88 은 italic 한글 글자 박스 (≈0.95em) 보다 작아 마지막 자(예: '오')
+					// 가 overflow-hidden 박스 하단으로 잘림. 1.0 으로 fit.
+					lineHeight: 1.0,
+					wordBreak: 'keep-all',
 				}}
 				items={[
-					{ text: '이석호' },
+					{ text: '이석호의' },
 					{ br: true },
-					{ text: '포트폴리오', accent: true },
+					{ text: '포트폴리오.', accent: true },
 				]}
 			/>
 

--- a/apps/web/components/primitives/WordReveal.jsx
+++ b/apps/web/components/primitives/WordReveal.jsx
@@ -19,12 +19,14 @@ export default function WordReveal({
 				if (item.br) return <br key={`br-${idx}`} />;
 				// italic accent 단어의 마지막 글자가 inline-block + overflow-hidden 박스 밖으로
 				// 살짝 비져나가 잘리는 현상이 있어 paddingRight 로 박스 너비 보강.
-				// 0.1em 은 큰 fontSize (12rem+) 에서 italic 끝부분이 여전히 잘려 0.2em 로 보강.
+				// 한글 batchim (ㄹ 등) 이 italic 시 우측·하단 양방향 확장 → 0.35em 우측 + 0.08em
+				// 하단 (pb-[0.04em] 기본 override).
 				const innerStyle = item.accent
 					? {
 							color: 'var(--indigo-soft)',
 							fontStyle: 'italic',
-							paddingRight: '0.2em',
+							paddingRight: '0.35em',
+							paddingBottom: '0.08em',
 						}
 					: undefined;
 				// 다음 단어와 공백 분리. 단 noSep 가 true 면 공백 없이 직접 붙임

--- a/apps/web/components/primitives/WordReveal.jsx
+++ b/apps/web/components/primitives/WordReveal.jsx
@@ -19,11 +19,12 @@ export default function WordReveal({
 				if (item.br) return <br key={`br-${idx}`} />;
 				// italic accent 단어의 마지막 글자가 inline-block + overflow-hidden 박스 밖으로
 				// 살짝 비져나가 잘리는 현상이 있어 paddingRight 로 박스 너비 보강.
+				// 0.1em 은 큰 fontSize (12rem+) 에서 italic 끝부분이 여전히 잘려 0.2em 로 보강.
 				const innerStyle = item.accent
 					? {
 							color: 'var(--indigo-soft)',
 							fontStyle: 'italic',
-							paddingRight: '0.1em',
+							paddingRight: '0.2em',
 						}
 					: undefined;
 				// 다음 단어와 공백 분리. 단 noSep 가 true 면 공백 없이 직접 붙임

--- a/apps/web/components/projects/bold/BoldProjectsHero.jsx
+++ b/apps/web/components/projects/bold/BoldProjectsHero.jsx
@@ -31,7 +31,7 @@ export default function BoldProjectsHero({ totalCount, categoryCount, yearCount 
 					홈
 				</Link>
 				<span className="w-6 h-px" style={{ background: 'var(--line-strong)' }} />
-				<Eyebrow>All Projects — 2026</Eyebrow>
+				<Eyebrow>All Projects</Eyebrow>
 			</Reveal>
 
 			{/* 거대 타이틀 */}
@@ -42,7 +42,7 @@ export default function BoldProjectsHero({ totalCount, categoryCount, yearCount 
 					letterSpacing: '-0.04em',
 					lineHeight: 1.0,
 				}}
-				items={[{ text: '모든' }, { br: true }, { text: '작업.', accent: true }]}
+				items={[{ text: '모든' }, { br: true }, { text: '프로젝트들.', accent: true }]}
 			/>
 
 			{/* tagline */}
@@ -56,7 +56,7 @@ export default function BoldProjectsHero({ totalCount, categoryCount, yearCount 
 					letterSpacing: '-0.02em',
 				}}
 			>
-				직접 만들거나 함께 만든 것들. 결정의 기록.
+				직접 만들고 함께 완성한 프로젝트들. 문제를 해결해 온 기록입니다.
 			</Reveal>
 
 			{/* stats — Total / Categories / Years */}

--- a/apps/web/components/projects/bold/BoldProjectsHero.jsx
+++ b/apps/web/components/projects/bold/BoldProjectsHero.jsx
@@ -56,7 +56,9 @@ export default function BoldProjectsHero({ totalCount, categoryCount, yearCount 
 					letterSpacing: '-0.02em',
 				}}
 			>
-				직접 만들고 함께 완성한 프로젝트들. 문제를 해결해 온 기록입니다.
+				직접 만들고 함께 완성한 프로젝트들.
+				<br />
+				문제를 해결해 온 기록입니다.
 			</Reveal>
 
 			{/* stats — Total / Categories / Years */}

--- a/apps/web/components/projects/bold/BoldProjectsMarquee.jsx
+++ b/apps/web/components/projects/bold/BoldProjectsMarquee.jsx
@@ -1,16 +1,22 @@
 import Marquee from '../../primitives/Marquee';
 
-// 라군 stacks 톤 (career/profile.md 참조) — 후속에 백엔드 stacks 와 연동 검토.
+// 라군 stacks 톤 (career/profile.md 참조) — 백엔드 프레임워크 → 프론트엔드 → DB →
+// 인프라/툴링 순. 후속에 백엔드 stacks 와 연동 검토.
 const DEFAULT_KEYWORDS = [
 	'FastAPI',
+	'Django',
 	'Next.js',
 	'NestJS',
+	'Express',
 	'PostgreSQL',
+	'MySQL',
+	'Redis',
+	'MongoDB',
+	'Nginx',
 	'Docker',
 	'AWS',
 	'CI/CD',
 	'AI · LLM',
-	'실험 · 개선',
 ];
 
 export default function BoldProjectsMarquee({ items = DEFAULT_KEYWORDS }) {


### PR DESCRIPTION
## Summary
About 카피 폴리시 (#100) 후속. Contact·Projects·Home Hero 카피·Marquee·잘림 + About CTA italic 통일. 인라인 텍스트/스타일만, 백엔드/DB/API 무변경.

> **업데이트**: 라군 라이브 피드백을 바탕으로 후속 폴리시 commit 3건 추가 (Projects tagline 줄바꿈, AboutBrands `기술들` accent, AboutJourney `과정` accent, AboutCounters `수치로` accent, WordReveal accent 잘림 보강). 자세한 내용은 아래 "후속 폴리시" 섹션.

## 변경 항목 (초기 commit · web — 5 파일)

| # | 위치 | 변경 |
|---|---|---|
| C-1 | `BoldContactHero` WordReveal | "같이 / [일해요.]" → "[함께할] [기회를] / 기다립니다." (두 단어 모두 indigo + italic) |
| C-2 | `BoldContactHero` Eyebrow | `Contact — 2026` → `Contact` |
| P-1 | `BoldProjectsHero` WordReveal | "모든 / [작업.]" → "모든 / [프로젝트들.]" |
| P-2 | `BoldProjectsHero` tagline | "직접 만들거나 함께 만든 것들. 결정의 기록." → "직접 만들고 함께 완성한 프로젝트들. 문제를 해결해 온 기록입니다." |
| P-3 | `BoldProjectsMarquee` 키워드 | '실험 · 개선' 제거 + Django / MySQL / Redis / MongoDB / Express / Nginx 추가. 백엔드→프론트엔드→DB→인프라 순 (14개) |
| P-4 | `BoldProjectsHero` Eyebrow | `All Projects — 2026` → `All Projects` |
| H-1 | `HomeHero` WordReveal + lineHeight | "이석호 / [포트폴리오]" → "이석호의 / [포트폴리오.]" + `lineHeight: 0.88 → 1.0` (italic 한글 박스가 overflow-hidden 박스보다 커서 '오' 자 잘리던 문제) + `wordBreak: keep-all` |
| A-1 | `AboutContactCTA` outer span | outer 에 `fontStyle: italic` 추가 → '함께할' 도 italic 적용. inner span italic 중복 제거 후 paddingRight 만 유지. Contact Hero 와 톤 통일 |

대괄호 = accent (indigo + italic).

## 후속 폴리시 (추가 commit — 3건 / 4 파일 추가)

라이브 검증 피드백 반영.

| # | 위치 | 변경 |
|---|---|---|
| P-5 | `BoldProjectsHero` tagline | 두 문장 사이 `<br/>` 추가 → "직접 만들고 함께 완성한 프로젝트들. / 문제를 해결해 온 기록입니다." 두 줄로 |
| A-2 | `AboutBrands` heading | "문제를 해결하며 사용한 [기술들]." — '기술들' 에 indigo + italic |
| A-3 | `AboutJourney` heading | "문제를 해결해 온 [과정]." — '과정' 에 indigo + italic ('과정' + '.' 모두 indigo) |
| A-4 | `AboutCounters` heading | "[수치로] 남긴 결과." — '수치로' 에 indigo + italic (양끝 indigo 균형) |
| C-3 | `WordReveal` primitive accent | `paddingRight: 0.1em → 0.35em` + `paddingBottom: 0.08em` 추가. Contact Hero '함께할'/'기회를' 의 한글 batchim (ㄹ) 이 italic 시 우측·하단 양방향 확장되어 잘리던 현상 보강 |

## 무변경
- 백엔드 / DB / API
- 기타 페이지 (`/`, `/about` AboutStrip 등)

## Test plan
- [ ] dev 머지 → cd-dev → `/contact` "[함께할] [기회를] / 기다립니다." + breadcrumb `— Contact` + '할'/'를' 끝 글자 잘림 없음
- [ ] `/projects` "모든 / [프로젝트들.]" + tagline 두 줄 + breadcrumb `— All Projects`
- [ ] `/projects` Marquee 14개 키워드 순환, '실험 · 개선' 없음, reduced-motion 정지
- [ ] `/` HomeHero "이석호의 / [포트폴리오.]" italic + '오' 자 잘림 없음
- [ ] `/about` CTA '함께할' '기회를' 두 단어 모두 italic
- [ ] `/about` JOURNEY "문제를 해결해 온 [과정]." 의 '과정' indigo + italic
- [ ] `/about` IN NUMBERS "[수치로] 남긴 결과." 의 '수치로' indigo + italic
- [ ] `/about` TECH STACK "문제를 해결하며 사용한 [기술들]." 의 '기술들' indigo + italic
- [ ] DARK/LIGHT 토글 / 모바일 viewport / reduced-motion 정상
- [ ] lint + build 그린

Closes #101
Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)