### PR TITLE
[feat] Project Links — GitHub / Notion / Demo 외부 링크 섹션

### DIFF
--- a/apps/api/src/database/migrations/1779792183503-AddProjectLinks.ts
+++ b/apps/api/src/database/migrations/1779792183503-AddProjectLinks.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProjectLinks1779792183503 implements MigrationInterface {
+  name = 'AddProjectLinks1779792183503';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // PROJECT_LINK: 프로젝트의 외부 링크 (GitHub / Notion / Demo / 배포 등). About socials 패턴.
+    await queryRunner.query(
+      `CREATE TABLE \`PROJECT_LINK\` (` +
+        `\`id\` int NOT NULL AUTO_INCREMENT,` +
+        `\`label\` varchar(100) NOT NULL,` +
+        `\`url\` varchar(500) NOT NULL,` +
+        `\`sort_order\` int NOT NULL DEFAULT '0',` +
+        `\`project_id\` int NOT NULL,` +
+        `\`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),` +
+        `PRIMARY KEY (\`id\`)` +
+        `) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`PROJECT_LINK\` ADD CONSTRAINT \`FK_project_link_project\` ` +
+        `FOREIGN KEY (\`project_id\`) REFERENCES \`PROJECT\`(\`id\`) ` +
+        `ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`PROJECT_LINK\` DROP FOREIGN KEY \`FK_project_link_project\``,
+    );
+    await queryRunner.query(`DROP TABLE \`PROJECT_LINK\``);
+  }
+}

--- a/apps/api/src/modules/projects/admin-projects.service.ts
+++ b/apps/api/src/modules/projects/admin-projects.service.ts
@@ -15,6 +15,7 @@ import { Project } from './entities/project.entity';
 import { ProjectCompanyInfo } from './entities/project-company-info.entity';
 import { ProjectDetail } from './entities/project-detail.entity';
 import { ProjectImage } from './entities/project-image.entity';
+import { ProjectLink } from './entities/project-link.entity';
 import { ProjectQuote } from './entities/project-quote.entity';
 import { ProjectStat } from './entities/project-stat.entity';
 import { ProjectTechnology } from './entities/project-technology.entity';
@@ -87,6 +88,7 @@ export class AdminProjectsService {
       await manager.delete(ProjectDetail, { projectId: id });
       await manager.delete(ProjectStat, { projectId: id });
       await manager.delete(ProjectQuote, { projectId: id });
+      await manager.delete(ProjectLink, { projectId: id });
 
       const updated = buildProject(dto);
       updated.id = id;
@@ -161,6 +163,7 @@ export class AdminProjectsService {
         details: true,
         stats: true,
         quote: true,
+        links: true,
       },
     });
   }
@@ -251,6 +254,17 @@ function buildProject(dto: UpsertProjectDto): Project {
   } else {
     project.quote = null;
   }
+
+  // Links (OneToMany) — label/url 둘 다 있어야 살림. 입력 순서대로 sortOrder.
+  project.links = (dto.links ?? [])
+    .filter((l) => l.label?.trim() && l.url?.trim())
+    .map((link, idx) => {
+      const e = new ProjectLink();
+      e.label = link.label.trim();
+      e.url = link.url.trim();
+      e.sortOrder = idx;
+      return e;
+    });
 
   return project;
 }

--- a/apps/api/src/modules/projects/dto/project-detail.dto.ts
+++ b/apps/api/src/modules/projects/dto/project-detail.dto.ts
@@ -78,6 +78,17 @@ export class ProjectQuoteItemDto {
   author!: string | null;
 }
 
+export class ProjectLinkItemDto {
+  @ApiProperty()
+  id!: number;
+
+  @ApiProperty()
+  label!: string;
+
+  @ApiProperty()
+  url!: string;
+}
+
 export class ProjectInfoDto {
   @ApiProperty()
   ClientHeading!: string;
@@ -109,6 +120,10 @@ export class ProjectInfoDto {
 
   @ApiProperty({ type: ProjectQuoteItemDto, required: false, nullable: true })
   Quote!: ProjectQuoteItemDto | null;
+
+  // Project Links — Hero meta strip 아래 Direct row 노출용. 빈 배열이면 영역 미렌더.
+  @ApiProperty({ type: [ProjectLinkItemDto] })
+  Links!: ProjectLinkItemDto[];
 }
 
 export class ProjectDetailDto {

--- a/apps/api/src/modules/projects/dto/upsert-project.dto.ts
+++ b/apps/api/src/modules/projects/dto/upsert-project.dto.ts
@@ -129,6 +129,22 @@ export class UpsertProjectQuoteDto {
   author?: string | null;
 }
 
+export class UpsertProjectLinkDto {
+  @ApiProperty({ maxLength: 100, example: '@LLagoon3' })
+  @Transform(({ value }) => trimIfString(value))
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  label!: string;
+
+  @ApiProperty({ maxLength: 500, example: 'https://github.com/LLagoon3' })
+  @Transform(({ value }) => trimIfString(value))
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(500)
+  url!: string;
+}
+
 export class UpsertProjectDto {
   @ApiProperty({ maxLength: 200 })
   @IsString()
@@ -223,6 +239,15 @@ export class UpsertProjectDto {
   @ValidateNested({ each: true })
   @Type(() => UpsertProjectStatDto)
   stats?: UpsertProjectStatDto[];
+
+  // Project Links — GitHub / Notion / Demo / 배포 등 외부 링크.
+  @ApiProperty({ type: [UpsertProjectLinkDto], required: false, maxItems: 10 })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(10)
+  @ValidateNested({ each: true })
+  @Type(() => UpsertProjectLinkDto)
+  links?: UpsertProjectLinkDto[];
 
   @ApiProperty({ type: [UpsertImageDto] })
   @IsArray()

--- a/apps/api/src/modules/projects/entities/project-link.entity.ts
+++ b/apps/api/src/modules/projects/entities/project-link.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Project } from './project.entity';
+
+@Entity('PROJECT_LINK')
+export class ProjectLink {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  // admin 이 표시할 라벨 자유 입력 (예: '@LLagoon3', 'Repository ↗', 'Demo ↗').
+  @Column({ length: 100 })
+  label!: string;
+
+  @Column({ length: 500 })
+  url!: string;
+
+  @Column({ name: 'sort_order', type: 'int', default: 0 })
+  sortOrder!: number;
+
+  @ManyToOne(() => Project, (project) => project.links, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'project_id' })
+  project!: Project;
+
+  @Column({ name: 'project_id', type: 'int' })
+  projectId!: number;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+}

--- a/apps/api/src/modules/projects/entities/project.entity.ts
+++ b/apps/api/src/modules/projects/entities/project.entity.ts
@@ -13,6 +13,7 @@ import { ProjectTechnology } from './project-technology.entity';
 import { ProjectDetail } from './project-detail.entity';
 import { ProjectStat } from './project-stat.entity';
 import { ProjectQuote } from './project-quote.entity';
+import { ProjectLink } from './project-link.entity';
 
 @Entity('PROJECT')
 export class Project {
@@ -95,4 +96,10 @@ export class Project {
     cascade: true,
   })
   quote!: ProjectQuote | null;
+
+  // Project Links (GitHub / Notion / Demo 등) — Hero meta strip 아래 Direct row 노출.
+  @OneToMany(() => ProjectLink, (link) => link.project, {
+    cascade: true,
+  })
+  links!: ProjectLink[];
 }

--- a/apps/api/src/modules/projects/mappers/project-detail.mapper.ts
+++ b/apps/api/src/modules/projects/mappers/project-detail.mapper.ts
@@ -10,6 +10,7 @@ export function toProjectDetailDto(project: Project): ProjectDetailDto {
   const technologies = [...(project.technologies ?? [])].sort(bySortOrder);
   const details = [...(project.details ?? [])].sort(bySortOrder);
   const stats = [...(project.stats ?? [])].sort(bySortOrder);
+  const links = [...(project.links ?? [])].sort(bySortOrder);
 
   return {
     id: project.id,
@@ -61,6 +62,11 @@ export function toProjectDetailDto(project: Project): ProjectDetailDto {
       Quote: project.quote
         ? { text: project.quote.text, author: project.quote.author ?? null }
         : null,
+      Links: links.map((link) => ({
+        id: link.id,
+        label: link.label,
+        url: link.url,
+      })),
     },
   };
 }

--- a/apps/api/src/modules/projects/projects.module.ts
+++ b/apps/api/src/modules/projects/projects.module.ts
@@ -13,6 +13,7 @@ import { ProjectTechnologyItem } from './entities/project-technology-item.entity
 import { ProjectDetail } from './entities/project-detail.entity';
 import { ProjectStat } from './entities/project-stat.entity';
 import { ProjectQuote } from './entities/project-quote.entity';
+import { ProjectLink } from './entities/project-link.entity';
 import { UploadsModule } from '../uploads/uploads.module';
 
 @Module({
@@ -26,6 +27,7 @@ import { UploadsModule } from '../uploads/uploads.module';
       ProjectDetail,
       ProjectStat,
       ProjectQuote,
+      ProjectLink,
     ]),
     UploadsModule,
   ],

--- a/apps/api/src/modules/projects/projects.repository.spec.ts
+++ b/apps/api/src/modules/projects/projects.repository.spec.ts
@@ -59,6 +59,7 @@ describe('ProjectsRepository', () => {
         details: true,
         stats: true,
         quote: true,
+        links: true,
       },
     });
   });

--- a/apps/api/src/modules/projects/projects.repository.ts
+++ b/apps/api/src/modules/projects/projects.repository.ts
@@ -28,6 +28,8 @@ export class ProjectsRepository {
         // Phase 2 — 공개 detail 페이지의 Impact / Quote 섹션이 보이도록 함께 로드.
         stats: true,
         quote: true,
+        // Project Links — Hero meta strip 아래 Direct row 용.
+        links: true,
       },
     });
   }

--- a/apps/web/components/admin/ProjectForm.jsx
+++ b/apps/web/components/admin/ProjectForm.jsx
@@ -22,6 +22,7 @@ const DEFAULT_VALUES = {
 	heroAccentWord: '',
 	quote: { text: '', author: '' },
 	stats: [],
+	links: [],
 	images: [],
 	companyInfo: [],
 	// 공개 상세 페이지가 Technologies[0] 을 직접 참조하므로 최소 1 그룹을 기본으로 유지한다.
@@ -31,10 +32,11 @@ const DEFAULT_VALUES = {
 
 function toFormState(initial) {
 	const merged = { ...DEFAULT_VALUES, ...(initial ?? {}) };
-	// Phase 2 — api 응답의 ProjectInfo.Impact / ProjectInfo.Quote 도 받아와 form state 로 변환.
+	// Phase 2 — api 응답의 ProjectInfo.Impact / ProjectInfo.Quote / ProjectInfo.Links 도 흡수.
 	// upsert 응답은 ProjectDetailDto 형식이므로 ProjectInfo 안에서 꺼낸다.
 	const apiImpact = initial?.ProjectInfo?.Impact ?? initial?.stats ?? [];
 	const apiQuote = initial?.ProjectInfo?.Quote ?? initial?.quote ?? null;
+	const apiLinks = initial?.ProjectInfo?.Links ?? initial?.links ?? [];
 	return {
 		...merged,
 		heroSubtitle: merged.heroSubtitle ?? '',
@@ -48,6 +50,11 @@ function toFormState(initial) {
 			label: s.label ?? '',
 			value: s.value ?? '',
 			sub: s.sub ?? '',
+		})),
+		links: apiLinks.map((l, i) => ({
+			_key: `link-${i}-${Math.random()}`,
+			label: l.label ?? '',
+			url: l.url ?? '',
 		})),
 		images: (merged.images ?? []).map((img, i) => ({
 			_key: `img-${i}-${Math.random()}`,
@@ -99,6 +106,12 @@ function toSubmitPayload(form) {
 				sub: s.sub?.trim() ? s.sub.trim() : null,
 			}))
 			.filter((s) => s.label && s.value),
+		links: form.links
+			.map((l) => ({
+				label: l.label.trim(),
+				url: l.url.trim(),
+			}))
+			.filter((l) => l.label && l.url),
 		images: form.images.map((img) => ({ title: img.title, img: img.img })),
 		companyInfo: form.companyInfo.map((info) => ({
 			title: info.title,
@@ -313,6 +326,41 @@ function ProjectForm({ initialValue, submitLabel = '저장', onSubmit }) {
 								aria-label="Stat sub"
 								value={item.sub}
 								onChange={(e) => onItemChange({ sub: e.target.value })}
+							/>
+						</div>
+					)}
+				/>
+			</AdminFormSection>
+
+			<AdminFormSection
+				title="Links (선택, 최대 10개)"
+				description="GitHub / Notion / Demo / 배포 등 외부 링크. Project Detail Hero meta strip 아래 Direct row 로 노출. label·url 둘 다 있어야 저장."
+			>
+				<DynamicList
+					items={form.links}
+					onChange={(next) => set('links', next)}
+					emptyItem={() => ({
+						_key: `link-${Date.now()}`,
+						label: '',
+						url: '',
+					})}
+					addLabel="Link 추가"
+					maxLength={10}
+					renderItem={(item, _idx, onItemChange) => (
+						<div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+							<input
+								className="px-3 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-secondary-dark rounded-md text-sm font-general-regular"
+								placeholder="라벨 (예: @LLagoon3, Demo ↗)"
+								aria-label="Link label"
+								value={item.label}
+								onChange={(e) => onItemChange({ label: e.target.value })}
+							/>
+							<input
+								className="px-3 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-secondary-dark rounded-md text-sm font-general-regular sm:col-span-2"
+								placeholder="URL"
+								aria-label="Link url"
+								value={item.url}
+								onChange={(e) => onItemChange({ url: e.target.value })}
 							/>
 						</div>
 					)}

--- a/apps/web/components/primitives/WordReveal.jsx
+++ b/apps/web/components/primitives/WordReveal.jsx
@@ -19,14 +19,14 @@ export default function WordReveal({
 				if (item.br) return <br key={`br-${idx}`} />;
 				// italic accent 단어의 마지막 글자가 inline-block + overflow-hidden 박스 밖으로
 				// 살짝 비져나가 잘리는 현상이 있어 paddingRight 로 박스 너비 보강.
-				// 한글 batchim (ㄹ 등) 이 italic 시 우측·하단 양방향 확장 → 0.35em 우측 + 0.08em
-				// 하단 (pb-[0.04em] 기본 override).
+				// 한글 batchim (ㄹ 등) 이 italic 시 우측·하단 양방향 확장 — Hero 의 tight
+				// lineHeight (1.1) 에서 paddingBottom 0.08em 으로 부족해 0.16em 로 보강.
 				const innerStyle = item.accent
 					? {
 							color: 'var(--indigo-soft)',
 							fontStyle: 'italic',
 							paddingRight: '0.35em',
-							paddingBottom: '0.08em',
+							paddingBottom: '0.16em',
 						}
 					: undefined;
 				// 다음 단어와 공백 분리. 단 noSep 가 true 면 공백 없이 직접 붙임

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailHero.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailHero.jsx
@@ -56,7 +56,9 @@ export default function BoldProjectDetailHero({
 						style={{
 							fontSize: 'clamp(2rem, calc((100vw - 3rem) / 8), 5rem)',
 							letterSpacing: '-0.04em',
-							lineHeight: 1.1,
+							// 1.1 은 italic 한글 descender 가 overflow-hidden 박스 하단으로 잘리는 경계.
+							// 1.2 로 살짝 키워 batchim (ㅋ / ㄱ 등) 안전 fit.
+							lineHeight: 1.2,
 							wordBreak: 'keep-all',
 						}}
 						items={items}

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailHero.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailHero.jsx
@@ -11,6 +11,7 @@ export default function BoldProjectDetailHero({
 	eyebrow,
 	coverImage,
 	meta = [],
+	links = [],
 }) {
 	// 마지막 단어를 accent 로 분리 (이미 accentWord 가 prop 으로 주어지면 그걸 사용).
 	const items = buildHeroItems(title, accentWord);
@@ -115,6 +116,29 @@ export default function BoldProjectDetailHero({
 				</Reveal>
 			)}
 
+			{/* Links — admin 입력 외부 링크 (GitHub / Notion / Demo 등). 빈 배열이면 미렌더.
+			    Contact Sidebar 의 DirectRow 패턴 복사 (후속에 primitive lift 검토). */}
+			{links.length > 0 && (
+				<Reveal
+					delay={0.28}
+					className="mt-10 lg:mt-12 flex flex-col gap-2 text-xs max-w-md"
+					style={{
+						fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+						color: 'var(--paper-faint)',
+					}}
+				>
+					{links.map((link) => (
+						<DirectRow
+							key={link.id ?? link.url}
+							label={deriveLinkLabel(link.url)}
+							href={link.url}
+						>
+							{link.label}
+						</DirectRow>
+					))}
+				</Reveal>
+			)}
+
 			{/* meta strip — 4-col (Client / Role / Timeline / Category). 미존재 행 hide */}
 			{meta.length > 0 && (
 				<Reveal
@@ -149,6 +173,36 @@ export default function BoldProjectDetailHero({
 // - accentWord 가 title 첫 토큰: accent / tail (2-line)
 // - accentWord 가 title 중간 토큰: head / accent / tail (3-line) — 시안 패턴
 // - accentWord 가 title 에 없거나 미지정: 마지막 토큰을 accent 로 폴백 (안전)
+// Contact Sidebar 의 DirectRow / deriveDirectLabel 패턴 그대로 복사 — 좌측 host
+// 라벨 자동 추출. 후속에 primitives/DirectLinkRow.jsx 로 lift 검토.
+function DirectRow({ label, href, children }) {
+	return (
+		<div className="flex items-center justify-between gap-3">
+			<span>{label}</span>
+			<a
+				href={href}
+				target="_blank"
+				rel="noopener noreferrer"
+				className="bold-interactive transition-colors hover:text-[color:var(--paper)] truncate"
+				style={{ color: 'var(--paper-dim)' }}
+			>
+				{children}
+			</a>
+		</div>
+	);
+}
+
+function deriveLinkLabel(url) {
+	try {
+		const host = new URL(url).host.toLowerCase();
+		const parts = host.split('.');
+		const root = parts.length >= 2 ? parts[parts.length - 2] : host;
+		return root.toUpperCase().slice(0, 10);
+	} catch {
+		return 'LINK';
+	}
+}
+
 function buildHeroItems(title, accentWord) {
 	const trimmed = (title ?? '').trim();
 	if (!trimmed) return [{ text: '' }];

--- a/apps/web/pages/projects/[url].jsx
+++ b/apps/web/pages/projects/[url].jsx
@@ -36,6 +36,7 @@ function ProjectDetail({ project, relatedProjects }) {
 	// 복원 가능.
 	const impactStats = project.ProjectInfo?.Impact ?? [];
 	const quote = project.ProjectInfo?.Quote ?? null;
+	const links = project.ProjectInfo?.Links ?? [];
 
 	// SideNav 는 실제 렌더되는 섹션만 노출.
 	const sections = [
@@ -70,6 +71,7 @@ function ProjectDetail({ project, relatedProjects }) {
 							eyebrow={heroEyebrow}
 							coverImage={project.ProjectImages?.[0]?.img}
 							meta={heroMeta}
+							links={links}
 						/>
 						<BoldProjectDetailOverview body={overview} />
 						<BoldProjectDetailGallery images={gallery} />


### PR DESCRIPTION
## Summary
프로젝트별 외부 링크 (GitHub / Notion / Demo / 배포 등) 를 admin 에서 명시 입력하고 Hero meta strip 바로 아래 Direct row 로 노출. About socials PR (#112) 패턴 그대로 미러링.

## Backend
| Entity | 컬럼 | 비고 |
|---|---|---|
| `ProjectLink` (OneToMany 신규) | label / url / sort_order + project_id FK CASCADE | AboutSocial 패턴 |

- migration `AddProjectLinks`: PROJECT_LINK 테이블 CREATE + FK
- `UpsertProjectLinkDto` / `ProjectLinkItemDto` 신규
- `UpsertProjectDto.links?` optional (ArrayMaxSize 10)
- `ProjectInfoDto.Links` 응답 노출
- mapper sortOrder 정렬 + admin-projects.service cascade DELETE + buildProject links map + findOneWithRelations
- projects.repository.findOneByUrl 에 links: true + spec 보정
- 27 suite / 128 test pass

## Admin
- ProjectForm 신규 섹션 'Links (선택, 최대 10개)' — DynamicList max 10. label / url 2칸 grid
- 빈 entry (label 또는 url 미입력) 자동 제거 후 payload
- 위치: Impact stats 뒤 (Bold Hero / Quote / Impact / Links 응집)

## Web
- BoldProjectDetailHero: `links` prop 추가, 거대 타이틀 + cover row 직후 / meta strip 위 에 max-w-md Direct row 렌더. 빈 배열이면 영역 미렌더
- 좌측 chip label 은 URL host 에서 자동 추출 (`github.com` → `GITHUB`, 알 수 없으면 `LINK`). Contact Sidebar deriveDirectLabel 패턴 복사 (후속 primitive lift 검토)
- `pages/projects/[url].jsx` 에서 `links = ProjectInfo.Links` 전달

## Test plan
- [ ] dev 머지 → cd-dev → api 부팅 시 migration 자동 적용
- [ ] `SHOW TABLES LIKE 'PROJECT_LINK'` 존재
- [ ] Admin `/admin/projects/{id}/edit` Links 섹션 입력/저장
- [ ] Web `/projects/{slug}` Hero 직후 Direct row 노출 (`GITHUB @LLagoon3` 등)
- [ ] links 비어있는 프로젝트는 Hero 그대로 (영역 미렌더)
- [ ] 좌측 host 자동 추출 정상
- [ ] DARK/LIGHT / 모바일 / reduced-motion 정상
- [ ] `/`, `/about`, `/contact`, `/projects` 무영향
- [ ] api test pass + web lint/build 그린

## 보류 (scope 밖)
- DirectRow / deriveDirectLabel 공용 primitive lift
- Link kind 별 아이콘 매핑 (GitHub octicons 등)
- 기존 CompanyInfo Repository entry 이주 (라군 결정)

Closes #117
Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)