### PR TITLE
[fix] Project Detail Hero subtitle 미렌더 (Overview 와 중복)

### DIFF
--- a/apps/web/pages/projects/[url].jsx
+++ b/apps/web/pages/projects/[url].jsx
@@ -31,7 +31,9 @@ function ProjectDetail({ project, relatedProjects }) {
 	const stackGroups = project.ProjectInfo?.Technologies ?? [];
 	// Phase 2 — admin 명시 값 우선, 미입력 시 폴백 (title 마지막 토큰).
 	const heroAccentWord = pickHeroAccentWord(project);
-	const heroSubtitle = project.heroSubtitle || null;
+	// heroSubtitle 은 DB / admin / API 에 보존하되 페이지에서는 미렌더 — Overview 섹션과
+	// 의미 중복이라 한 곳만 두기로 결정 (사용자 결정). 후속에 emotional 카피로 차별화 시
+	// 복원 가능.
 	const impactStats = project.ProjectInfo?.Impact ?? [];
 	const quote = project.ProjectInfo?.Quote ?? null;
 
@@ -65,7 +67,6 @@ function ProjectDetail({ project, relatedProjects }) {
 						<BoldProjectDetailHero
 							title={project.title}
 							accentWord={heroAccentWord}
-							subtitle={heroSubtitle}
 							eyebrow={heroEyebrow}
 							coverImage={project.ProjectImages?.[0]?.img}
 							meta={heroMeta}


### PR DESCRIPTION
## Summary
6 프로젝트의 heroSubtitle 과 Overview 가 핵심 메시지 중복 → Hero 의 subtitle 한 줄만 페이지에서 미렌더. 데이터 (DB / admin / API) 는 보존.

## 변경
- `pages/projects/[url].jsx`: Hero 호출에서 `subtitle` prop 제거 + 로컬 `heroSubtitle` 변수 제거 (주석으로 결정 사유 + 복원 경로 명시)
- `BoldProjectDetailHero` 컴포넌트의 `subtitle` prop 자체는 유지 — 후속에 emotional 카피로 차별화 시 복원 가능 (한 줄 추가만)

## 무변경
- DB schema (PROJECT.hero_subtitle 컬럼 유지)
- admin AboutForm 의 Hero Subtitle 입력 (저장은 되지만 페이지 미반영)
- API DTO (ProjectDetailDto.heroSubtitle)
- 나머지 페이지 / Overview 섹션 / Hero 의 거대 타이틀·meta strip

## Test plan
- [ ] dev 머지 → cd-dev → `/projects/{slug}` 에서 Hero 거대 타이틀 직후 한 줄 subtitle 미노출
- [ ] meta strip / Overview / Gallery / Process / Impact / Quote / Related 모두 그대로
- [ ] admin 폼에 Hero Subtitle 여전히 입력 가능 (저장은 OK, 화면 미반영)
- [ ] DARK/LIGHT / 모바일 / reduced-motion 정상
- [ ] 다른 페이지 무영향

Closes #115
Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)