### PR TITLE
[fix] 썸네일 업로드 preset 16:9 → 4:5 (카드 프레임 정렬)

### DIFF
--- a/apps/api/src/modules/uploads/upload-preset.spec.ts
+++ b/apps/api/src/modules/uploads/upload-preset.spec.ts
@@ -20,10 +20,10 @@ describe('upload-preset', () => {
   });
 
   describe('getPresetSpec', () => {
-    it('thumbnail 은 16:9 (1600×900) cover', () => {
+    it('thumbnail 은 4:5 (1200×1500) cover', () => {
       expect(getPresetSpec(UploadPreset.THUMBNAIL)).toEqual({
-        width: 1600,
-        height: 900,
+        width: 1200,
+        height: 1500,
         fit: 'cover',
       });
     });

--- a/apps/api/src/modules/uploads/upload-preset.ts
+++ b/apps/api/src/modules/uploads/upload-preset.ts
@@ -1,5 +1,7 @@
 // 업로드 슬롯별 resize/crop 프리셋.
-// - thumbnail: 프로젝트 카드 썸네일. 16:9 로 중앙 crop + 1600×900 까지 다운스케일
+// - thumbnail: 프로젝트 카드 썸네일. 4:5 로 중앙 crop + 1200×1500 까지 다운스케일
+//   (Bold 카드 / Hero 프레임이 4:5 aspectRatio + objectFit:cover 라 동일 비율로
+//   pre-crop. 과거 16:9 프리셋이 카드 프레임에서 이중 크롭되며 확대돼 보이던 문제 해소)
 // - gallery: 프로젝트 상세 갤러리. 비율 유지하되 장축 1600px 이하로만 다운스케일
 // - profile: About 프로필. 1:1 중앙 crop + 512×512 까지 다운스케일
 
@@ -16,7 +18,7 @@ export interface PresetSpec {
 }
 
 const SPEC: Record<UploadPreset, PresetSpec> = {
-  [UploadPreset.THUMBNAIL]: { width: 1600, height: 900, fit: 'cover' },
+  [UploadPreset.THUMBNAIL]: { width: 1200, height: 1500, fit: 'cover' },
   [UploadPreset.GALLERY]: { width: 1600, height: 1600, fit: 'inside' },
   [UploadPreset.PROFILE]: { width: 512, height: 512, fit: 'cover' },
 };

--- a/apps/api/src/modules/uploads/uploads.controller.spec.ts
+++ b/apps/api/src/modules/uploads/uploads.controller.spec.ts
@@ -68,21 +68,21 @@ describe('UploadsController', () => {
     );
   });
 
-  it('thumbnail preset 은 16:9 로 중앙 crop 된다 (1920×1080 → 1600×900)', async () => {
+  it('thumbnail preset 은 4:5 로 중앙 crop 된다 (1920×1080 → 1200×1500)', async () => {
     const file = await seedFile('t.jpg', 1920, 1080);
     const result = await controller.upload(file, UploadPreset.THUMBNAIL);
     expect(result.url).toBe(`${UPLOADS_URL_PREFIX}/t.jpg`);
     expect(result.mime).toBe('image/jpeg');
     expect(result.preset).toBe(UploadPreset.THUMBNAIL);
-    expect(result.width).toBe(1600);
-    expect(result.height).toBe(900);
+    expect(result.width).toBe(1200);
+    expect(result.height).toBe(1500);
   });
 
   it('thumbnail 은 cover 이므로 작은 원본도 목표 크기로 업스케일', async () => {
-    const file = await seedFile('small.jpg', 800, 450);
+    const file = await seedFile('small.jpg', 600, 750);
     const result = await controller.upload(file, UploadPreset.THUMBNAIL);
-    expect(result.width).toBe(1600);
-    expect(result.height).toBe(900);
+    expect(result.width).toBe(1200);
+    expect(result.height).toBe(1500);
   });
 
   it('profile preset 은 1:1 로 중앙 crop 된다', async () => {

--- a/apps/web/components/admin/ProjectForm.jsx
+++ b/apps/web/components/admin/ProjectForm.jsx
@@ -480,14 +480,32 @@ function ProjectForm({ initialValue, submitLabel = '저장', onSubmit }) {
 				/>
 			</AdminFormSection>
 
-			<AdminFormSection title="갤러리 이미지" description="프로젝트 상세 상단에 노출되는 이미지 배열. alt 텍스트와 함께 업로드합니다.">
+			<AdminFormSection
+				title="갤러리 이미지"
+				description={
+					<>
+						프로젝트 상세 상단에 노출되는 이미지 배열. alt 텍스트와 함께 업로드합니다.
+						<br />
+						<strong>1번째 이미지 (Hero cover)</strong>: 권장 <code>1200 × 1500 px (4:5)</code> — 세로형 카드 프레임.
+						<br />
+						<strong>2번째 이미지부터 (Gallery)</strong>: 권장 <code>1600 × 1200 px (4:3)</code> — 가로형 모자이크 프레임.
+						<br />
+						gallery 프리셋은 비율 유지 (장축 1600px 다운스케일만) 이므로 권장 비율과 다르면 프레임에서 잘립니다.
+					</>
+				}
+			>
 				<DynamicList
 					items={form.images}
 					onChange={(next) => set('images', next)}
 					emptyItem={() => ({ _key: `img-${Date.now()}`, title: '', img: '' })}
 					addLabel="이미지 추가"
-					renderItem={(item, _idx, onItemChange) => (
+					renderItem={(item, idx, onItemChange) => (
 						<div className="flex flex-col gap-2">
+							<div className="text-xs font-general-regular text-primary-dark dark:text-ternary-light">
+								{idx === 0
+									? '1번째 — Hero cover (권장 1200 × 1500 px, 4:5)'
+									: `${idx + 1}번째 — Gallery tile (권장 1600 × 1200 px, 4:3)`}
+							</div>
 							<input
 								className="px-3 py-2 border border-gray-300 dark:border-primary-dark border-opacity-50 text-primary-dark dark:text-secondary-light bg-ternary-light dark:bg-secondary-dark rounded-md text-sm font-general-regular"
 								placeholder="alt 텍스트"

--- a/apps/web/components/admin/ProjectForm.jsx
+++ b/apps/web/components/admin/ProjectForm.jsx
@@ -180,7 +180,7 @@ function ProjectForm({ initialValue, submitLabel = '저장', onSubmit }) {
 					onChange={(e) => set('category', e.target.value)}
 				/>
 				<label className="block text-lg text-primary-dark dark:text-primary-light mb-1 font-general-regular">
-					썸네일 이미지 (16:9 자동 crop)
+					썸네일 이미지 (4:5 자동 crop)
 				</label>
 				<ImageUploader
 					value={form.thumbnailImg}


### PR DESCRIPTION
## Summary

- \`upload-preset.THUMBNAIL\` 을 4:5 (1200×1500) cover 로 정렬 — Bold 카드 / Hero 프레임과 동일 비율
- 과거 16:9 (1600×900) 으로 pre-crop 후 카드 4:5 frame 의 \`objectFit:cover\` 가 좌·우를 또 잘라 중앙만 확대돼 보이던 이중 크롭 문제 해소
- 관련 spec 2개 + admin label 동기화

## Test plan

- [x] \`npm --workspace apps/api test\` (27 suite / 128 test) 그린
- [x] \`npm --workspace apps/web run lint\` 그린
- [ ] dev-preview 에서 admin 썸네일 슬롯 재업로드 → \`/projects\` 카드 잘림 없이 표시
- [ ] gallery / profile 프리셋 무영향

## Notes

기존 디스크의 16:9 썸네일은 그대로라 admin 재업로드 시점에만 4:5 로 갱신됩니다.

Closes #119
Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)