### PR TITLE
[feat] Project Detail Process — admin kind / title 명시 입력

### DIFF
--- a/apps/api/src/database/migrations/1779786308747-AddProjectDetailKindTitle.ts
+++ b/apps/api/src/database/migrations/1779786308747-AddProjectDetailKindTitle.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProjectDetailKindTitle1779786308747 implements MigrationInterface {
+  name = 'AddProjectDetailKindTitle1779786308747';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // PROJECT_DETAIL: Process step 의 admin 명시 kind / title (Phase 2 후속).
+    // 모두 nullable — 기존 entry 는 그대로 두고 web 의 parseProcessSteps 폴백이 처리.
+    await queryRunner.query(
+      `ALTER TABLE \`PROJECT_DETAIL\` ADD \`kind\` varchar(50) NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`PROJECT_DETAIL\` ADD \`title\` varchar(200) NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`PROJECT_DETAIL\` DROP COLUMN \`title\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`PROJECT_DETAIL\` DROP COLUMN \`kind\``,
+    );
+  }
+}

--- a/apps/api/src/modules/projects/admin-projects.service.ts
+++ b/apps/api/src/modules/projects/admin-projects.service.ts
@@ -223,6 +223,10 @@ function buildProject(dto: UpsertProjectDto): Project {
 
   project.details = dto.details.map((detail, idx) => {
     const e = new ProjectDetail();
+    // Phase 2 후속 — admin 명시 kind/title 은 trim 후 null 정규화. 미입력 entry 는
+    // web 의 parseProcessSteps 가 markdown h2 split 폴백으로 처리.
+    e.kind = detail.kind?.trim() ? detail.kind : null;
+    e.title = detail.title?.trim() ? detail.title : null;
     e.details = detail.details;
     e.sortOrder = idx;
     return e;

--- a/apps/api/src/modules/projects/dto/project-detail.dto.ts
+++ b/apps/api/src/modules/projects/dto/project-detail.dto.ts
@@ -45,6 +45,13 @@ export class ProjectDetailItemDto {
   @ApiProperty()
   id!: number;
 
+  // Phase 2 후속 — admin 명시. 비어있으면 web 의 markdown h2 split 폴백.
+  @ApiProperty({ required: false, nullable: true })
+  kind!: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  title!: string | null;
+
   @ApiProperty()
   details!: string;
 }

--- a/apps/api/src/modules/projects/dto/upsert-project.dto.ts
+++ b/apps/api/src/modules/projects/dto/upsert-project.dto.ts
@@ -68,7 +68,24 @@ export class UpsertTechnologyGroupDto {
 }
 
 export class UpsertProjectDetailDto {
-  @ApiProperty({ description: '마크다운 허용' })
+  // Phase 2 후속 — admin 이 명시하면 1 entry = 1 step. 비우면 web 의 parseProcessSteps
+  // 가 details 의 h2 split + 키워드 매칭 폴백으로 처리.
+  @ApiProperty({ maxLength: 50, required: false, nullable: true, example: 'DECISION' })
+  @Transform(({ value }) => trimToNull(value))
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  kind?: string | null;
+
+  @ApiProperty({ maxLength: 200, required: false, nullable: true })
+  @Transform(({ value }) => trimToNull(value))
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  title?: string | null;
+
+  @ApiProperty({ description: '마크다운 허용. 신규 entry 는 body. 기존 entry 는 h2 split 폴백' })
+  @Transform(({ value }) => trimIfString(value))
   @IsString()
   @IsNotEmpty()
   details!: string;

--- a/apps/api/src/modules/projects/entities/project-detail.entity.ts
+++ b/apps/api/src/modules/projects/entities/project-detail.entity.ts
@@ -12,6 +12,14 @@ export class ProjectDetail {
   @PrimaryGeneratedColumn()
   id!: number;
 
+  // Phase 2 후속 (PR #113) — Process step 의 chip label + 헤딩. 미입력 시 web 에서
+  // 기존 markdown h2 split + 키워드 매칭 폴백 (parseProcessSteps).
+  @Column({ type: 'varchar', length: 50, nullable: true })
+  kind!: string | null;
+
+  @Column({ type: 'varchar', length: 200, nullable: true })
+  title!: string | null;
+
   @Column({ type: 'text' })
   details!: string;
 

--- a/apps/api/src/modules/projects/mappers/project-detail.mapper.ts
+++ b/apps/api/src/modules/projects/mappers/project-detail.mapper.ts
@@ -47,6 +47,8 @@ export function toProjectDetailDto(project: Project): ProjectDetailDto {
       ProjectDetailsHeading: project.projectDetailsHeading,
       ProjectDetails: details.map((detail) => ({
         id: detail.id,
+        kind: detail.kind ?? null,
+        title: detail.title ?? null,
         details: detail.details,
       })),
       SocialSharingHeading: project.socialSharingHeading,

--- a/apps/web/components/admin/ProjectForm.jsx
+++ b/apps/web/components/admin/ProjectForm.jsx
@@ -66,6 +66,8 @@ function toFormState(initial) {
 		})),
 		details: (merged.details ?? []).map((d, i) => ({
 			_key: `d-${i}-${Math.random()}`,
+			kind: d.kind ?? '',
+			title: d.title ?? '',
 			details: d.details ?? '',
 		})),
 	};
@@ -109,7 +111,11 @@ function toSubmitPayload(form) {
 				.map((s) => s.trim())
 				.filter(Boolean),
 		})),
-		details: form.details.map((d) => ({ details: d.details })),
+		details: form.details.map((d) => ({
+			kind: d.kind?.trim() || null,
+			title: d.title?.trim() || null,
+			details: d.details,
+		})),
 	};
 }
 
@@ -417,7 +423,10 @@ function ProjectForm({ initialValue, submitLabel = '저장', onSubmit }) {
 				/>
 			</AdminFormSection>
 
-			<AdminFormSection title="Challenge 섹션" description="각 블록은 마크다운을 지원합니다.">
+			<AdminFormSection
+				title="Challenge 섹션"
+				description="Project Detail 의 Process 카드. kind / title 을 직접 입력하면 1 entry = 1 step. 비우면 본문 markdown 의 ## h2 split + 키워드 매칭 폴백."
+			>
 				<FormInput
 					inputLabel="Challenge heading"
 					labelFor="projectDetailsHeading"
@@ -432,18 +441,41 @@ function ProjectForm({ initialValue, submitLabel = '저장', onSubmit }) {
 				<DynamicList
 					items={form.details}
 					onChange={(next) => set('details', next)}
-					emptyItem={() => ({ _key: `d-${Date.now()}`, details: '' })}
+					emptyItem={() => ({
+						_key: `d-${Date.now()}`,
+						kind: '',
+						title: '',
+						details: '',
+					})}
 					addLabel="Challenge 단락 추가"
 					renderItem={(item, _idx, onItemChange) => (
-						<textarea
-							className="w-full px-3 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-secondary-dark rounded-md text-sm font-mono"
-							rows={8}
-							placeholder="## 섹션 제목&#10;본문 (마크다운 가능)"
-							aria-label="Challenge markdown block"
-							value={item.details}
-							onChange={(e) => onItemChange({ details: e.target.value })}
-							required
-						/>
+						<div className="flex flex-col gap-2">
+							<div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+								<input
+									className="px-3 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-secondary-dark rounded-md text-sm font-general-regular"
+									placeholder="Kind (예: DECISION / OPS / 구조 결정)"
+									aria-label="Process kind"
+									value={item.kind}
+									onChange={(e) => onItemChange({ kind: e.target.value })}
+								/>
+								<input
+									className="px-3 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-secondary-dark rounded-md text-sm font-general-regular"
+									placeholder="Title (예: 하나의 이벤트 소스)"
+									aria-label="Process title"
+									value={item.title}
+									onChange={(e) => onItemChange({ title: e.target.value })}
+								/>
+							</div>
+							<textarea
+								className="w-full px-3 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-secondary-dark rounded-md text-sm font-mono"
+								rows={8}
+								placeholder="본문 (마크다운 가능). kind/title 비우면 ## h2 split 폴백"
+								aria-label="Challenge markdown block"
+								value={item.details}
+								onChange={(e) => onItemChange({ details: e.target.value })}
+								required
+							/>
+						</div>
 					)}
 				/>
 			</AdminFormSection>

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailProcess.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailProcess.jsx
@@ -76,17 +76,19 @@ export default function BoldProjectDetailProcess({ steps = [] }) {
 										</span>
 										<span style={{ color: 'var(--indigo-soft)' }}>{step.kind}</span>
 									</div>
-									<h3
-										className="font-general-semibold mb-4"
-										style={{
-											fontSize: 'clamp(1.4rem, 2.2vw, 2rem)',
-											letterSpacing: '-0.02em',
-											lineHeight: 1.25,
-											wordBreak: 'keep-all',
-										}}
-									>
-										{step.title}
-									</h3>
+									{step.title && (
+										<h3
+											className="font-general-semibold mb-4"
+											style={{
+												fontSize: 'clamp(1.4rem, 2.2vw, 2rem)',
+												letterSpacing: '-0.02em',
+												lineHeight: 1.25,
+												wordBreak: 'keep-all',
+											}}
+										>
+											{step.title}
+										</h3>
+									)}
 									{step.body && (
 										<div className="bold-prose">
 											<ReactMarkdown>{step.body}</ReactMarkdown>

--- a/apps/web/pages/projects/[url].jsx
+++ b/apps/web/pages/projects/[url].jsx
@@ -156,27 +156,44 @@ function pickOverview(objectivesDetails) {
 	return first || '';
 }
 
-// ProjectDetails[] 의 markdown 을 합쳐 `## ` 헤더 기준 split → step 카드 자동 생성.
+// admin 명시 우선 (1 entry = 1 step), 미입력 entry 는 details markdown 의 ## h2 split
+// + 키워드 매칭 폴백. 둘이 섞여 있어도 하나의 step 시퀀스로 합쳐 출력 (sortOrder 보존).
 function parseProcessSteps(projectDetails = []) {
-	const allMd = projectDetails
-		.map((d) => d.details ?? '')
-		.join('\n\n')
-		.trim();
-	if (!allMd) return [];
+	const steps = [];
+	for (const entry of projectDetails) {
+		const md = entry.details ?? '';
+		const kindExplicit = entry.kind?.trim();
+		const titleExplicit = entry.title?.trim();
 
-	// `## ` 헤더가 1개 이상이면 split, 아니면 전체를 단일 카드로 fallback.
-	const hasH2 = /^##\s+/m.test(allMd);
-	if (!hasH2) {
-		return [{ kind: 'NOTE', title: '메모', body: allMd }];
+		if (kindExplicit || titleExplicit) {
+			// admin 명시 — 1 entry = 1 step
+			steps.push({
+				kind: kindExplicit || pickKind(titleExplicit ?? '', steps.length),
+				title: titleExplicit || '',
+				body: md,
+			});
+			continue;
+		}
+
+		// 폴백: 기존 markdown h2 split. ## 없으면 단일 메모.
+		if (!md.trim()) continue;
+		const hasH2 = /^##\s+/m.test(md);
+		if (!hasH2) {
+			steps.push({ kind: 'NOTE', title: '메모', body: md.trim() });
+			continue;
+		}
+		const sections = md.split(/^##\s+/gm).filter((s) => s.trim().length > 0);
+		sections.forEach((section) => {
+			const [titleLine, ...bodyLines] = section.split('\n');
+			const title = titleLine.trim();
+			steps.push({
+				kind: pickKind(title, steps.length),
+				title,
+				body: bodyLines.join('\n').trim(),
+			});
+		});
 	}
-
-	const sections = allMd.split(/^##\s+/gm).filter((s) => s.trim().length > 0);
-	return sections.map((section, idx) => {
-		const [titleLine, ...bodyLines] = section.split('\n');
-		const title = titleLine.trim();
-		const body = bodyLines.join('\n').trim();
-		return { kind: pickKind(title, idx), title, body };
-	});
+	return steps;
 }
 
 function pickKind(title, idx) {


### PR DESCRIPTION
## Summary
PR #108 plan 의 보류 항목 (Process kind 정교화) 의 후속. admin 이 markdown 본문만 입력하던 것에서 **kind 와 title 을 명시 입력**할 수 있도록 ProjectDetail entity 확장. 1 entry = 1 step 구조 + 기존 markdown h2 split 폴백 유지.

## Backend (api)

| 컬럼 | 위치 | 비고 |
|---|---|---|
| `kind` varchar(50) NULL | PROJECT_DETAIL | 자유 입력 (DECISION/OPS/RESULT/TRADEOFF + INFRA/TEST/구조 결정 등) |
| `title` varchar(200) NULL | PROJECT_DETAIL | step 헤딩. 비우면 markdown h2 첫 줄 폴백 |

- migration `AddProjectDetailKindTitle`: ALTER ADD 2 컬럼. 모두 nullable → 기존 entry 무손실
- `UpsertProjectDetailDto`: kind/title optional + `trimToNull` `@Transform`
- `ProjectDetailItemDto`: kind/title 응답 노출
- `project-detail.mapper`: kind/title 매핑
- `admin-projects.service.buildProject`: details map 에 kind/title trim 후 null 정규화
- 27 suite / 128 test pass

## Admin

`ProjectForm.jsx` 의 Challenge 단락 DynamicList renderItem 확장:
- 3-row: `[kind input][title input]` (sm:grid-cols-2) + body textarea
- 섹션 description 갱신 — "kind/title 비우면 ## h2 split 폴백" 안내
- `toFormState` / `toSubmitPayload`: kind/title 직렬화 + 빈 string → null 정규화
- emptyItem: kind/title 빈 string

## Web

- `parseProcessSteps` 갱신: entry 별로 admin 명시 우선
  - `kind` 또는 `title` 입력 → 1 entry = 1 step (body 는 details 그대로)
  - 둘 다 비면 markdown h2 split + 키워드 매칭 폴백 (기존 동작)
  - 두 방식 혼재 시 sortOrder 순서대로 단일 시퀀스
- `BoldProjectDetailProcess`: title 빈 string 일 때 h3 미렌더 가드 (kind 만 입력한 케이스 대비)

## 1 entry = 1 step
새 entry 는 admin 이 kind+title+body 직접 입력. 기존 entry (kind/title null) 는 web 폴백으로 markdown h2 split → 라군 점진 이주 가능.

## Test plan
- [ ] dev 머지 → cd-dev → api 부팅 시 migration 자동 적용
- [ ] `DESCRIBE PROJECT_DETAIL` 에 `kind` / `title` 컬럼 NULL
- [ ] Admin `/admin/projects/{id}/edit` Challenge 단락 각 entry 에 kind/title 입력 가능
- [ ] 저장 후 DB 반영 + Detail 페이지 노출 (`01 · {kind}` + `{title}` + body markdown)
- [ ] 기존 entry (kind/title null) 는 markdown h2 split 폴백 유지
- [ ] kind 만 / title 만 입력한 케이스 graceful (폴백 결합)
- [ ] DARK/LIGHT / 모바일 / reduced-motion 정상
- [ ] `/`, `/about`, `/contact`, `/projects` 무영향
- [ ] api test pass + web lint/build 그린

## 보류
- 기존 markdown 데이터 일괄 마이그레이션 (h2 split → 개별 entry)
- ProjectDetailsHeading admin 입력
- kind 권장 키워드 docs

Closes #113
Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)