### PR TITLE
[feat] Project Detail 페이지 Bold 리디자인 (Phase 1 — UI + 식 폴백)

### DIFF
--- a/apps/web/components/projects/bold/detail/BoldProjectDetailGallery.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailGallery.jsx
@@ -1,0 +1,90 @@
+import Image from 'next/image';
+import Reveal from '../../../primitives/Reveal';
+import Eyebrow from '../../../primitives/Eyebrow';
+
+export default function BoldProjectDetailGallery({ images = [] }) {
+	if (!images.length) return null;
+
+	// 모자이크: 1 big (col-span-7) + 2 stacked (col-span-5). 4번째 이상은 horizontal scroll.
+	const big = images[0];
+	const stacked = images.slice(1, 3);
+	const extras = images.slice(3);
+
+	return (
+		<section
+			id="gallery"
+			className="py-20 lg:py-24 border-t"
+			style={{ borderColor: 'var(--line)' }}
+		>
+			<Reveal className="mb-10">
+				<Eyebrow className="mb-3">— Gallery</Eyebrow>
+				<h2
+					className="font-general-semibold"
+					style={{
+						fontSize: 'clamp(1.8rem, 3vw, 2.6rem)',
+						letterSpacing: '-0.04em',
+						lineHeight: 1.15,
+					}}
+				>
+					화면으로 보기
+					<span style={{ color: 'var(--indigo-soft)' }}>.</span>
+				</h2>
+			</Reveal>
+
+			<div className="grid grid-cols-1 lg:grid-cols-12 gap-4 lg:gap-6">
+				<Reveal className="lg:col-span-7">
+					<GalleryTile image={big} aspect="4 / 3" />
+				</Reveal>
+				{stacked.length > 0 && (
+					<div className="lg:col-span-5 grid grid-cols-1 gap-4 lg:gap-6">
+						{stacked.map((img, idx) => (
+							<Reveal key={img.id ?? idx} delay={0.08 + idx * 0.06}>
+								<GalleryTile image={img} aspect="4 / 3" />
+							</Reveal>
+						))}
+					</div>
+				)}
+			</div>
+
+			{extras.length > 0 && (
+				<Reveal delay={0.16} className="mt-8 lg:mt-12">
+					<Eyebrow className="mb-4">— 추가 스크린</Eyebrow>
+					<div className="flex gap-4 lg:gap-6 overflow-x-auto pb-4 snap-x snap-mandatory">
+						{extras.map((img) => (
+							<div
+								key={img.id}
+								className="flex-shrink-0 w-[280px] sm:w-[360px] lg:w-[420px] snap-start"
+							>
+								<GalleryTile image={img} aspect="4 / 3" />
+							</div>
+						))}
+					</div>
+				</Reveal>
+			)}
+		</section>
+	);
+}
+
+function GalleryTile({ image, aspect }) {
+	return (
+		<div
+			className="relative overflow-hidden rounded-[14px] w-full"
+			style={{
+				border: '1px solid var(--line-strong)',
+				aspectRatio: aspect,
+				background:
+					'linear-gradient(135deg, rgba(99,102,241,0.18), rgba(99,102,241,0.04))',
+			}}
+		>
+			{image?.img && (
+				<Image
+					src={image.img}
+					alt={image.title || ''}
+					fill
+					sizes="(min-width: 1024px) 50vw, 90vw"
+					style={{ objectFit: 'cover' }}
+				/>
+			)}
+		</div>
+	);
+}

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailHero.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailHero.jsx
@@ -1,0 +1,142 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import Reveal from '../../../primitives/Reveal';
+import WordReveal from '../../../primitives/WordReveal';
+import Eyebrow from '../../../primitives/Eyebrow';
+
+export default function BoldProjectDetailHero({
+	title,
+	accentWord,
+	eyebrow,
+	coverImage,
+	meta = [],
+}) {
+	// 마지막 단어를 accent 로 분리 (이미 accentWord 가 prop 으로 주어지면 그걸 사용).
+	const items = buildHeroItems(title, accentWord);
+
+	return (
+		<section id="hero" className="pt-28 lg:pt-40 pb-16 lg:pb-20">
+			{/* breadcrumb */}
+			<Reveal className="flex items-center gap-3 mb-10">
+				<Link
+					href="/projects"
+					className="bold-interactive flex items-center gap-1.5 transition"
+					style={{
+						fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+						fontSize: '0.75rem',
+						color: 'var(--paper-faint)',
+					}}
+				>
+					<svg
+						className="w-3 h-3"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						aria-hidden="true"
+					>
+						<path d="M19 12H5M12 19l-7-7 7-7" />
+					</svg>
+					모든 프로젝트
+				</Link>
+				<span className="w-6 h-px" style={{ background: 'var(--line-strong)' }} />
+				<Eyebrow>{eyebrow}</Eyebrow>
+			</Reveal>
+
+			{/* 거대 타이틀 + 우측 cover */}
+			<div className="grid grid-cols-12 gap-6 lg:gap-12 items-center">
+				<div className="col-span-12 lg:col-span-8">
+					<WordReveal
+						className="font-general-semibold"
+						style={{
+							fontSize: 'clamp(2rem, calc((100vw - 3rem) / 8), 5rem)',
+							letterSpacing: '-0.04em',
+							lineHeight: 1.1,
+							wordBreak: 'keep-all',
+						}}
+						items={items}
+					/>
+				</div>
+				<Reveal
+					delay={0.16}
+					className="col-span-12 lg:col-span-4 flex justify-center lg:justify-end"
+				>
+					<div
+						className="relative rounded-[18px] overflow-hidden w-full max-w-[280px] sm:max-w-[320px] lg:max-w-none"
+						style={{
+							border: '1px solid var(--line-strong)',
+							aspectRatio: '4 / 5',
+							background:
+								'linear-gradient(135deg, rgba(99,102,241,0.25), rgba(99,102,241,0.04))',
+							boxShadow: '0 30px 80px -20px rgba(0,0,0,0.6)',
+						}}
+					>
+						{coverImage ? (
+							<Image
+								src={coverImage}
+								alt={title}
+								fill
+								sizes="(min-width: 1024px) 33vw, 80vw"
+								style={{ objectFit: 'cover' }}
+								priority
+							/>
+						) : null}
+						<div
+							className="absolute inset-0 pointer-events-none"
+							style={{
+								background:
+									'linear-gradient(180deg, transparent 60%, rgba(7,14,23,0.5))',
+							}}
+							aria-hidden="true"
+						/>
+					</div>
+				</Reveal>
+			</div>
+
+			{/* meta strip — 4-col (Client / Role / Timeline / Category). 미존재 행 hide */}
+			{meta.length > 0 && (
+				<Reveal
+					delay={0.24}
+					className="mt-14 lg:mt-20 grid grid-cols-2 lg:grid-cols-4 gap-6 lg:gap-10 pt-8 lg:pt-10 border-t"
+					style={{ borderColor: 'var(--line-strong)' }}
+				>
+					{meta.map((m) => (
+						<div key={m.label}>
+							<Eyebrow className="mb-2">{m.label}</Eyebrow>
+							<div
+								className="font-general-semibold"
+								style={{
+									fontSize: 'clamp(1.05rem, 1.4vw, 1.4rem)',
+									letterSpacing: '-0.02em',
+									lineHeight: 1.25,
+									wordBreak: 'keep-all',
+								}}
+							>
+								{m.value}
+							</div>
+						</div>
+					))}
+				</Reveal>
+			)}
+		</section>
+	);
+}
+
+function buildHeroItems(title, accentWord) {
+	const trimmed = (title ?? '').trim();
+	if (!trimmed) return [{ text: '' }];
+
+	// accentWord 가 지정되면 끝부분과 일치 여부 확인 후 분리. 아니면 마지막 공백 토큰 사용.
+	const tokens = trimmed.split(/\s+/);
+	const accent = accentWord || tokens[tokens.length - 1];
+	const head = tokens.slice(0, -1).join(' ');
+
+	if (!head) {
+		return [{ text: accent, accent: true }];
+	}
+	return [
+		{ text: head },
+		{ br: true },
+		{ text: accent, accent: true },
+	];
+}

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailOverview.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailOverview.jsx
@@ -1,0 +1,47 @@
+import Reveal from '../../../primitives/Reveal';
+import Eyebrow from '../../../primitives/Eyebrow';
+
+export default function BoldProjectDetailOverview({ body }) {
+	if (!body) return null;
+
+	return (
+		<section
+			id="overview"
+			className="py-20 lg:py-24 border-t"
+			style={{ borderColor: 'var(--line)' }}
+		>
+			<div className="grid grid-cols-12 gap-6 lg:gap-12">
+				<Reveal className="col-span-12 lg:col-span-4">
+					<div className="lg:sticky lg:top-32">
+						<Eyebrow className="mb-3">— Overview</Eyebrow>
+						<h2
+							className="font-general-semibold"
+							style={{
+								fontSize: 'clamp(1.8rem, 3vw, 2.6rem)',
+								letterSpacing: '-0.04em',
+								lineHeight: 1.15,
+							}}
+						>
+							이 프로젝트는
+							<span style={{ color: 'var(--indigo-soft)' }}>.</span>
+						</h2>
+					</div>
+				</Reveal>
+				<Reveal delay={0.08} className="col-span-12 lg:col-span-8">
+					<p
+						className="font-general-semibold"
+						style={{
+							fontSize: 'clamp(1.4rem, 2.2vw, 2.4rem)',
+							lineHeight: 1.4,
+							letterSpacing: '-0.02em',
+							color: 'var(--paper)',
+							wordBreak: 'keep-all',
+						}}
+					>
+						{body}
+					</p>
+				</Reveal>
+			</div>
+		</section>
+	);
+}

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailProcess.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailProcess.jsx
@@ -1,0 +1,85 @@
+import ReactMarkdown from 'react-markdown';
+import Reveal from '../../../primitives/Reveal';
+import Eyebrow from '../../../primitives/Eyebrow';
+
+export default function BoldProjectDetailProcess({ steps = [] }) {
+	if (!steps.length) return null;
+
+	return (
+		<section
+			id="process"
+			className="py-20 lg:py-24 border-t"
+			style={{ borderColor: 'var(--line)' }}
+		>
+			<div className="grid grid-cols-12 gap-6 lg:gap-12">
+				<Reveal className="col-span-12 lg:col-span-4">
+					<div className="lg:sticky lg:top-32">
+						<Eyebrow className="mb-3">— Process</Eyebrow>
+						<h2
+							className="font-general-semibold"
+							style={{
+								fontSize: 'clamp(1.8rem, 3vw, 2.6rem)',
+								letterSpacing: '-0.04em',
+								lineHeight: 1.15,
+							}}
+						>
+							결정의 흐름
+							<span style={{ color: 'var(--indigo-soft)' }}>.</span>
+						</h2>
+					</div>
+				</Reveal>
+
+				<div className="col-span-12 lg:col-span-8 flex flex-col gap-6 lg:gap-8">
+					{steps.map((step, idx) => (
+						<Reveal key={`${step.title}-${idx}`} delay={idx * 0.06}>
+							<article
+								className="rounded-[18px] p-6 lg:p-8"
+								style={{
+									border: '1px solid var(--line-strong)',
+									background:
+										'linear-gradient(135deg, rgba(99,102,241,0.06), rgba(99,102,241,0.01))',
+								}}
+							>
+								<div
+									className="flex items-center gap-3 mb-4 text-xs uppercase"
+									style={{
+										fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+										letterSpacing: '0.14em',
+										color: 'var(--paper-faint)',
+									}}
+								>
+									<span>{String(idx + 1).padStart(2, '0')}</span>
+									<span
+										className="px-2 py-0.5 rounded-full"
+										style={{
+											border: '1px solid var(--line-strong)',
+											color: 'var(--indigo-soft)',
+										}}
+									>
+										{step.kind}
+									</span>
+								</div>
+								<h3
+									className="font-general-semibold mb-3"
+									style={{
+										fontSize: 'clamp(1.2rem, 1.8vw, 1.7rem)',
+										letterSpacing: '-0.02em',
+										lineHeight: 1.25,
+										wordBreak: 'keep-all',
+									}}
+								>
+									{step.title}
+								</h3>
+								{step.body && (
+									<div className="bold-prose">
+										<ReactMarkdown>{step.body}</ReactMarkdown>
+									</div>
+								)}
+							</article>
+						</Reveal>
+					))}
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailRelated.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailRelated.jsx
@@ -1,0 +1,133 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import Reveal from '../../../primitives/Reveal';
+import Eyebrow from '../../../primitives/Eyebrow';
+import PillButton from '../../../primitives/PillButton';
+
+export default function BoldProjectDetailRelated({ projects = [] }) {
+	if (!projects.length) return null;
+
+	const visible = projects.slice(0, 3);
+
+	return (
+		<section
+			id="related"
+			className="py-20 lg:py-24 border-t"
+			style={{ borderColor: 'var(--line)' }}
+		>
+			<Reveal className="flex items-end justify-between mb-10 lg:mb-12 gap-4 flex-wrap">
+				<div>
+					<Eyebrow className="mb-3">— Next Up</Eyebrow>
+					<h2
+						className="font-general-semibold"
+						style={{
+							fontSize: 'clamp(1.8rem, 3vw, 2.6rem)',
+							letterSpacing: '-0.04em',
+							lineHeight: 1.15,
+						}}
+					>
+						다른 프로젝트도 보기
+						<span style={{ color: 'var(--indigo-soft)' }}>.</span>
+					</h2>
+				</div>
+				<PillButton href="/projects" variant="ghost" ariaLabel="모든 프로젝트 보기">
+					<span>모든 프로젝트</span>
+					<svg
+						className="w-4 h-4"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						aria-hidden="true"
+					>
+						<path d="M5 12h14M13 6l6 6-6 6" />
+					</svg>
+				</PillButton>
+			</Reveal>
+
+			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8">
+				{visible.map((p, idx) => (
+					<Reveal key={p.id} delay={idx * 0.06}>
+						<Link
+							href={`/projects/${p.url}`}
+							aria-label={p.title}
+							className="bold-interactive block group"
+						>
+							<div
+								className="relative overflow-hidden rounded-[18px]"
+								style={{
+									border: '1px solid var(--line-strong)',
+									aspectRatio: '4 / 5',
+									background:
+										'linear-gradient(135deg, rgba(99,102,241,0.18), rgba(99,102,241,0.04))',
+								}}
+							>
+								{p.img && (
+									<Image
+										src={p.img}
+										alt={p.title}
+										fill
+										sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+										className="transition-transform duration-700 group-hover:scale-105"
+										style={{ objectFit: 'cover' }}
+									/>
+								)}
+								<div
+									className="absolute inset-0 pointer-events-none"
+									style={{
+										background:
+											'linear-gradient(180deg, transparent 45%, rgba(7,14,23,0.85) 100%)',
+									}}
+									aria-hidden="true"
+								/>
+								<div
+									className="absolute top-4 right-4 w-10 h-10 rounded-full flex items-center justify-center transition-transform duration-500 group-hover:rotate-[-45deg]"
+									style={{
+										background: 'rgba(255,255,255,0.12)',
+										backdropFilter: 'blur(6px)',
+										border: '1px solid rgba(255,255,255,0.18)',
+									}}
+									aria-hidden="true"
+								>
+									<svg
+										className="w-4 h-4"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										strokeWidth="2"
+										style={{ color: '#ffffff' }}
+									>
+										<path d="M5 12h14M13 6l6 6-6 6" />
+									</svg>
+								</div>
+								<div className="absolute left-5 right-5 bottom-5 z-[2]">
+									<div
+										className="text-[10px] uppercase mb-2"
+										style={{
+											fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+											letterSpacing: '0.14em',
+											color: 'rgba(255,255,255,0.7)',
+										}}
+									>
+										{p.category}
+									</div>
+									<div
+										className="font-general-semibold leading-tight"
+										style={{
+											fontSize: 'clamp(1.1rem, 1.6vw, 1.5rem)',
+											letterSpacing: '-0.02em',
+											color: '#ffffff',
+											wordBreak: 'keep-all',
+										}}
+									>
+										{p.title}
+									</div>
+								</div>
+							</div>
+						</Link>
+					</Reveal>
+				))}
+			</div>
+		</section>
+	);
+}

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailSideNav.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailSideNav.jsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react';
+
+// lg+ 좌측 sticky 섹션 네비. IntersectionObserver 로 active 추적, 모바일은 hide.
+export default function BoldProjectDetailSideNav({ sections = [] }) {
+	const [activeId, setActiveId] = useState(sections[0]?.id ?? '');
+
+	useEffect(() => {
+		const ids = sections.map((s) => s.id).filter(Boolean);
+		const els = ids
+			.map((id) => document.getElementById(id))
+			.filter(Boolean);
+		if (els.length === 0) return undefined;
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				// 화면 중앙 근처에 가장 가까운 entry 를 active 로 잡음.
+				const visible = entries
+					.filter((e) => e.isIntersecting)
+					.sort((a, b) => b.intersectionRatio - a.intersectionRatio);
+				if (visible[0]) {
+					setActiveId(visible[0].target.id);
+				}
+			},
+			{
+				rootMargin: '-30% 0px -50% 0px',
+				threshold: [0, 0.25, 0.5, 0.75, 1],
+			},
+		);
+		els.forEach((el) => observer.observe(el));
+		return () => observer.disconnect();
+	}, [sections]);
+
+	const handleClick = (e, id) => {
+		e.preventDefault();
+		const target = document.getElementById(id);
+		if (target) {
+			target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+		}
+	};
+
+	return (
+		<aside
+			className="hidden lg:block fixed left-6 top-1/2 -translate-y-1/2 z-30"
+			aria-label="섹션 네비"
+		>
+			<nav className="flex flex-col gap-3">
+				{sections.map((s, idx) => {
+					const active = s.id === activeId;
+					return (
+						<a
+							key={s.id}
+							href={`#${s.id}`}
+							onClick={(e) => handleClick(e, s.id)}
+							className="bold-interactive flex items-center gap-3 group"
+							style={{
+								fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+								fontSize: '0.7rem',
+								letterSpacing: '0.14em',
+								color: active ? 'var(--paper)' : 'var(--paper-faint)',
+								textTransform: 'uppercase',
+								transition: 'color 0.3s',
+							}}
+						>
+							<span
+								style={{
+									display: 'inline-block',
+									width: active ? '28px' : '14px',
+									height: '1px',
+									background: active ? 'var(--paper)' : 'var(--line-strong)',
+									transition: 'width 0.3s, background 0.3s',
+								}}
+								aria-hidden="true"
+							/>
+							<span>
+								{String(idx + 1).padStart(2, '0')} {s.label}
+							</span>
+						</a>
+					);
+				})}
+			</nav>
+		</aside>
+	);
+}

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailStack.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailStack.jsx
@@ -1,0 +1,63 @@
+import Reveal from '../../../primitives/Reveal';
+import Eyebrow from '../../../primitives/Eyebrow';
+
+export default function BoldProjectDetailStack({ groups = [] }) {
+	// 기존 single-project 페이지가 technologies[0] 만 렌더하던 버그를 여기서 해소 — 모든 그룹 표시.
+	const visible = groups.filter((g) => g?.techs?.length);
+	if (!visible.length) return null;
+
+	return (
+		<section
+			id="stack"
+			className="py-20 lg:py-24 border-t"
+			style={{ borderColor: 'var(--line)' }}
+		>
+			<div className="grid grid-cols-12 gap-6 lg:gap-12">
+				<Reveal className="col-span-12 lg:col-span-4">
+					<div className="lg:sticky lg:top-32">
+						<Eyebrow className="mb-3">— Stack</Eyebrow>
+						<h2
+							className="font-general-semibold"
+							style={{
+								fontSize: 'clamp(1.8rem, 3vw, 2.6rem)',
+								letterSpacing: '-0.04em',
+								lineHeight: 1.15,
+							}}
+						>
+							사용한 도구들
+							<span style={{ color: 'var(--indigo-soft)' }}>.</span>
+						</h2>
+					</div>
+				</Reveal>
+
+				<div className="col-span-12 lg:col-span-8 flex flex-col gap-8 lg:gap-10">
+					{visible.map((group) => (
+						<Reveal key={group.title}>
+							<div
+								className="pt-6"
+								style={{ borderTop: '1px solid var(--line-strong)' }}
+							>
+								<Eyebrow className="mb-4">{group.title}</Eyebrow>
+								<div className="flex flex-wrap gap-2 lg:gap-3">
+									{group.techs.map((tech) => (
+										<span
+											key={tech}
+											className="inline-flex items-center font-general-medium text-[13px] px-[1.1rem] py-[0.7rem] rounded-full"
+											style={{
+												border: '1px solid var(--line-strong)',
+												color: 'var(--paper)',
+												background: 'transparent',
+											}}
+										>
+											{tech}
+										</span>
+									))}
+								</div>
+							</div>
+						</Reveal>
+					))}
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/apps/web/pages/projects/[url].jsx
+++ b/apps/web/pages/projects/[url].jsx
@@ -1,140 +1,144 @@
-import Image from 'next/image';
-import { FiClock, FiTag } from 'react-icons/fi';
-import ReactMarkdown from 'react-markdown';
+import BoldLayout from '../../components/layout/bold/BoldLayout';
 import PagesMetaHead from '../../components/PagesMetaHead';
-import RelatedProjects from '../../components/projects/RelatedProjects';
+import BoldProjectDetailHero from '../../components/projects/bold/detail/BoldProjectDetailHero';
+import BoldProjectDetailOverview from '../../components/projects/bold/detail/BoldProjectDetailOverview';
+import BoldProjectDetailGallery from '../../components/projects/bold/detail/BoldProjectDetailGallery';
+import BoldProjectDetailProcess from '../../components/projects/bold/detail/BoldProjectDetailProcess';
+import BoldProjectDetailStack from '../../components/projects/bold/detail/BoldProjectDetailStack';
+import BoldProjectDetailRelated from '../../components/projects/bold/detail/BoldProjectDetailRelated';
+import BoldProjectDetailSideNav from '../../components/projects/bold/detail/BoldProjectDetailSideNav';
 
 const API_BASE_URL =
 	process.env.API_INTERNAL_URL || 'http://localhost:7341';
 
-function ProjectSingle(props) {
+const PROCESS_KIND_KEYWORDS = [
+	{ kind: 'DECISION', keywords: ['결정', '선택', 'DECISION', 'CHOOSE'] },
+	{ kind: 'OPS', keywords: ['운영', '배포', 'OPS', 'DEPLOY'] },
+	{ kind: 'RESULT', keywords: ['결과', '성과', 'RESULT', 'IMPACT'] },
+	{ kind: 'TRADEOFF', keywords: ['트레이드오프', '대안', 'TRADEOFF'] },
+];
+const KIND_ROTATION = ['DECISION', 'OPS', 'RESULT', 'TRADEOFF'];
+
+function ProjectDetail({ project, relatedProjects }) {
+	const heroEyebrow = buildHeroEyebrow(project);
+	const heroMeta = buildHeroMeta(project);
+	const overview = pickOverview(project.ProjectInfo?.ObjectivesDetails);
+	const gallery = project.ProjectImages?.slice(1) ?? [];
+	const steps = parseProcessSteps(project.ProjectInfo?.ProjectDetails);
+	const stackGroups = project.ProjectInfo?.Technologies ?? [];
+
+	// SideNav 는 실제 렌더되는 섹션만 노출.
+	const sections = [
+		{ id: 'hero', label: 'Intro' },
+		overview && { id: 'overview', label: 'Overview' },
+		gallery.length > 0 && { id: 'gallery', label: 'Gallery' },
+		steps.length > 0 && { id: 'process', label: 'Process' },
+		stackGroups.some((g) => g?.techs?.length) && { id: 'stack', label: 'Stack' },
+		relatedProjects.length > 0 && { id: 'related', label: 'Next Up' },
+	].filter(Boolean);
+
 	return (
-		<div className="container mx-auto">
-			<PagesMetaHead title={props.project.title} />
+		<>
+			<PagesMetaHead title={project.title} />
+			<BoldProjectDetailSideNav sections={sections} />
 
-			{/* Header */}
-			<div>
-				<p className="font-general-medium text-left text-3xl sm:text-4xl font-bold text-primary-dark dark:text-primary-light mt-14 sm:mt-20 mb-7">
-					{props.project.ProjectHeader.title}
-				</p>
-				<div className="flex">
-					<div className="flex items-center mr-10">
-						<FiClock className="text-xl text-ternary-dark dark:text-ternary-light" />
-						<span className="font-general-regular ml-2 leading-none text-primary-dark dark:text-primary-light">
-							{props.project.ProjectHeader.publishDate}
-						</span>
-					</div>
-					<div className="flex items-center">
-						<FiTag className="w-4 h-4 text-ternary-dark dark:text-ternary-light" />
-						<span className="font-general-regular ml-2 leading-none text-primary-dark dark:text-primary-light">
-							{props.project.ProjectHeader.tags}
-						</span>
-					</div>
-				</div>
+			<div className="container mx-auto px-6 lg:px-10">
+				<BoldProjectDetailHero
+					title={project.title}
+					eyebrow={heroEyebrow}
+					coverImage={project.ProjectImages?.[0]?.img}
+					meta={heroMeta}
+				/>
+				<BoldProjectDetailOverview body={overview} />
+				<BoldProjectDetailGallery images={gallery} />
+				<BoldProjectDetailProcess steps={steps} />
+				<BoldProjectDetailStack groups={stackGroups} />
+				<BoldProjectDetailRelated projects={relatedProjects} />
 			</div>
-
-			{/* Gallery */}
-			<div className="grid grid-cols-1 sm:grid-cols-3 sm:gap-10 mt-12">
-				{props.project.ProjectImages.map((project) => {
-					return (
-						<div className="mb-10 sm:mb-0" key={project.id}>
-							<Image
-								src={project.img}
-								className="rounded-xl cursor-pointer shadow-lg sm:shadow-none"
-								alt={project.title}
-								sizes="100vw"
-								style={{ width: '100%', height: 'auto' }}
-								width={100}
-								height={90}
-							/>
-						</div>
-					);
-				})}
-			</div>
-
-			{/* Info */}
-			<div className="block sm:flex gap-0 sm:gap-10 mt-14">
-				<div className="w-full sm:w-1/3 text-left">
-					{/* Single project client details */}
-					<div className="mb-7">
-						<p className="font-general-regular text-2xl font-semibold text-secondary-dark dark:text-secondary-light mb-2">
-							{props.project.ProjectInfo.ClientHeading}
-						</p>
-						<ul className="leading-loose">
-							{props.project.ProjectInfo.CompanyInfo.map(
-								(info) => {
-									const isUrl = /^https?:\/\//i.test(info.details);
-									return (
-										<li
-											className="font-general-regular text-ternary-dark dark:text-ternary-light"
-											key={info.id}
-										>
-											<span>{info.title}: </span>
-											{isUrl ? (
-												<a
-													href={info.details}
-													target="_blank"
-													rel="noopener noreferrer"
-													className="hover:underline hover:text-indigo-500 dark:hover:text-indigo-400 cursor-pointer duration-300 break-all"
-													aria-label={`${info.title}: ${info.details}`}
-												>
-													{info.details}
-												</a>
-											) : (
-												<span>{info.details}</span>
-											)}
-										</li>
-									);
-								}
-							)}
-						</ul>
-					</div>
-
-					{/* Single project objectives */}
-					<div className="mb-7">
-						<p className="font-general-regular text-2xl font-semibold text-ternary-dark dark:text-ternary-light mb-2">
-							{props.project.ProjectInfo.ObjectivesHeading}
-						</p>
-						<p className="font-general-regular text-primary-dark dark:text-ternary-light">
-							{props.project.ProjectInfo.ObjectivesDetails}
-						</p>
-					</div>
-
-					{/* Single project technologies */}
-					<div className="mb-7">
-						<p className="font-general-regular text-2xl font-semibold text-ternary-dark dark:text-ternary-light mb-2">
-							{props.project.ProjectInfo.Technologies[0].title}
-						</p>
-						<p className="font-general-regular text-primary-dark dark:text-ternary-light">
-							{props.project.ProjectInfo.Technologies[0].techs.join(
-								', '
-							)}
-						</p>
-					</div>
-
-				</div>
-
-				{/*  Single project right section details */}
-				<div className="w-full sm:w-2/3 text-left mt-10 sm:mt-0">
-					<p className="text-primary-dark dark:text-primary-light text-2xl font-bold mb-7">
-						{props.project.ProjectInfo.ProjectDetailsHeading}
-					</p>
-					{props.project.ProjectInfo.ProjectDetails.map((details) => {
-						return (
-							<div
-								key={details.id}
-								className="prose dark:prose-invert max-w-none mb-5 font-general-regular text-ternary-dark dark:text-ternary-light prose-headings:text-primary-dark dark:prose-headings:text-primary-light prose-strong:text-primary-dark dark:prose-strong:text-primary-light prose-h2:text-xl prose-h2:font-semibold prose-h2:mb-2 prose-h2:mt-4 prose-h3:text-base prose-h3:font-semibold prose-h3:mb-1 prose-h3:mt-3"
-							>
-								<ReactMarkdown>{details.details}</ReactMarkdown>
-							</div>
-						);
-					})}
-				</div>
-			</div>
-
-			<RelatedProjects projects={props.relatedProjects} />
-		</div>
+		</>
 	);
+}
+
+ProjectDetail.getLayout = (page) => <BoldLayout>{page}</BoldLayout>;
+
+function parseYear(headerPublishDate) {
+	const head = (headerPublishDate ?? '').slice(0, 4);
+	return /^\d{4}$/.test(head) ? head : '';
+}
+
+function buildHeroEyebrow(project) {
+	const year = parseYear(project.ProjectHeader?.publishDate);
+	const category = project.category;
+	if (year && category) return `Selected Work — ${year} · ${category}`;
+	if (category) return `Selected Work · ${category}`;
+	return 'Selected Work';
+}
+
+// CompanyInfo[] 의 title 매칭으로 Client/Role/Team/Status 폴백 + 항상 Timeline / Category 표시.
+function buildHeroMeta(project) {
+	const info = project.ProjectInfo?.CompanyInfo ?? [];
+	const findByKeywords = (keywords) =>
+		info.find((row) =>
+			keywords.some((k) =>
+				row.title?.toLowerCase().includes(k.toLowerCase()),
+			),
+		);
+
+	const meta = [];
+
+	const client = findByKeywords(['client', '클라이언트', '고객']);
+	if (client) meta.push({ label: 'Client', value: client.details });
+
+	const role = findByKeywords(['role', '역할', '담당']);
+	if (role) meta.push({ label: 'Role', value: role.details });
+
+	if (project.ProjectHeader?.publishDate) {
+		meta.push({ label: 'Timeline', value: project.ProjectHeader.publishDate });
+	}
+
+	if (project.category) {
+		meta.push({ label: 'Category', value: project.category });
+	}
+
+	return meta;
+}
+
+// 첫 단락 (빈 줄 split 의 첫 청크) 만 노출 — Overview 는 한 호흡 요약.
+function pickOverview(objectivesDetails) {
+	if (!objectivesDetails) return '';
+	const first = objectivesDetails.split(/\n\s*\n/)[0]?.trim();
+	return first || '';
+}
+
+// ProjectDetails[] 의 markdown 을 합쳐 `## ` 헤더 기준 split → step 카드 자동 생성.
+function parseProcessSteps(projectDetails = []) {
+	const allMd = projectDetails
+		.map((d) => d.details ?? '')
+		.join('\n\n')
+		.trim();
+	if (!allMd) return [];
+
+	// `## ` 헤더가 1개 이상이면 split, 아니면 전체를 단일 카드로 fallback.
+	const hasH2 = /^##\s+/m.test(allMd);
+	if (!hasH2) {
+		return [{ kind: 'NOTE', title: '메모', body: allMd }];
+	}
+
+	const sections = allMd.split(/^##\s+/gm).filter((s) => s.trim().length > 0);
+	return sections.map((section, idx) => {
+		const [titleLine, ...bodyLines] = section.split('\n');
+		const title = titleLine.trim();
+		const body = bodyLines.join('\n').trim();
+		return { kind: pickKind(title, idx), title, body };
+	});
+}
+
+function pickKind(title, idx) {
+	const lower = title.toLowerCase();
+	for (const { kind, keywords } of PROCESS_KIND_KEYWORDS) {
+		if (keywords.some((k) => lower.includes(k.toLowerCase()))) return kind;
+	}
+	return KIND_ROTATION[idx % KIND_ROTATION.length];
 }
 
 export async function getServerSideProps({ query }) {
@@ -160,7 +164,7 @@ export async function getServerSideProps({ query }) {
 		try {
 			const category = encodeURIComponent(project.category);
 			const relRes = await fetch(
-				`${API_BASE_URL}/api/projects?category=${category}`
+				`${API_BASE_URL}/api/projects?category=${category}`,
 			);
 			if (relRes.ok) {
 				const relBody = await relRes.json();
@@ -179,4 +183,4 @@ export async function getServerSideProps({ query }) {
 	}
 }
 
-export default ProjectSingle;
+export default ProjectDetail;


### PR DESCRIPTION
## Summary
- 5페이지 Bold 시리즈 **마지막** 페이지. 시안 (`Project Detail v2 - Bold.html` + `mapping_project_detail.md`) 의 10개 섹션 중 **8개를 Phase 1 으로 노출**, 신규 entity 필드가 필요한 Impact (stats) / Quote 는 Phase 2 PR 로 보류 (데이터 없으면 자동 hide).
- **백엔드/entity/migration/admin 무변경**. 모든 데이터는 기존 ProjectDetailDto + web 식 폴백 파싱으로 처리.
- 기존 `pages/projects/[url].jsx` 의 `Technologies[0]` 만 렌더하던 **버그 자연 해소** — 신규 `BoldProjectDetailStack` 이 모든 그룹 `.map`.

## Phase 1 섹션 (web 신규 7 파일 + 페이지 갈아끼움)

| # | 섹션 | 컴포넌트 | 데이터 |
|---|---|---|---|
| 1 | Hero | `BoldProjectDetailHero` | title / category / publishDate / images[0] + companyInfo 매칭 meta strip |
| 2 | Overview | `BoldProjectDetailOverview` | objectivesDetails 첫 단락 |
| 3 | Gallery | `BoldProjectDetailGallery` | images[1:] 모자이크 (1 big + 2 stacked) + 추가 horizontal scroll |
| 4 | Process | `BoldProjectDetailProcess` | projectDetails[] markdown h2 split 으로 자동 N-card |
| 5 | (Impact) | — | **Phase 2** — 신규 stats 필드 도입 시 자동 등장 |
| 6 | Stack | `BoldProjectDetailStack` | technologies[] **모든 그룹** (기존 [0] 버그 해소) |
| 7 | (Quote) | — | **Phase 2** — 신규 quote 필드 |
| 8 | Related | `BoldProjectDetailRelated` | relatedProjects 4:5 카드 3개 + '모든 프로젝트' 링크 |
| 9 | SideNav | `BoldProjectDetailSideNav` | IntersectionObserver active 추적 (lg+ fixed 좌측, 모바일 hide) |

## 폴백 전략 (web only)

| 시안 요소 | 폴백 출처 | 미존재 처리 |
|---|---|---|
| Hero accent 단어 | `title` 마지막 공백 토큰 | 항상 |
| Hero eyebrow | `Selected Work — {year} · {category}` (year=publishDate 첫 4자리) | year 미파싱 시 `Selected Work · {category}` |
| Hero meta `Client` / `Role` | `CompanyInfo[]` title 한·영 키워드 매칭 | 미매칭 행 hide |
| Hero meta `Timeline` | `publishDate` | 미존재 시 hide |
| Hero meta `Category` | `category` | 항상 |
| Overview | `ObjectivesDetails` 첫 단락 | 미존재 시 섹션 hide |
| Gallery | `ProjectImages[1:]` | 1개 이하면 섹션 hide |
| Process steps | `ProjectDetails[]` markdown `## ` split | 결과 0이면 섹션 hide. h2 없으면 단일 카드 |
| Process kind | 한·영 키워드 (결정/운영/결과/트레이드오프) → 매칭 안 되면 순환 할당 (DECISION/OPS/RESULT/TRADEOFF) | — |
| Impact / Quote | 신규 필드 없음 | Phase 1 항상 hide |
| Stack | `technologies[]` 모든 그룹 | 미존재 시 섹션 hide |
| Related | `relatedProjects` | 미존재 시 섹션 hide |

SideNav 의 sections 배열은 실제 렌더 조건에 따라 동적으로 — overview/gallery/process/stack/related 가 데이터 없으면 nav 에서도 자동 제거.

## 보류 (후속 Phase 2)
- Impact (stats[]) / Quote 신규 entity 필드 + admin 입력 + UI 노출
- heroSubtitle / heroAccentWord 명시적 필드 (현재는 파싱)
- Process kind 정교화 (admin 입력)
- 기존 `components/projects/single-project/*`, `RelatedProjects.jsx` 일괄 삭제 (미사용 확정 후)

## Test plan
- [ ] dev 머지 → cd-dev → `/projects/{url}` 8 섹션 정상 노출
- [ ] Hero meta strip: Client/Role/Timeline/Category 행 표시 (미매칭 row 는 hide)
- [ ] Gallery 모자이크 + 4번째 이상 horizontal scroll
- [ ] Process: markdown h2 split 카드 N개 (1-N개)
- [ ] Stack: 모든 technologies 그룹 노출 (이전 [0] 버그 해소)
- [ ] Related: 4:5 카드 3개 + '모든 프로젝트' 링크
- [ ] SideNav: lg+ fixed 좌측, scroll 시 active 갱신, 모바일 hide
- [ ] Impact / Quote 섹션 DOM 미렌더 (Phase 1)
- [ ] DARK/LIGHT 토글 / 모바일 viewport / reduced-motion 정상
- [ ] `/`, `/about`, `/projects`, `/contact` 무영향
- [ ] lint + build 그린

Closes #103
Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)