### PR TITLE
[feat] Project Detail Phase 2 (Impact / Quote / Hero meta)

### DIFF
--- a/apps/api/src/database/migrations/1779751522149-AddProjectPhase2Fields.ts
+++ b/apps/api/src/database/migrations/1779751522149-AddProjectPhase2Fields.ts
@@ -1,0 +1,71 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProjectPhase2Fields1779751522149 implements MigrationInterface {
+  name = 'AddProjectPhase2Fields1779751522149';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // PROJECT: Hero subtitle / accent 명시 컬럼 (Phase 2 도입).
+    await queryRunner.query(
+      `ALTER TABLE \`PROJECT\` ADD \`hero_subtitle\` varchar(255) NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`PROJECT\` ADD \`hero_accent_word\` varchar(100) NULL`,
+    );
+
+    // PROJECT_STAT: Impact 섹션 (label/value/sub + sort_order + project_id). AboutStat 패턴.
+    await queryRunner.query(
+      `CREATE TABLE \`PROJECT_STAT\` (` +
+        `\`id\` int NOT NULL AUTO_INCREMENT,` +
+        `\`label\` varchar(100) NOT NULL,` +
+        `\`value\` varchar(100) NOT NULL,` +
+        `\`sub\` varchar(255) NULL,` +
+        `\`sort_order\` int NOT NULL DEFAULT '0',` +
+        `\`project_id\` int NOT NULL,` +
+        `\`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),` +
+        `PRIMARY KEY (\`id\`)` +
+        `) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`PROJECT_STAT\` ADD CONSTRAINT \`FK_project_stat_project\` ` +
+        `FOREIGN KEY (\`project_id\`) REFERENCES \`PROJECT\`(\`id\`) ` +
+        `ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+
+    // PROJECT_QUOTE: Pull quote (text required + author optional). 프로젝트당 0~1개라 project_id UNIQUE.
+    await queryRunner.query(
+      `CREATE TABLE \`PROJECT_QUOTE\` (` +
+        `\`id\` int NOT NULL AUTO_INCREMENT,` +
+        `\`text\` text NOT NULL,` +
+        `\`author\` varchar(200) NULL,` +
+        `\`project_id\` int NOT NULL,` +
+        `\`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),` +
+        `PRIMARY KEY (\`id\`),` +
+        `UNIQUE KEY \`UQ_project_quote_project\` (\`project_id\`)` +
+        `) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`PROJECT_QUOTE\` ADD CONSTRAINT \`FK_project_quote_project\` ` +
+        `FOREIGN KEY (\`project_id\`) REFERENCES \`PROJECT\`(\`id\`) ` +
+        `ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`PROJECT_QUOTE\` DROP FOREIGN KEY \`FK_project_quote_project\``,
+    );
+    await queryRunner.query(`DROP TABLE \`PROJECT_QUOTE\``);
+
+    await queryRunner.query(
+      `ALTER TABLE \`PROJECT_STAT\` DROP FOREIGN KEY \`FK_project_stat_project\``,
+    );
+    await queryRunner.query(`DROP TABLE \`PROJECT_STAT\``);
+
+    await queryRunner.query(
+      `ALTER TABLE \`PROJECT\` DROP COLUMN \`hero_accent_word\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`PROJECT\` DROP COLUMN \`hero_subtitle\``,
+    );
+  }
+}

--- a/apps/api/src/modules/projects/admin-projects.service.ts
+++ b/apps/api/src/modules/projects/admin-projects.service.ts
@@ -15,6 +15,8 @@ import { Project } from './entities/project.entity';
 import { ProjectCompanyInfo } from './entities/project-company-info.entity';
 import { ProjectDetail } from './entities/project-detail.entity';
 import { ProjectImage } from './entities/project-image.entity';
+import { ProjectQuote } from './entities/project-quote.entity';
+import { ProjectStat } from './entities/project-stat.entity';
 import { ProjectTechnology } from './entities/project-technology.entity';
 import { ProjectTechnologyItem } from './entities/project-technology-item.entity';
 import { UpsertProjectDto } from './dto/upsert-project.dto';
@@ -83,6 +85,8 @@ export class AdminProjectsService {
       await manager.delete(ProjectImage, { projectId: id });
       await manager.delete(ProjectCompanyInfo, { projectId: id });
       await manager.delete(ProjectDetail, { projectId: id });
+      await manager.delete(ProjectStat, { projectId: id });
+      await manager.delete(ProjectQuote, { projectId: id });
 
       const updated = buildProject(dto);
       updated.id = id;
@@ -155,6 +159,8 @@ export class AdminProjectsService {
         companyInfo: true,
         technologies: { items: true },
         details: true,
+        stats: true,
+        quote: true,
       },
     });
   }
@@ -180,6 +186,11 @@ function buildProject(dto: UpsertProjectDto): Project {
   project.objectivesDetails = dto.objectivesDetails;
   project.projectDetailsHeading = dto.projectDetailsHeading;
   project.socialSharingHeading = dto.socialSharingHeading ?? '';
+  // Phase 2: 빈 문자열은 null 로 정규화 (DB nullable).
+  project.heroSubtitle = dto.heroSubtitle?.trim() ? dto.heroSubtitle : null;
+  project.heroAccentWord = dto.heroAccentWord?.trim()
+    ? dto.heroAccentWord
+    : null;
 
   project.images = dto.images.map((img, idx) => {
     const e = new ProjectImage();
@@ -216,6 +227,26 @@ function buildProject(dto: UpsertProjectDto): Project {
     e.sortOrder = idx;
     return e;
   });
+
+  // Phase 2: stats (OneToMany) — 입력 순서대로 sort_order 부여.
+  project.stats = (dto.stats ?? []).map((stat, idx) => {
+    const e = new ProjectStat();
+    e.label = stat.label;
+    e.value = stat.value;
+    e.sub = stat.sub?.trim() ? stat.sub : null;
+    e.sortOrder = idx;
+    return e;
+  });
+
+  // Phase 2: quote (OneToOne) — text 비면 null.
+  if (dto.quote && dto.quote.text?.trim()) {
+    const q = new ProjectQuote();
+    q.text = dto.quote.text;
+    q.author = dto.quote.author?.trim() ? dto.quote.author : null;
+    project.quote = q;
+  } else {
+    project.quote = null;
+  }
 
   return project;
 }

--- a/apps/api/src/modules/projects/dto/project-detail.dto.ts
+++ b/apps/api/src/modules/projects/dto/project-detail.dto.ts
@@ -49,6 +49,28 @@ export class ProjectDetailItemDto {
   details!: string;
 }
 
+export class ProjectStatItemDto {
+  @ApiProperty()
+  id!: number;
+
+  @ApiProperty()
+  label!: string;
+
+  @ApiProperty()
+  value!: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  sub!: string | null;
+}
+
+export class ProjectQuoteItemDto {
+  @ApiProperty()
+  text!: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  author!: string | null;
+}
+
 export class ProjectInfoDto {
   @ApiProperty()
   ClientHeading!: string;
@@ -73,6 +95,13 @@ export class ProjectInfoDto {
 
   @ApiProperty()
   SocialSharingHeading!: string;
+
+  // Phase 2 — 빈 배열 / null 이면 web 에서 섹션 미렌더.
+  @ApiProperty({ type: [ProjectStatItemDto] })
+  Impact!: ProjectStatItemDto[];
+
+  @ApiProperty({ type: ProjectQuoteItemDto, required: false, nullable: true })
+  Quote!: ProjectQuoteItemDto | null;
 }
 
 export class ProjectDetailDto {
@@ -90,6 +119,13 @@ export class ProjectDetailDto {
 
   @ApiProperty()
   img!: string;
+
+  // Phase 2 — Hero subtitle / accent 명시 필드. 미입력이면 null.
+  @ApiProperty({ required: false, nullable: true })
+  heroSubtitle!: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  heroAccentWord!: string | null;
 
   @ApiProperty({ type: ProjectHeaderDto })
   ProjectHeader!: ProjectHeaderDto;

--- a/apps/api/src/modules/projects/dto/upsert-project.dto.ts
+++ b/apps/api/src/modules/projects/dto/upsert-project.dto.ts
@@ -62,6 +62,39 @@ export class UpsertProjectDetailDto {
   details!: string;
 }
 
+export class UpsertProjectStatDto {
+  @ApiProperty({ maxLength: 100, example: 'Latency' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  label!: string;
+
+  @ApiProperty({ maxLength: 100, example: '-72%' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  value!: string;
+
+  @ApiProperty({ maxLength: 255, required: false, nullable: true })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  sub?: string | null;
+}
+
+export class UpsertProjectQuoteDto {
+  @ApiProperty({ description: '인용문 본문' })
+  @IsString()
+  @IsNotEmpty()
+  text!: string;
+
+  @ApiProperty({ maxLength: 200, required: false, nullable: true })
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  author?: string | null;
+}
+
 export class UpsertProjectDto {
   @ApiProperty({ maxLength: 200 })
   @IsString()
@@ -127,6 +160,33 @@ export class UpsertProjectDto {
   @IsString()
   @MaxLength(200)
   socialSharingHeading?: string;
+
+  // Phase 2 — 모두 optional. 미입력 시 UI 폴백/미노출.
+  @ApiProperty({ maxLength: 255, required: false, nullable: true })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  heroSubtitle?: string | null;
+
+  @ApiProperty({ maxLength: 100, required: false, nullable: true })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  heroAccentWord?: string | null;
+
+  @ApiProperty({ type: UpsertProjectQuoteDto, required: false, nullable: true })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => UpsertProjectQuoteDto)
+  quote?: UpsertProjectQuoteDto | null;
+
+  @ApiProperty({ type: [UpsertProjectStatDto], required: false, maxItems: 3 })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(3)
+  @ValidateNested({ each: true })
+  @Type(() => UpsertProjectStatDto)
+  stats?: UpsertProjectStatDto[];
 
   @ApiProperty({ type: [UpsertImageDto] })
   @IsArray()

--- a/apps/api/src/modules/projects/entities/project-quote.entity.ts
+++ b/apps/api/src/modules/projects/entities/project-quote.entity.ts
@@ -1,0 +1,33 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Project } from './project.entity';
+
+@Entity('PROJECT_QUOTE')
+export class ProjectQuote {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: 'text' })
+  text!: string;
+
+  @Column({ type: 'varchar', length: 200, nullable: true })
+  author!: string | null;
+
+  @OneToOne(() => Project, (project) => project.quote, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'project_id' })
+  project!: Project;
+
+  @Column({ name: 'project_id', type: 'int' })
+  projectId!: number;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+}

--- a/apps/api/src/modules/projects/entities/project-stat.entity.ts
+++ b/apps/api/src/modules/projects/entities/project-stat.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Project } from './project.entity';
+
+@Entity('PROJECT_STAT')
+export class ProjectStat {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ length: 100 })
+  label!: string;
+
+  @Column({ length: 100 })
+  value!: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  sub!: string | null;
+
+  @Column({ name: 'sort_order', type: 'int', default: 0 })
+  sortOrder!: number;
+
+  @ManyToOne(() => Project, (project) => project.stats, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'project_id' })
+  project!: Project;
+
+  @Column({ name: 'project_id', type: 'int' })
+  projectId!: number;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+}

--- a/apps/api/src/modules/projects/entities/project.entity.ts
+++ b/apps/api/src/modules/projects/entities/project.entity.ts
@@ -4,12 +4,15 @@ import {
   Entity,
   Index,
   OneToMany,
+  OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { ProjectImage } from './project-image.entity';
 import { ProjectCompanyInfo } from './project-company-info.entity';
 import { ProjectTechnology } from './project-technology.entity';
 import { ProjectDetail } from './project-detail.entity';
+import { ProjectStat } from './project-stat.entity';
+import { ProjectQuote } from './project-quote.entity';
 
 @Entity('PROJECT')
 export class Project {
@@ -50,6 +53,14 @@ export class Project {
   @Column({ name: 'social_sharing_heading', length: 200 })
   socialSharingHeading!: string;
 
+  // Phase 2: Hero 의 큰 타이틀 아래 한 줄 설명. 미입력 시 UI 에서 미노출.
+  @Column({ name: 'hero_subtitle', type: 'varchar', length: 255, nullable: true })
+  heroSubtitle!: string | null;
+
+  // Phase 2: Hero 타이틀 중 indigo+italic 강조할 단어. 미입력 시 web 에서 title 마지막 토큰 폴백.
+  @Column({ name: 'hero_accent_word', type: 'varchar', length: 100, nullable: true })
+  heroAccentWord!: string | null;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;
 
@@ -72,4 +83,16 @@ export class Project {
     cascade: true,
   })
   details!: ProjectDetail[];
+
+  // Phase 2: Impact (3-stat) 섹션용 OneToMany. AboutStat 패턴 동일.
+  @OneToMany(() => ProjectStat, (stat) => stat.project, {
+    cascade: true,
+  })
+  stats!: ProjectStat[];
+
+  // Phase 2: Quote (pull quote) 섹션용 OneToOne. 미존재 시 UI 에서 미노출.
+  @OneToOne(() => ProjectQuote, (quote) => quote.project, {
+    cascade: true,
+  })
+  quote!: ProjectQuote | null;
 }

--- a/apps/api/src/modules/projects/mappers/project-detail.mapper.ts
+++ b/apps/api/src/modules/projects/mappers/project-detail.mapper.ts
@@ -9,6 +9,7 @@ export function toProjectDetailDto(project: Project): ProjectDetailDto {
   const companyInfo = [...(project.companyInfo ?? [])].sort(bySortOrder);
   const technologies = [...(project.technologies ?? [])].sort(bySortOrder);
   const details = [...(project.details ?? [])].sort(bySortOrder);
+  const stats = [...(project.stats ?? [])].sort(bySortOrder);
 
   return {
     id: project.id,
@@ -16,6 +17,8 @@ export function toProjectDetailDto(project: Project): ProjectDetailDto {
     url: project.url,
     category: project.category,
     img: project.thumbnailImg,
+    heroSubtitle: project.heroSubtitle ?? null,
+    heroAccentWord: project.heroAccentWord ?? null,
     ProjectHeader: {
       title: project.title,
       publishDate: project.headerPublishDate,
@@ -47,6 +50,15 @@ export function toProjectDetailDto(project: Project): ProjectDetailDto {
         details: detail.details,
       })),
       SocialSharingHeading: project.socialSharingHeading,
+      Impact: stats.map((stat) => ({
+        id: stat.id,
+        label: stat.label,
+        value: stat.value,
+        sub: stat.sub ?? null,
+      })),
+      Quote: project.quote
+        ? { text: project.quote.text, author: project.quote.author ?? null }
+        : null,
     },
   };
 }

--- a/apps/api/src/modules/projects/projects.module.ts
+++ b/apps/api/src/modules/projects/projects.module.ts
@@ -11,6 +11,8 @@ import { ProjectCompanyInfo } from './entities/project-company-info.entity';
 import { ProjectTechnology } from './entities/project-technology.entity';
 import { ProjectTechnologyItem } from './entities/project-technology-item.entity';
 import { ProjectDetail } from './entities/project-detail.entity';
+import { ProjectStat } from './entities/project-stat.entity';
+import { ProjectQuote } from './entities/project-quote.entity';
 import { UploadsModule } from '../uploads/uploads.module';
 
 @Module({
@@ -22,6 +24,8 @@ import { UploadsModule } from '../uploads/uploads.module';
       ProjectTechnology,
       ProjectTechnologyItem,
       ProjectDetail,
+      ProjectStat,
+      ProjectQuote,
     ]),
     UploadsModule,
   ],

--- a/apps/api/src/modules/projects/projects.repository.spec.ts
+++ b/apps/api/src/modules/projects/projects.repository.spec.ts
@@ -57,6 +57,8 @@ describe('ProjectsRepository', () => {
         companyInfo: true,
         technologies: { items: true },
         details: true,
+        stats: true,
+        quote: true,
       },
     });
   });

--- a/apps/api/src/modules/projects/projects.repository.ts
+++ b/apps/api/src/modules/projects/projects.repository.ts
@@ -25,6 +25,9 @@ export class ProjectsRepository {
         companyInfo: true,
         technologies: { items: true },
         details: true,
+        // Phase 2 — 공개 detail 페이지의 Impact / Quote 섹션이 보이도록 함께 로드.
+        stats: true,
+        quote: true,
       },
     });
   }

--- a/apps/web/components/admin/DynamicList.jsx
+++ b/apps/web/components/admin/DynamicList.jsx
@@ -8,6 +8,7 @@ import { FiArrowDown, FiArrowUp, FiPlus, FiTrash2 } from 'react-icons/fi';
 //   emptyItem: () => newItem  (추가 버튼 눌렀을 때 생성)
 //   addLabel: 버튼 라벨 (기본 '추가')
 //   minLength: 최소 개수 (기본 0)
+//   maxLength: 최대 개수 (기본 무한). 도달 시 add 버튼 비활성 + 안내 문구
 function DynamicList({
 	items,
 	onChange,
@@ -15,7 +16,10 @@ function DynamicList({
 	emptyItem,
 	addLabel = '추가',
 	minLength = 0,
+	maxLength,
 }) {
+	const canAdd = maxLength == null || items.length < maxLength;
+
 	function update(index, partial) {
 		const next = items.map((it, i) =>
 			i === index ? { ...it, ...partial } : it,
@@ -24,6 +28,7 @@ function DynamicList({
 	}
 
 	function add() {
+		if (!canAdd) return;
 		onChange([...items, emptyItem()]);
 	}
 
@@ -87,10 +92,15 @@ function DynamicList({
 			<button
 				type="button"
 				onClick={add}
-				className="flex items-center justify-center gap-1.5 font-general-medium text-sm text-indigo-600 dark:text-indigo-400 border border-dashed border-indigo-300 dark:border-indigo-700 rounded-lg py-2.5 hover:bg-indigo-50 dark:hover:bg-secondary-dark duration-300"
+				disabled={!canAdd}
+				aria-disabled={!canAdd}
+				title={!canAdd ? `최대 ${maxLength}개까지 추가 가능합니다` : undefined}
+				className="flex items-center justify-center gap-1.5 font-general-medium text-sm text-indigo-600 dark:text-indigo-400 border border-dashed border-indigo-300 dark:border-indigo-700 rounded-lg py-2.5 hover:bg-indigo-50 dark:hover:bg-secondary-dark duration-300 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
 			>
 				<FiPlus className="w-4 h-4" />
-				{addLabel}
+				{canAdd
+					? addLabel
+					: `${addLabel} (최대 ${maxLength}개)`}
 			</button>
 		</div>
 	);

--- a/apps/web/components/admin/ProjectForm.jsx
+++ b/apps/web/components/admin/ProjectForm.jsx
@@ -17,6 +17,11 @@ const DEFAULT_VALUES = {
 	objectivesDetails: '',
 	projectDetailsHeading: 'Challenge',
 	socialSharingHeading: '',
+	// Phase 2 (선택) — Bold Hero / Impact / Quote 섹션.
+	heroSubtitle: '',
+	heroAccentWord: '',
+	quote: { text: '', author: '' },
+	stats: [],
 	images: [],
 	companyInfo: [],
 	// 공개 상세 페이지가 Technologies[0] 을 직접 참조하므로 최소 1 그룹을 기본으로 유지한다.
@@ -26,8 +31,24 @@ const DEFAULT_VALUES = {
 
 function toFormState(initial) {
 	const merged = { ...DEFAULT_VALUES, ...(initial ?? {}) };
+	// Phase 2 — api 응답의 ProjectInfo.Impact / ProjectInfo.Quote 도 받아와 form state 로 변환.
+	// upsert 응답은 ProjectDetailDto 형식이므로 ProjectInfo 안에서 꺼낸다.
+	const apiImpact = initial?.ProjectInfo?.Impact ?? initial?.stats ?? [];
+	const apiQuote = initial?.ProjectInfo?.Quote ?? initial?.quote ?? null;
 	return {
 		...merged,
+		heroSubtitle: merged.heroSubtitle ?? '',
+		heroAccentWord: merged.heroAccentWord ?? '',
+		quote: {
+			text: apiQuote?.text ?? '',
+			author: apiQuote?.author ?? '',
+		},
+		stats: apiImpact.map((s, i) => ({
+			_key: `stat-${i}-${Math.random()}`,
+			label: s.label ?? '',
+			value: s.value ?? '',
+			sub: s.sub ?? '',
+		})),
 		images: (merged.images ?? []).map((img, i) => ({
 			_key: `img-${i}-${Math.random()}`,
 			title: img.title ?? '',
@@ -51,6 +72,8 @@ function toFormState(initial) {
 }
 
 function toSubmitPayload(form) {
+	const quoteText = form.quote?.text?.trim() ?? '';
+	const quoteAuthor = form.quote?.author?.trim() ?? '';
 	return {
 		title: form.title.trim(),
 		url: form.url.trim(),
@@ -63,6 +86,17 @@ function toSubmitPayload(form) {
 		objectivesDetails: form.objectivesDetails.trim(),
 		projectDetailsHeading: form.projectDetailsHeading.trim(),
 		socialSharingHeading: form.socialSharingHeading.trim() || undefined,
+		heroSubtitle: form.heroSubtitle.trim() || null,
+		heroAccentWord: form.heroAccentWord.trim() || null,
+		// Phase 2: text 비면 quote 자체 미전송 (api 가 null 로 cascade delete).
+		quote: quoteText ? { text: quoteText, author: quoteAuthor || null } : null,
+		stats: form.stats
+			.map((s) => ({
+				label: s.label.trim(),
+				value: s.value.trim(),
+				sub: s.sub?.trim() ? s.sub.trim() : null,
+			}))
+			.filter((s) => s.label && s.value),
 		images: form.images.map((img) => ({ title: img.title, img: img.img })),
 		companyInfo: form.companyInfo.map((info) => ({
 			title: info.title,
@@ -170,6 +204,112 @@ function ProjectForm({ initialValue, submitLabel = '저장', onSubmit }) {
 					placeholderText="Backend / Realtime"
 					value={form.headerTags}
 					onChange={(e) => set('headerTags', e.target.value)}
+				/>
+			</AdminFormSection>
+
+			<AdminFormSection
+				title="Bold Hero (선택)"
+				description="Bold Project Detail 의 거대 타이틀 보강. 미입력 시 web 이 폴백(마지막 단어 accent + Overview 첫 단락)."
+			>
+				<FormInput
+					inputLabel="Hero Subtitle"
+					labelFor="heroSubtitle"
+					inputType="text"
+					inputId="heroSubtitle"
+					inputName="heroSubtitle"
+					ariaLabelName="Hero subtitle"
+					placeholderText="여러 서비스 로그를 한 곳에 모으는 인프라."
+					value={form.heroSubtitle}
+					onChange={(e) => set('heroSubtitle', e.target.value)}
+				/>
+				<FormInput
+					inputLabel="Hero Accent Word (강조할 단어, 미입력 시 타이틀 마지막 단어)"
+					labelFor="heroAccentWord"
+					inputType="text"
+					inputId="heroAccentWord"
+					inputName="heroAccentWord"
+					ariaLabelName="Hero accent word"
+					placeholderText="시스템"
+					value={form.heroAccentWord}
+					onChange={(e) => set('heroAccentWord', e.target.value)}
+				/>
+			</AdminFormSection>
+
+			<AdminFormSection
+				title="Quote (선택)"
+				description="Bold Project Detail 의 pull quote 섹션. text 가 비면 섹션 자체가 미노출."
+			>
+				<label
+					className="block text-lg text-primary-dark dark:text-primary-light mb-1 font-general-regular"
+					htmlFor="quoteText"
+				>
+					Quote text
+				</label>
+				<textarea
+					id="quoteText"
+					name="quoteText"
+					rows={3}
+					placeholder="6주 안에 결제 로직을 안정화하면서, 운영팀의 새벽 호출이 90% 줄었다."
+					aria-label="Quote text"
+					className="w-full px-5 py-2 mb-4 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-ternary-dark rounded-md shadow-sm text-md font-general-regular"
+					value={form.quote.text}
+					onChange={(e) => set('quote', { ...form.quote, text: e.target.value })}
+				/>
+				<FormInput
+					inputLabel="Author (선택)"
+					labelFor="quoteAuthor"
+					inputType="text"
+					inputId="quoteAuthor"
+					inputName="quoteAuthor"
+					ariaLabelName="Quote author"
+					placeholderText="프로젝트 회고"
+					value={form.quote.author}
+					onChange={(e) => set('quote', { ...form.quote, author: e.target.value })}
+				/>
+			</AdminFormSection>
+
+			<AdminFormSection
+				title="Impact stats (선택, 최대 3개)"
+				description="Bold Project Detail 의 Impact 섹션 카운터. value 가 숫자면 자동 카운트업, 단위 섞이면 plain. 빈 배열이면 섹션 미노출."
+			>
+				<DynamicList
+					items={form.stats}
+					onChange={(next) => set('stats', next)}
+					emptyItem={() => ({
+						_key: `stat-${Date.now()}`,
+						label: '',
+						value: '',
+						sub: '',
+					})}
+					addLabel="Stat 추가"
+					maxLength={3}
+					renderItem={(item, _idx, onItemChange) => (
+						<div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+							<input
+								className="px-3 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-secondary-dark rounded-md text-sm font-general-regular"
+								placeholder="Label (예: Latency)"
+								aria-label="Stat label"
+								value={item.label}
+								onChange={(e) => onItemChange({ label: e.target.value })}
+								required
+							/>
+							<input
+								className="px-3 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-secondary-dark rounded-md text-sm font-general-regular"
+								placeholder="Value (예: -72%)"
+								aria-label="Stat value"
+								value={item.value}
+								onChange={(e) => onItemChange({ value: e.target.value })}
+								required
+							/>
+							<input
+								className="px-3 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-secondary-dark rounded-md text-sm font-general-regular"
+								placeholder="Sub (선택, 예: 검색 평균 응답)"
+								aria-label="Stat sub"
+								value={item.sub}
+								onChange={(e) => onItemChange({ sub: e.target.value })}
+							/>
+						</div>
+					)}
 				/>
 			</AdminFormSection>
 

--- a/apps/web/components/primitives/Eyebrow.jsx
+++ b/apps/web/components/primitives/Eyebrow.jsx
@@ -1,11 +1,12 @@
 // 11px uppercase 메타 라벨. 섹션 상단의 "— Selected Work, 2026" 류.
-export default function Eyebrow({ children, className = '' }) {
+export default function Eyebrow({ children, className = '', style }) {
 	return (
 		<div
 			className={`font-general-medium text-[11px] uppercase ${className}`}
 			style={{
 				letterSpacing: '0.22em',
 				color: 'color-mix(in oklab, var(--paper) 55%, transparent)',
+				...style,
 			}}
 		>
 			{children}

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailHero.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailHero.jsx
@@ -144,21 +144,33 @@ export default function BoldProjectDetailHero({
 	);
 }
 
+// title 안에서 accentWord 의 위치를 찾아 head / accent / tail 3-part 로 split.
+// - accentWord 가 title 마지막 토큰: head / accent (2-line)
+// - accentWord 가 title 첫 토큰: accent / tail (2-line)
+// - accentWord 가 title 중간 토큰: head / accent / tail (3-line) — 시안 패턴
+// - accentWord 가 title 에 없거나 미지정: 마지막 토큰을 accent 로 폴백 (안전)
 function buildHeroItems(title, accentWord) {
 	const trimmed = (title ?? '').trim();
 	if (!trimmed) return [{ text: '' }];
 
-	// accentWord 가 지정되면 끝부분과 일치 여부 확인 후 분리. 아니면 마지막 공백 토큰 사용.
 	const tokens = trimmed.split(/\s+/);
-	const accent = accentWord || tokens[tokens.length - 1];
-	const head = tokens.slice(0, -1).join(' ');
-
-	if (!head) {
-		return [{ text: accent, accent: true }];
+	let accentIdx = tokens.length - 1;
+	if (accentWord) {
+		const idx = tokens.indexOf(accentWord);
+		if (idx >= 0) accentIdx = idx;
 	}
-	return [
-		{ text: head },
-		{ br: true },
-		{ text: accent, accent: true },
-	];
+
+	const accent = tokens[accentIdx];
+	const head = tokens.slice(0, accentIdx).join(' ');
+	const tail = tokens.slice(accentIdx + 1).join(' ');
+
+	const items = [];
+	if (head) {
+		items.push({ text: head }, { br: true });
+	}
+	items.push({ text: accent, accent: true });
+	if (tail) {
+		items.push({ br: true }, { text: tail });
+	}
+	return items;
 }

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailHero.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailHero.jsx
@@ -17,11 +17,11 @@ export default function BoldProjectDetailHero({
 
 	return (
 		<section id="hero" className="pt-28 lg:pt-40 pb-16 lg:pb-20">
-			{/* breadcrumb */}
-			<Reveal className="flex items-center gap-3 mb-10">
+			{/* breadcrumb — 좁은 viewport 에서 단정하게 두 줄로 wrap. spacer 는 sm 이상만 */}
+			<Reveal className="flex flex-wrap items-center gap-x-3 gap-y-2 mb-10">
 				<Link
 					href="/projects"
-					className="bold-interactive flex items-center gap-1.5 transition"
+					className="bold-interactive flex items-center gap-1.5 transition whitespace-nowrap"
 					style={{
 						fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
 						fontSize: '0.75rem',
@@ -29,7 +29,7 @@ export default function BoldProjectDetailHero({
 					}}
 				>
 					<svg
-						className="w-3 h-3"
+						className="w-3 h-3 flex-shrink-0"
 						viewBox="0 0 24 24"
 						fill="none"
 						stroke="currentColor"
@@ -38,10 +38,13 @@ export default function BoldProjectDetailHero({
 					>
 						<path d="M19 12H5M12 19l-7-7 7-7" />
 					</svg>
-					모든 프로젝트
+					<span>모든 프로젝트</span>
 				</Link>
-				<span className="w-6 h-px" style={{ background: 'var(--line-strong)' }} />
-				<Eyebrow>{eyebrow}</Eyebrow>
+				<span
+					className="hidden sm:inline-block w-6 h-px"
+					style={{ background: 'var(--line-strong)' }}
+				/>
+				<Eyebrow style={{ wordBreak: 'keep-all' }}>{eyebrow}</Eyebrow>
 			</Reveal>
 
 			{/* 거대 타이틀 + 우측 cover */}

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailHero.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailHero.jsx
@@ -7,6 +7,7 @@ import Eyebrow from '../../../primitives/Eyebrow';
 export default function BoldProjectDetailHero({
 	title,
 	accentWord,
+	subtitle,
 	eyebrow,
 	coverImage,
 	meta = [],
@@ -92,6 +93,24 @@ export default function BoldProjectDetailHero({
 					</div>
 				</Reveal>
 			</div>
+
+			{/* Hero subtitle — admin 명시 입력 시에만 노출. WordReveal 직후, meta strip 위. */}
+			{subtitle && (
+				<Reveal
+					delay={0.2}
+					as="p"
+					className="mt-10 lg:mt-12 max-w-3xl font-general-semibold"
+					style={{
+						fontSize: 'clamp(1.2rem, 1.6vw, 1.6rem)',
+						lineHeight: 1.4,
+						letterSpacing: '-0.02em',
+						color: 'var(--paper-dim)',
+						wordBreak: 'keep-all',
+					}}
+				>
+					{subtitle}
+				</Reveal>
+			)}
 
 			{/* meta strip — 4-col (Client / Role / Timeline / Category). 미존재 행 hide */}
 			{meta.length > 0 && (

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailImpact.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailImpact.jsx
@@ -1,0 +1,81 @@
+import Reveal from '../../../primitives/Reveal';
+import Eyebrow from '../../../primitives/Eyebrow';
+import StatCounter from '../../../primitives/StatCounter';
+
+// stats 빈 배열이면 섹션 자체 미렌더 (Phase 1 동일 동작 호환).
+// AboutCounters 패턴 동일 — value 가 순수 숫자면 카운트업, 단위 섞이면 plain.
+export default function BoldProjectDetailImpact({ stats = [] }) {
+	if (!stats.length) return null;
+
+	return (
+		<section
+			id="impact"
+			className="py-20 lg:py-24 border-t"
+			style={{ borderColor: 'var(--line)' }}
+		>
+			<Reveal className="flex items-end justify-between mb-10 lg:mb-14">
+				<div>
+					<Eyebrow className="mb-3">— Impact</Eyebrow>
+					<h2
+						className="font-general-semibold"
+						style={{
+							fontSize: 'clamp(1.8rem, 3vw, 2.6rem)',
+							letterSpacing: '-0.04em',
+							lineHeight: 1.15,
+						}}
+					>
+						숫자로 남긴 결과
+						<span style={{ color: 'var(--indigo-soft)' }}>.</span>
+					</h2>
+				</div>
+			</Reveal>
+
+			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-10">
+				{stats.map((stat, idx) => (
+					<Reveal key={`${stat.id ?? stat.label}-${idx}`} delay={idx * 0.08}>
+						<div
+							className="pt-[1.4rem]"
+							style={{ borderTop: '1px solid var(--line-strong)' }}
+						>
+							<div
+								className="font-general-semibold"
+								style={{
+									fontSize: 'clamp(3rem, 7vw, 5.5rem)',
+									letterSpacing: '-0.05em',
+									lineHeight: 1,
+									background:
+										'linear-gradient(180deg, var(--paper) 0%, color-mix(in oklab, var(--paper) 55%, transparent) 100%)',
+									WebkitBackgroundClip: 'text',
+									backgroundClip: 'text',
+									color: 'transparent',
+								}}
+							>
+								<StatCounterOrText value={stat.value} />
+							</div>
+							<Eyebrow className="mt-3">{stat.label}</Eyebrow>
+							{stat.sub && (
+								<div
+									className="text-sm mt-1"
+									style={{ color: 'var(--paper-dim)' }}
+								>
+									{stat.sub}
+								</div>
+							)}
+						</div>
+					</Reveal>
+				))}
+			</div>
+		</section>
+	);
+}
+
+// AboutCounters 의 StatCounterOrText 와 동일 — 순수 숫자면 카운트업, 단위 섞이면 plain.
+function StatCounterOrText({ value }) {
+	const str = String(value ?? '');
+	if (/^-?\d+(?:\.\d+)?$/.test(str)) {
+		const numeric = parseFloat(str);
+		const decimals = str.includes('.') ? str.split('.')[1].length : 0;
+		return <StatCounter end={numeric} decimals={decimals} />;
+	}
+	return <span>{str}</span>;
+}

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailProcess.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailProcess.jsx
@@ -2,6 +2,10 @@ import ReactMarkdown from 'react-markdown';
 import Reveal from '../../../primitives/Reveal';
 import Eyebrow from '../../../primitives/Eyebrow';
 
+// 시안 (Project Detail v2 - Bold.html) 의 process-step 패턴:
+// - 카드 배경/둥근 모서리 없이 vertical sequence
+// - 각 step 상단 border-top, 마지막 step 만 border-bottom 추가
+// - idx label 은 monospace '01 · DECISION' 한 줄, title h3, 본문 markdown 순서
 export default function BoldProjectDetailProcess({ steps = [] }) {
 	if (!steps.length) return null;
 
@@ -14,70 +18,84 @@ export default function BoldProjectDetailProcess({ steps = [] }) {
 			<div className="grid grid-cols-12 gap-6 lg:gap-12">
 				<Reveal className="col-span-12 lg:col-span-4">
 					<div className="lg:sticky lg:top-32">
-						<Eyebrow className="mb-3">— Process</Eyebrow>
+						<Eyebrow className="mb-3">— Challenge</Eyebrow>
 						<h2
 							className="font-general-semibold"
 							style={{
-								fontSize: 'clamp(1.8rem, 3vw, 2.6rem)',
+								fontSize: 'clamp(2rem, 3.4vw, 3rem)',
 								letterSpacing: '-0.04em',
 								lineHeight: 1.15,
+								wordBreak: 'keep-all',
 							}}
 						>
-							결정의 흐름
+							결정의{' '}
+							<span
+								style={{
+									display: 'inline-block',
+									color: 'var(--indigo-soft)',
+									fontStyle: 'italic',
+									paddingRight: '0.1em',
+								}}
+							>
+								흐름
+							</span>
 							<span style={{ color: 'var(--indigo-soft)' }}>.</span>
 						</h2>
+						<p
+							className="mt-5 text-sm leading-relaxed max-w-xs"
+							style={{ color: 'var(--paper-dim)' }}
+						>
+							&ldquo;무엇을 만들었나&rdquo; 보다 &ldquo;왜 그렇게 결정했나&rdquo; 를 남깁니다.
+						</p>
 					</div>
 				</Reveal>
 
-				<div className="col-span-12 lg:col-span-8 flex flex-col gap-6 lg:gap-8">
-					{steps.map((step, idx) => (
-						<Reveal key={`${step.title}-${idx}`} delay={idx * 0.06}>
-							<article
-								className="rounded-[18px] p-6 lg:p-8"
-								style={{
-									border: '1px solid var(--line-strong)',
-									background:
-										'linear-gradient(135deg, rgba(99,102,241,0.06), rgba(99,102,241,0.01))',
-								}}
-							>
-								<div
-									className="flex items-center gap-3 mb-4 text-xs uppercase"
-									style={{
-										fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
-										letterSpacing: '0.14em',
-										color: 'var(--paper-faint)',
-									}}
+				<div className="col-span-12 lg:col-span-8 flex flex-col">
+					{steps.map((step, idx) => {
+						const isLast = idx === steps.length - 1;
+						return (
+							<Reveal key={`${step.title}-${idx}`} delay={idx * 0.06}>
+								<article
+									className={`py-8 lg:py-10 border-t${isLast ? ' border-b' : ''}`}
+									style={{ borderColor: 'var(--line-strong)' }}
 								>
-									<span>{String(idx + 1).padStart(2, '0')}</span>
-									<span
-										className="px-2 py-0.5 rounded-full"
+									<div
+										className="mb-4 text-xs uppercase"
 										style={{
-											border: '1px solid var(--line-strong)',
-											color: 'var(--indigo-soft)',
+											fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+											letterSpacing: '0.14em',
+											color: 'var(--paper-faint)',
 										}}
 									>
-										{step.kind}
-									</span>
-								</div>
-								<h3
-									className="font-general-semibold mb-3"
-									style={{
-										fontSize: 'clamp(1.2rem, 1.8vw, 1.7rem)',
-										letterSpacing: '-0.02em',
-										lineHeight: 1.25,
-										wordBreak: 'keep-all',
-									}}
-								>
-									{step.title}
-								</h3>
-								{step.body && (
-									<div className="bold-prose">
-										<ReactMarkdown>{step.body}</ReactMarkdown>
+										{String(idx + 1).padStart(2, '0')}
+										<span
+											className="mx-2"
+											style={{ color: 'var(--line-strong)' }}
+										>
+											·
+										</span>
+										<span style={{ color: 'var(--indigo-soft)' }}>{step.kind}</span>
 									</div>
-								)}
-							</article>
-						</Reveal>
-					))}
+									<h3
+										className="font-general-semibold mb-4"
+										style={{
+											fontSize: 'clamp(1.4rem, 2.2vw, 2rem)',
+											letterSpacing: '-0.02em',
+											lineHeight: 1.25,
+											wordBreak: 'keep-all',
+										}}
+									>
+										{step.title}
+									</h3>
+									{step.body && (
+										<div className="bold-prose">
+											<ReactMarkdown>{step.body}</ReactMarkdown>
+										</div>
+									)}
+								</article>
+							</Reveal>
+						);
+					})}
 				</div>
 			</div>
 		</section>

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailQuote.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailQuote.jsx
@@ -1,0 +1,46 @@
+import Reveal from '../../../primitives/Reveal';
+import Eyebrow from '../../../primitives/Eyebrow';
+
+// quote 가 null 이면 섹션 자체 미렌더.
+export default function BoldProjectDetailQuote({ quote }) {
+	if (!quote?.text) return null;
+
+	return (
+		<section
+			id="quote"
+			className="py-20 lg:py-28 border-t"
+			style={{ borderColor: 'var(--line)' }}
+		>
+			<Reveal className="text-center">
+				<Eyebrow className="mb-6 inline-block">— Quote</Eyebrow>
+				<blockquote
+					className="font-general-semibold mx-auto max-w-4xl"
+					style={{
+						fontSize: 'clamp(1.6rem, 3.4vw, 2.8rem)',
+						lineHeight: 1.35,
+						letterSpacing: '-0.02em',
+						fontStyle: 'italic',
+						color: 'var(--paper)',
+						wordBreak: 'keep-all',
+					}}
+				>
+					<span style={{ color: 'var(--indigo-soft)' }}>“</span>
+					{quote.text}
+					<span style={{ color: 'var(--indigo-soft)' }}>”</span>
+				</blockquote>
+				{quote.author && (
+					<div
+						className="mt-6 text-xs uppercase"
+						style={{
+							fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+							letterSpacing: '0.14em',
+							color: 'var(--paper-faint)',
+						}}
+					>
+						— {quote.author}
+					</div>
+				)}
+			</Reveal>
+		</section>
+	);
+}

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailSideNav.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailSideNav.jsx
@@ -15,16 +15,14 @@ export default function BoldProjectDetailSideNav({ sections = [] }) {
 			if (typeof window === 'undefined') return;
 			const refLine = window.innerHeight * 0.3;
 			let currentId = ids[0];
+			// 모든 섹션을 순회해서 top < refLine 인 마지막 섹션 = 현재 통과 중인 섹션.
+			// 이전엔 break 로 조기 종료했지만 smooth scroll 중 stack 의 top 이 refLine 보다
+			// 잠시 아래 있을 때 process 에 멈추는 race 가 있어 break 제거.
 			for (const id of ids) {
 				const el = document.getElementById(id);
 				if (!el) continue;
-				const top = el.getBoundingClientRect().top;
-				// 섹션의 top 이 refLine 보다 위 (top < refLine) 면 그 섹션이 진입 또는 통과 중.
-				// ids 순서를 따라가면서 가장 최근에 통과한 섹션을 active 로 잡음.
-				if (top < refLine) {
+				if (el.getBoundingClientRect().top < refLine) {
 					currentId = id;
-				} else {
-					break;
 				}
 			}
 			setActiveId(currentId);
@@ -52,6 +50,9 @@ export default function BoldProjectDetailSideNav({ sections = [] }) {
 
 	const handleClick = (e, id) => {
 		e.preventDefault();
+		// 즉시 active 설정 → smooth scroll 중 race 로 잠시 다른 섹션이 active 가 되는 깜빡임 회피.
+		// scroll 종료 후 handleScroll 가 다시 정확한 active 로 재확인.
+		setActiveId(id);
 		const target = document.getElementById(id);
 		if (target) {
 			target.scrollIntoView({ behavior: 'smooth', block: 'start' });

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailSideNav.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailSideNav.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 // lg+ 좌측 컬럼 sticky 섹션 네비. main content 와 별도 column 이라 침범 없음.
 // active 추적은 scroll 위치 기반 — viewport 상단 30% 라인 기준 가장 최근에 통과한 섹션을
@@ -6,6 +6,10 @@ import { useEffect, useState } from 'react';
 // 짧은 섹션 (예: Gallery 3-image) 을 skip 하는 문제가 있어 교체.
 export default function BoldProjectDetailSideNav({ sections = [] }) {
 	const [activeId, setActiveId] = useState(sections[0]?.id ?? '');
+	// 클릭 직후 smooth scroll 동안 handleScroll 가 활성 섹션을 다시 detect 해서
+	// 직전 섹션 (process 등) 으로 덮어쓰는 race 차단. 클릭 1초 후 detection 재개.
+	const isClickScrollingRef = useRef(false);
+	const clickTimerRef = useRef(null);
 
 	useEffect(() => {
 		const ids = sections.map((s) => s.id).filter(Boolean);
@@ -13,11 +17,11 @@ export default function BoldProjectDetailSideNav({ sections = [] }) {
 
 		const handleScroll = () => {
 			if (typeof window === 'undefined') return;
+			// 클릭에 의한 smooth scroll 동안 active 갱신 차단.
+			if (isClickScrollingRef.current) return;
 			const refLine = window.innerHeight * 0.3;
 			let currentId = ids[0];
 			// 모든 섹션을 순회해서 top < refLine 인 마지막 섹션 = 현재 통과 중인 섹션.
-			// 이전엔 break 로 조기 종료했지만 smooth scroll 중 stack 의 top 이 refLine 보다
-			// 잠시 아래 있을 때 process 에 멈추는 race 가 있어 break 제거.
 			for (const id of ids) {
 				const el = document.getElementById(id);
 				if (!el) continue;
@@ -50,9 +54,15 @@ export default function BoldProjectDetailSideNav({ sections = [] }) {
 
 	const handleClick = (e, id) => {
 		e.preventDefault();
-		// 즉시 active 설정 → smooth scroll 중 race 로 잠시 다른 섹션이 active 가 되는 깜빡임 회피.
-		// scroll 종료 후 handleScroll 가 다시 정확한 active 로 재확인.
+		// 즉시 active 설정 + handleScroll lock → smooth scroll 동안 detection 차단.
+		// 1초 후 자동 해제하면 사용자가 다음 스크롤할 때 다시 정상 추적.
 		setActiveId(id);
+		isClickScrollingRef.current = true;
+		if (clickTimerRef.current) window.clearTimeout(clickTimerRef.current);
+		clickTimerRef.current = window.setTimeout(() => {
+			isClickScrollingRef.current = false;
+			clickTimerRef.current = null;
+		}, 1000);
 		const target = document.getElementById(id);
 		if (target) {
 			target.scrollIntoView({ behavior: 'smooth', block: 'start' });

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailSideNav.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailSideNav.jsx
@@ -1,33 +1,53 @@
 import { useEffect, useState } from 'react';
 
-// lg+ 좌측 sticky 섹션 네비. IntersectionObserver 로 active 추적, 모바일은 hide.
+// lg+ 좌측 컬럼 sticky 섹션 네비. main content 와 별도 column 이라 침범 없음.
+// active 추적은 scroll 위치 기반 — viewport 상단 30% 라인 기준 가장 최근에 통과한 섹션을
+// active 로. IntersectionObserver 의 intersectionRatio 방식은 섹션 높이가 들쭉날쭉하면
+// 짧은 섹션 (예: Gallery 3-image) 을 skip 하는 문제가 있어 교체.
 export default function BoldProjectDetailSideNav({ sections = [] }) {
 	const [activeId, setActiveId] = useState(sections[0]?.id ?? '');
 
 	useEffect(() => {
 		const ids = sections.map((s) => s.id).filter(Boolean);
-		const els = ids
-			.map((id) => document.getElementById(id))
-			.filter(Boolean);
-		if (els.length === 0) return undefined;
+		if (ids.length === 0) return undefined;
 
-		const observer = new IntersectionObserver(
-			(entries) => {
-				// 화면 중앙 근처에 가장 가까운 entry 를 active 로 잡음.
-				const visible = entries
-					.filter((e) => e.isIntersecting)
-					.sort((a, b) => b.intersectionRatio - a.intersectionRatio);
-				if (visible[0]) {
-					setActiveId(visible[0].target.id);
+		const handleScroll = () => {
+			if (typeof window === 'undefined') return;
+			const refLine = window.innerHeight * 0.3;
+			let currentId = ids[0];
+			for (const id of ids) {
+				const el = document.getElementById(id);
+				if (!el) continue;
+				const top = el.getBoundingClientRect().top;
+				// 섹션의 top 이 refLine 보다 위 (top < refLine) 면 그 섹션이 진입 또는 통과 중.
+				// ids 순서를 따라가면서 가장 최근에 통과한 섹션을 active 로 잡음.
+				if (top < refLine) {
+					currentId = id;
+				} else {
+					break;
 				}
-			},
-			{
-				rootMargin: '-30% 0px -50% 0px',
-				threshold: [0, 0.25, 0.5, 0.75, 1],
-			},
-		);
-		els.forEach((el) => observer.observe(el));
-		return () => observer.disconnect();
+			}
+			setActiveId(currentId);
+		};
+
+		// rAF 로 throttle — scroll 이벤트 빈도 ↓
+		let raf = 0;
+		const onScroll = () => {
+			if (raf) return;
+			raf = window.requestAnimationFrame(() => {
+				raf = 0;
+				handleScroll();
+			});
+		};
+
+		window.addEventListener('scroll', onScroll, { passive: true });
+		window.addEventListener('resize', onScroll, { passive: true });
+		handleScroll();
+		return () => {
+			window.removeEventListener('scroll', onScroll);
+			window.removeEventListener('resize', onScroll);
+			if (raf) window.cancelAnimationFrame(raf);
+		};
 	}, [sections]);
 
 	const handleClick = (e, id) => {
@@ -40,7 +60,7 @@ export default function BoldProjectDetailSideNav({ sections = [] }) {
 
 	return (
 		<aside
-			className="hidden lg:block fixed left-6 top-1/2 -translate-y-1/2 z-30"
+			className="sticky top-32"
 			aria-label="섹션 네비"
 		>
 			<nav className="flex flex-col gap-3">

--- a/apps/web/pages/admin/projects/[id]/edit.jsx
+++ b/apps/web/pages/admin/projects/[id]/edit.jsx
@@ -18,6 +18,18 @@ function toFormInitial(project) {
 		objectivesDetails: info.ObjectivesDetails ?? '',
 		projectDetailsHeading: info.ProjectDetailsHeading ?? 'Challenge',
 		socialSharingHeading: info.SocialSharingHeading ?? '',
+		// Phase 2 — 누락 시 form 의 빈 값이 payload null/[] 로 변환돼 cascade DELETE 발생.
+		// 기존 값을 반드시 form 에 적재해서 다른 필드만 편집해도 Phase 2 데이터가 보존되도록 한다.
+		heroSubtitle: project.heroSubtitle ?? '',
+		heroAccentWord: project.heroAccentWord ?? '',
+		stats: (info.Impact ?? []).map((s) => ({
+			label: s.label,
+			value: s.value,
+			sub: s.sub ?? '',
+		})),
+		quote: info.Quote
+			? { text: info.Quote.text, author: info.Quote.author ?? '' }
+			: { text: '', author: '' },
 		images: (project.ProjectImages ?? []).map((img) => ({
 			title: img.title,
 			img: img.img,

--- a/apps/web/pages/projects/[url].jsx
+++ b/apps/web/pages/projects/[url].jsx
@@ -49,24 +49,32 @@ function ProjectDetail({ project, relatedProjects }) {
 	return (
 		<>
 			<PagesMetaHead title={project.title} />
-			<BoldProjectDetailSideNav sections={sections} />
 
 			<div className="container mx-auto px-6 lg:px-10">
-				<BoldProjectDetailHero
-					title={project.title}
-					accentWord={heroAccentWord}
-					subtitle={heroSubtitle}
-					eyebrow={heroEyebrow}
-					coverImage={project.ProjectImages?.[0]?.img}
-					meta={heroMeta}
-				/>
-				<BoldProjectDetailOverview body={overview} />
-				<BoldProjectDetailGallery images={gallery} />
-				<BoldProjectDetailProcess steps={steps} />
-				<BoldProjectDetailImpact stats={impactStats} />
-				<BoldProjectDetailStack groups={stackGroups} />
-				<BoldProjectDetailQuote quote={quote} />
-				<BoldProjectDetailRelated projects={relatedProjects} />
+				{/* lg+ 에서 SideNav 를 별도 컬럼으로 분리 → fixed 시 main content 침범 문제 해소.
+				    SideNav 자체는 sticky top-32. 모바일에선 SideNav 영역 자체 미렌더. */}
+				<div className="lg:flex lg:gap-10 xl:gap-14">
+					<aside className="hidden lg:block lg:w-[160px] lg:flex-shrink-0 lg:pt-32">
+						<BoldProjectDetailSideNav sections={sections} />
+					</aside>
+					<div className="lg:flex-1 lg:min-w-0">
+						<BoldProjectDetailHero
+							title={project.title}
+							accentWord={heroAccentWord}
+							subtitle={heroSubtitle}
+							eyebrow={heroEyebrow}
+							coverImage={project.ProjectImages?.[0]?.img}
+							meta={heroMeta}
+						/>
+						<BoldProjectDetailOverview body={overview} />
+						<BoldProjectDetailGallery images={gallery} />
+						<BoldProjectDetailProcess steps={steps} />
+						<BoldProjectDetailImpact stats={impactStats} />
+						<BoldProjectDetailStack groups={stackGroups} />
+						<BoldProjectDetailQuote quote={quote} />
+						<BoldProjectDetailRelated projects={relatedProjects} />
+					</div>
+				</div>
 			</div>
 		</>
 	);

--- a/apps/web/pages/projects/[url].jsx
+++ b/apps/web/pages/projects/[url].jsx
@@ -7,6 +7,8 @@ import BoldProjectDetailProcess from '../../components/projects/bold/detail/Bold
 import BoldProjectDetailStack from '../../components/projects/bold/detail/BoldProjectDetailStack';
 import BoldProjectDetailRelated from '../../components/projects/bold/detail/BoldProjectDetailRelated';
 import BoldProjectDetailSideNav from '../../components/projects/bold/detail/BoldProjectDetailSideNav';
+import BoldProjectDetailImpact from '../../components/projects/bold/detail/BoldProjectDetailImpact';
+import BoldProjectDetailQuote from '../../components/projects/bold/detail/BoldProjectDetailQuote';
 
 const API_BASE_URL =
 	process.env.API_INTERNAL_URL || 'http://localhost:7341';
@@ -26,6 +28,11 @@ function ProjectDetail({ project, relatedProjects }) {
 	const gallery = project.ProjectImages?.slice(1) ?? [];
 	const steps = parseProcessSteps(project.ProjectInfo?.ProjectDetails);
 	const stackGroups = project.ProjectInfo?.Technologies ?? [];
+	// Phase 2 — admin 명시 값 우선, 미입력 시 폴백 (title 마지막 토큰).
+	const heroAccentWord = pickHeroAccentWord(project);
+	const heroSubtitle = project.heroSubtitle || null;
+	const impactStats = project.ProjectInfo?.Impact ?? [];
+	const quote = project.ProjectInfo?.Quote ?? null;
 
 	// SideNav 는 실제 렌더되는 섹션만 노출.
 	const sections = [
@@ -33,7 +40,9 @@ function ProjectDetail({ project, relatedProjects }) {
 		overview && { id: 'overview', label: 'Overview' },
 		gallery.length > 0 && { id: 'gallery', label: 'Gallery' },
 		steps.length > 0 && { id: 'process', label: 'Process' },
+		impactStats.length > 0 && { id: 'impact', label: 'Impact' },
 		stackGroups.some((g) => g?.techs?.length) && { id: 'stack', label: 'Stack' },
+		quote && { id: 'quote', label: 'Quote' },
 		relatedProjects.length > 0 && { id: 'related', label: 'Next Up' },
 	].filter(Boolean);
 
@@ -45,6 +54,8 @@ function ProjectDetail({ project, relatedProjects }) {
 			<div className="container mx-auto px-6 lg:px-10">
 				<BoldProjectDetailHero
 					title={project.title}
+					accentWord={heroAccentWord}
+					subtitle={heroSubtitle}
 					eyebrow={heroEyebrow}
 					coverImage={project.ProjectImages?.[0]?.img}
 					meta={heroMeta}
@@ -52,11 +63,22 @@ function ProjectDetail({ project, relatedProjects }) {
 				<BoldProjectDetailOverview body={overview} />
 				<BoldProjectDetailGallery images={gallery} />
 				<BoldProjectDetailProcess steps={steps} />
+				<BoldProjectDetailImpact stats={impactStats} />
 				<BoldProjectDetailStack groups={stackGroups} />
+				<BoldProjectDetailQuote quote={quote} />
 				<BoldProjectDetailRelated projects={relatedProjects} />
 			</div>
 		</>
 	);
+}
+
+// admin 명시 값이 있으면 그대로, 없으면 title 마지막 공백 토큰 폴백.
+function pickHeroAccentWord(project) {
+	if (project.heroAccentWord && project.heroAccentWord.trim()) {
+		return project.heroAccentWord.trim();
+	}
+	const tokens = (project.title ?? '').trim().split(/\s+/);
+	return tokens[tokens.length - 1] || '';
 }
 
 ProjectDetail.getLayout = (page) => <BoldLayout>{page}</BoldLayout>;

--- a/apps/web/pages/projects/[url].jsx
+++ b/apps/web/pages/projects/[url].jsx
@@ -57,7 +57,10 @@ function ProjectDetail({ project, relatedProjects }) {
 					<aside className="hidden lg:block lg:w-[160px] lg:flex-shrink-0 lg:pt-32">
 						<BoldProjectDetailSideNav sections={sections} />
 					</aside>
-					<div className="lg:flex-1 lg:min-w-0">
+					<div
+						className="lg:flex-1 lg:min-w-0"
+						style={{ wordBreak: 'keep-all' }}
+					>
 						<BoldProjectDetailHero
 							title={project.title}
 							accentWord={heroAccentWord}
@@ -96,12 +99,29 @@ function parseYear(headerPublishDate) {
 	return /^\d{4}$/.test(head) ? head : '';
 }
 
+// JSX 로 반환 → 두 phrase 사이의 공백 1곳에서만 wrap 가능. 좁은 viewport 에서
+// 'Selected Work / — 2025 · Web Application' 처럼 깔끔하게 두 줄.
 function buildHeroEyebrow(project) {
 	const year = parseYear(project.ProjectHeader?.publishDate);
 	const category = project.category;
-	if (year && category) return `Selected Work — ${year} · ${category}`;
-	if (category) return `Selected Work · ${category}`;
-	return 'Selected Work';
+	const primary = <span className="whitespace-nowrap">Selected Work</span>;
+	if (year && category) {
+		return (
+			<>
+				{primary}{' '}
+				<span className="whitespace-nowrap">— {year} · {category}</span>
+			</>
+		);
+	}
+	if (category) {
+		return (
+			<>
+				{primary}{' '}
+				<span className="whitespace-nowrap">· {category}</span>
+			</>
+		);
+	}
+	return primary;
 }
 
 // CompanyInfo[] 의 title 매칭으로 Client/Role/Team/Status 폴백 + 항상 Timeline / Category 표시.


### PR DESCRIPTION
## Summary
Project Detail Phase 1 (PR #104) 후속. 시안 10 섹션 중 Phase 1 에서 hide 됐던 **Impact (3-stat) / Quote (pull quote)** 2 섹션을 데이터 도입과 함께 노출. Hero subtitle / accent 단어도 admin 명시 입력 가능 (미입력 시 Phase 1 폴백 유지).

> **업데이트**: 라이브 피드백 기반 후속 fix 6건 추가. SideNav 침범/race 해소, Process 시안 톤 재스타일, 모바일 줄바꿈 보강, 한국어 단어 단위 wrap. 자세한 내용은 아래 "후속 fix" 섹션.

## 초기 commit (api + admin + UI) — 3 commit

### Backend (api)
| 필드 | 위치 | 비고 |
|---|---|---|
| `heroSubtitle` | PROJECT 컬럼 (varchar 255 NULL) | Hero 타이틀 아래 한 줄 설명 |
| `heroAccentWord` | PROJECT 컬럼 (varchar 100 NULL) | Hero 강조할 단어. 미입력 시 title 마지막 토큰 폴백 |
| `ProjectStat` | OneToMany 신규 PROJECT_STAT 테이블 | label/value/sub + sort_order. AboutStat 패턴 |
| `ProjectQuote` | OneToOne 신규 PROJECT_QUOTE 테이블 | text required + author nullable. project_id UNIQUE |

- migration `AddProjectPhase2Fields`: ALTER ADD 2 컬럼 + CREATE TABLE 2개. up/down 대칭. nullable / 신규 테이블이라 기존 데이터 무손실
- `UpsertProjectStatDto` / `UpsertProjectQuoteDto` 신규 + `UpsertProjectDto` 4 필드 optional 확장
- `ProjectStatItemDto` / `ProjectQuoteItemDto` 신규 + `ProjectInfoDto.Impact[]` / `Quote|null` + `ProjectDetailDto.heroSubtitle` / `heroAccentWord` 노출
- mapper / admin-projects.service buildProject / update() cascade DELETE 모두 반영
- 27 suite / 128 test pass

### Admin
- `ProjectForm.jsx` — 3 신규 섹션 (Bold Hero / Quote / Impact stats DynamicList)
- toFormState / toSubmitPayload — api 응답에서 Impact/Quote 흡수, 빈 값은 null/[] 로 정규화

### Web UI
- `BoldProjectDetailHero`: `subtitle` prop 추가
- 신규 `BoldProjectDetailImpact.jsx`: 3-stat grid (StatCounter 패턴, AboutCounters 재사용)
- 신규 `BoldProjectDetailQuote.jsx`: 중앙 italic blockquote + author
- `pages/projects/[url].jsx` — `pickHeroAccentWord` 폴백, Impact/Quote wiring, SideNav 동적

## 후속 fix (라이브 검증 피드백) — 6 commit

| # | 영역 | 내용 |
|---|---|---|
| F-1 | SideNav 침범 | layout 을 `lg:flex` 로 재구성 → SideNav 를 `lg:w-[160px]` flex-shrink 컬럼으로 분리. `fixed` 폐기. main content 와 침범 없음 |
| F-2 | Gallery active skip | IntersectionObserver `-30% -50%` 의 20% zone 이 짧은 Gallery 를 놓치던 문제 → scroll 위치 기반 추적 (viewport 30% 라인 기준 마지막 통과 섹션) |
| F-3 | Stack 클릭 active stuck | smooth scroll 중 race → click 즉시 `setActiveId` + 1초간 `handleScroll` lock (`isClickScrollingRef`) |
| F-4 | Process 시안 톤 | 카드 (둥근 모서리 + 그라데이션) → vertical sequence + border-t/border-b. idx label `01 · DECISION` 한 줄. 좌측 heading 에 italic accent (`결정의 [흐름]`) + 보조 paragraph |
| F-5 | Hero breadcrumb 모바일 wrap | `모든 프\n로젝트` 자모 분리 → Link `whitespace-nowrap` + breadcrumb container `flex-wrap`. spacer 가로선은 sm 이상만. Eyebrow primitive 에 style prop 지원 추가 |
| F-6 | Eyebrow 분리 wrap + 페이지 한국어 keep-all | `Selected Work — 2025 · Web Application` 이 `Selected Work / — 2025 · Web Application` 으로 정확한 위치에서 wrap. `buildHeroEyebrow` 가 JSX 반환 (두 phrase 각각 nowrap span). 메인 content wrapper 에 `wordBreak: keep-all` 적용 → Overview/Process markdown/Stack/Quote 모두 단어 단위 줄바꿈 (자모 분리 차단) |

## 폴백 호환성

Phase 2 필드 미입력 프로젝트 (기존 5건) 는 Phase 1 과 동일하게 동작:
- Impact / Quote 섹션 자체 미렌더
- Hero subtitle 미노출
- Hero accent 는 title 마지막 토큰 폴백

## 무변경
- 기존 페이지 (`/`, `/about`, `/contact`, `/projects`) 무영향
- Process 섹션의 markdown h2 split 파싱 로직 유지 (DB 데이터는 사용자가 새 디자인에 맞게 업데이트 예정)

## Test plan
- [ ] dev 머지 → cd-dev → api 부팅 시 migration 자동 적용
- [ ] `DESCRIBE PROJECT` 에 `hero_subtitle`, `hero_accent_word` + `PROJECT_STAT` / `PROJECT_QUOTE` 테이블 존재
- [ ] Admin `/admin/projects/{id}/edit` 에서 4 신규 필드 입력 → 저장 → DB 반영
- [ ] Web `/projects/{slug}` Hero subtitle, Impact 3-stat, Quote 노출
- [ ] SideNav: `Impact` / `Quote` 자동 추가, 침범 없음, 클릭 시 정확한 섹션으로 active 갱신, Gallery 도 active 표시
- [ ] Process 섹션 vertical sequence + idx label 시안 톤
- [ ] 모바일/좁은 lg 에서 breadcrumb / eyebrow 단정하게 wrap, 자모 분리 없음
- [ ] 한국어 본문 모두 단어 단위 줄바꿈
- [ ] 신규 필드 미입력 프로젝트는 Phase 1 그대로
- [ ] DARK/LIGHT / 모바일 viewport / reduced-motion 정상
- [ ] api 27 suite / 128 test pass + web lint/build 그린

Closes #107
Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)