### PR TITLE
[fix] SideNav 마지막 짧은 섹션 + Contact Hero italic + StatCounter 숫자+단위

### DIFF
--- a/apps/web/components/about/bold/AboutCounters.jsx
+++ b/apps/web/components/about/bold/AboutCounters.jsx
@@ -51,7 +51,9 @@ export default function AboutCounters({ stats = [] }) {
 								style={{
 									fontSize: 'clamp(3rem, 7vw, 5.5rem)',
 									letterSpacing: '-0.05em',
-									lineHeight: 1,
+									// lineHeight 1.0 은 background-clip:text 마스크가 line box 와
+									// 동일해져 '%' 등 글리프 하단 끝이 잘리는 경계. 1.15 로 여유.
+									lineHeight: 1.15,
 									background:
 										'linear-gradient(180deg, var(--paper) 0%, color-mix(in oklab, var(--paper) 55%, transparent) 100%)',
 									WebkitBackgroundClip: 'text',

--- a/apps/web/components/contact/bold/BoldContactHero.jsx
+++ b/apps/web/components/contact/bold/BoldContactHero.jsx
@@ -39,7 +39,9 @@ export default function BoldContactHero() {
 				style={{
 					fontSize: 'clamp(2.6rem, 11vw, 12rem)',
 					letterSpacing: '-0.04em',
-					lineHeight: 1.0,
+					// 1.0 은 12rem fontSize 의 italic 한글 (예: 함께할/기회를) batchim 이
+					// overflow-hidden 박스 하단으로 잘리는 경계. 1.15 로 살짝 키워 fit.
+					lineHeight: 1.15,
 				}}
 				items={[
 					{ text: '함께할', accent: true },

--- a/apps/web/components/primitives/StatCounter.jsx
+++ b/apps/web/components/primitives/StatCounter.jsx
@@ -5,7 +5,9 @@ import useReducedMotion from '../../hooks/useReducedMotion';
 // reduced-motion 시 즉시 end 값 표시.
 export default function StatCounter({
 	end,
-	duration = 1.5,
+	// react-countup 기본 easing 이 ease-out (초반 빠르게 시작 → 종반 천천히 종료).
+	// duration 1.5s 는 종반 감속 구간이 짧아 거의 안 느껴져서 2.5s 로 키움.
+	duration = 2.5,
 	decimals = 0,
 	prefix = '',
 	suffix = '',

--- a/apps/web/components/primitives/StatCounterOrText.jsx
+++ b/apps/web/components/primitives/StatCounterOrText.jsx
@@ -1,17 +1,29 @@
 import StatCounter from './StatCounter';
 
 // AboutCounters / BoldProjectDetailImpact 등 stat 카운터 노출처에서 공용 사용.
-// value 가 순수 숫자 / 소수 ('333' / '99.98') 면 react-countup 으로 카운트업.
-// 단위·기호가 섞이면 ('333ms' / '8+ Years' / '1108ms saved' 등) admin 이 입력한
-// 형식을 그대로 보존해서 plain 으로 노출. 카운트업 + 단위 조합은 admin 의 의도
-// 형식을 깰 수 있고 (예: '333ms saved' 면 saved 까지 suffix 로 들어가 어색),
-// 단위 분리·합성 휴리스틱은 케이스마다 비결정적이라 보수적으로 처리.
+// value 안의 첫 숫자 토큰을 추출해 react-countup 으로 카운트업, 앞·뒤 비-숫자는
+// prefix/suffix 로 분리해서 admin 입력 형식 그대로 보존.
+//   '75%'         → 0→75 + suffix '%'
+//   '10x'         → 0→10 + suffix 'x'
+//   '99.98'       → 0.00→99.98
+//   '8+ Years'    → 0→8 + suffix '+ Years'
+//   '1108ms saved'→ 0→1108 + suffix 'ms saved'
+//   'v1.2'        → prefix 'v' + 1.2
+//   '-86%'        → 0→-86 + suffix '%'
+//   'N/A'         → plain text (숫자 없음 → 폴백)
 export default function StatCounterOrText({ value }) {
 	const str = String(value ?? '');
-	if (/^-?\d+(?:\.\d+)?$/.test(str)) {
-		const numeric = parseFloat(str);
-		const decimals = str.includes('.') ? str.split('.')[1].length : 0;
-		return <StatCounter end={numeric} decimals={decimals} />;
-	}
-	return <span>{str}</span>;
+	const match = str.match(/^(.*?)(-?\d+(?:\.\d+)?)(.*)$/);
+	if (!match) return <span>{str}</span>;
+	const [, prefix, numStr, suffix] = match;
+	const numeric = parseFloat(numStr);
+	const decimals = numStr.includes('.') ? numStr.split('.')[1].length : 0;
+	return (
+		<StatCounter
+			end={numeric}
+			decimals={decimals}
+			prefix={prefix}
+			suffix={suffix}
+		/>
+	);
 }

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailImpact.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailImpact.jsx
@@ -42,7 +42,9 @@ export default function BoldProjectDetailImpact({ stats = [] }) {
 								style={{
 									fontSize: 'clamp(3rem, 7vw, 5.5rem)',
 									letterSpacing: '-0.05em',
-									lineHeight: 1,
+									// lineHeight 1.0 은 background-clip:text 마스크가 line box 와
+									// 동일해져 '%' 등 글리프 하단 끝이 잘리는 경계. 1.15 로 여유.
+									lineHeight: 1.15,
 									background:
 										'linear-gradient(180deg, var(--paper) 0%, color-mix(in oklab, var(--paper) 55%, transparent) 100%)',
 									WebkitBackgroundClip: 'text',

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailSideNav.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailSideNav.jsx
@@ -19,6 +19,14 @@ export default function BoldProjectDetailSideNav({ sections = [] }) {
 			if (typeof window === 'undefined') return;
 			// 클릭에 의한 smooth scroll 동안 active 갱신 차단.
 			if (isClickScrollingRef.current) return;
+			// 페이지 바닥 도달 시 마지막 섹션 강제 active — 짧은 마지막 섹션 (예: Quote)
+			// 이 refLine (30vh) 까지 못 올라와도 사용자는 그 섹션을 보고 있는 상태.
+			const scrollBottom = window.innerHeight + window.scrollY;
+			const docHeight = document.documentElement.scrollHeight;
+			if (scrollBottom >= docHeight - 4) {
+				setActiveId(ids[ids.length - 1]);
+				return;
+			}
 			const refLine = window.innerHeight * 0.3;
 			let currentId = ids[0];
 			// 모든 섹션을 순회해서 top < refLine 인 마지막 섹션 = 현재 통과 중인 섹션.


### PR DESCRIPTION
## Summary

3개 small visual UX fix 묶음:

1. **\`BoldProjectDetailSideNav\`** — 페이지 바닥 도달 시 마지막 섹션 강제 active. Quote 처럼 짧은 마지막 섹션이 30vh refLine 까지 못 올라와 직전 섹션 (Stack) 으로 표시되던 문제 해소.
2. **\`BoldContactHero\`** — lineHeight 1.0 → 1.15. 12rem fontSize 의 italic 한글 batchim 잘림 보강.
3. **\`StatCounterOrText\`** — 첫 숫자 토큰을 추출해 react-countup 의 prefix/suffix 로 분리, '75%' / '10x' / '8+ Years' 등 단위 섞인 값도 카운트업. 매치 없으면 plain text 폴백.

## Test plan

- [x] \`npm --workspace apps/web run lint && build\` 그린
- [ ] dev-preview \`/projects/unified-log-system\` 끝까지 스크롤 → 07 QUOTE active
- [ ] dev-preview \`/contact\` Hero '함께할 기회를' 잘림 없음
- [ ] dev-preview \`/about\` IN NUMBERS '75%' / '10x' 카운트업 동작

Closes #121
Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)