### PR TITLE
[feat] About Tech Stack 그룹화 (project Stack 패턴)

### DIFF
--- a/apps/api/src/database/migrations/1779871000000-WrapAboutStacksAsGroups.ts
+++ b/apps/api/src/database/migrations/1779871000000-WrapAboutStacksAsGroups.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class WrapAboutStacksAsGroups1779871000000
+  implements MigrationInterface
+{
+  name = 'WrapAboutStacksAsGroups1779871000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // legacy ABOUT_PROFILE.stacks (flat string[]) → 그룹 형상 {title, techs[]}[] 으로
+    // 단일 그룹 wrap. 첫 요소 JSON_TYPE 이 STRING 일 때만 적용 — 이미 OBJECT 형상으로
+    // 옮긴 데이터는 WHERE 조건에서 제외돼 idempotent.
+    //
+    // 이 단계 없이 코드만 배포하면 AboutBrands 의 g?.techs?.length 가 false 가 돼
+    // 섹션 전체 미렌더 + admin 폼이 flat 데이터를 빈 {title, techs} 로 hydrate 해서
+    // 저장 시 silent data loss 발생.
+    await queryRunner.query(`
+      UPDATE \`ABOUT_PROFILE\`
+      SET stacks = JSON_ARRAY(JSON_OBJECT('title', '기술 스택', 'techs', stacks))
+      WHERE stacks IS NOT NULL
+        AND JSON_TYPE(stacks) = 'ARRAY'
+        AND JSON_LENGTH(stacks) > 0
+        AND JSON_TYPE(JSON_EXTRACT(stacks, '$[0]')) = 'STRING'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // 첫 그룹의 techs 만 보존하고 flat string[] 으로 복원. 여러 그룹으로 세분화된
+    // 데이터는 첫 그룹 외 손실 — 가역성 한계가 있으니 운영 환경에서는 신중히.
+    await queryRunner.query(`
+      UPDATE \`ABOUT_PROFILE\`
+      SET stacks = JSON_EXTRACT(stacks, '$[0].techs')
+      WHERE stacks IS NOT NULL
+        AND JSON_TYPE(stacks) = 'ARRAY'
+        AND JSON_LENGTH(stacks) > 0
+        AND JSON_TYPE(JSON_EXTRACT(stacks, '$[0]')) = 'OBJECT'
+    `);
+  }
+}

--- a/apps/api/src/modules/about/dto/about-response.dto.ts
+++ b/apps/api/src/modules/about/dto/about-response.dto.ts
@@ -35,6 +35,14 @@ export class AboutFaqDto {
   answer!: string;
 }
 
+export class AboutStackGroupDto {
+  @ApiProperty({ example: 'Backend' })
+  title!: string;
+
+  @ApiProperty({ type: [String], example: ['NestJS', 'Express'] })
+  techs!: string[];
+}
+
 export class AboutJourneyDto {
   @ApiProperty({ example: '2026.01 — Now', description: '자유 표현 가능한 기간 라벨' })
   year!: string;
@@ -92,8 +100,8 @@ export class AboutResponseDto {
   @ApiProperty({ type: [AboutJourneyDto], description: 'sort_order 정렬' })
   journey!: AboutJourneyDto[];
 
-  @ApiProperty({ type: [String], example: ['NestJS', 'Express', 'TypeScript'] })
-  stacks!: string[];
+  @ApiProperty({ type: [AboutStackGroupDto] })
+  stacks!: AboutStackGroupDto[];
 
   // Contact PR (#94) 보류분 — Contact Sidebar Direct / FAQ 섹션에 사용.
   @ApiProperty({ type: [AboutSocialDto], description: 'sort_order 정렬' })

--- a/apps/api/src/modules/about/dto/upsert-about.dto.ts
+++ b/apps/api/src/modules/about/dto/upsert-about.dto.ts
@@ -95,6 +95,23 @@ export class UpsertFaqDto {
   answer!: string;
 }
 
+export class UpsertAboutStackGroupDto {
+  @ApiProperty({ maxLength: 100, example: 'Backend' })
+  @Transform(({ value }) => trimIfString(value))
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  title!: string;
+
+  @ApiProperty({ type: [String], example: ['NestJS', 'Express', 'TypeScript'] })
+  @Transform(({ value }) => trimArray(value))
+  @IsArray()
+  @ArrayMaxSize(30)
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  techs!: string[];
+}
+
 export class UpsertJourneyDto {
   @ApiProperty({ maxLength: 100, description: '자유 표현 — "2026.01 — Now" 등' })
   @Transform(({ value }) => trimIfString(value))
@@ -208,13 +225,13 @@ export class UpsertAboutDto {
   @Type(() => UpsertJourneyDto)
   journey?: UpsertJourneyDto[];
 
-  @ApiProperty({ type: [String], required: false })
-  @Transform(({ value }) => trimArray(value))
+  @ApiProperty({ type: [UpsertAboutStackGroupDto], required: false })
   @IsOptional()
   @IsArray()
-  @ArrayMaxSize(30)
-  @IsString({ each: true })
-  stacks?: string[];
+  @ArrayMaxSize(20)
+  @ValidateNested({ each: true })
+  @Type(() => UpsertAboutStackGroupDto)
+  stacks?: UpsertAboutStackGroupDto[];
 
   // Contact PR (#94) 보류분 — Contact Sidebar Direct 섹션 / FAQ 섹션 데이터.
   @ApiProperty({ type: [UpsertSocialDto], required: false })

--- a/apps/api/src/modules/about/entities/about-profile.entity.ts
+++ b/apps/api/src/modules/about/entities/about-profile.entity.ts
@@ -13,6 +13,12 @@ import { AboutJourney } from './about-journey.entity';
 import { AboutSocial } from './about-social.entity';
 import { AboutFaq } from './about-faq.entity';
 
+// Tech Stack 그룹 JSON 값 형상. 별도 엔티티 아니라 타입 alias.
+export interface AboutStackGroupValue {
+  title: string;
+  techs: string[];
+}
+
 // singleton: ABOUT_PROFILE 은 항상 id = 1 인 단일 row 만 허용한다.
 // 앱 레벨 컨벤션만으로는 실수 방지가 부족하므로 CHECK 제약으로 못박는다.
 @Entity('ABOUT_PROFILE')
@@ -39,13 +45,14 @@ export class AboutProfile {
   @Column({ type: 'varchar', length: 50, nullable: true })
   phone!: string | null;
 
-  // Bold 리디자인 후속 — Hero status 한 줄, Tech Stack 단순 string 배열.
+  // Bold 리디자인 후속 — Hero status 한 줄, Tech Stack 그룹별 묶음.
   @Column({ type: 'varchar', length: 255, nullable: true })
   availability!: string | null;
 
-  // json 타입으로 단순 string[] 저장. 8개 정도라 별도 테이블 오버킬.
+  // Tech Stack 을 그룹별로 묶어 저장 (Project Detail Stack 패턴 차용).
+  // {title, techs[]} 형상이며 json 컬럼 그대로. 작은 데이터라 별도 테이블 오버킬.
   @Column({ type: 'json', nullable: true })
-  stacks!: string[] | null;
+  stacks!: AboutStackGroupValue[] | null;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;

--- a/apps/web/components/about/bold/AboutBrands.jsx
+++ b/apps/web/components/about/bold/AboutBrands.jsx
@@ -1,9 +1,13 @@
 import Reveal from '../../primitives/Reveal';
 import Eyebrow from '../../primitives/Eyebrow';
 
-// stacks 가 빈 배열이면 섹션 미렌더.
-export default function AboutBrands({ stacks = [] }) {
-	if (!stacks.length) return null;
+// 그룹 단위 ({title, techs[]}) 로 묶어 노출. project detail 의 Stack 섹션 동일 패턴.
+// 빈 배열이면 섹션 미렌더 — 각 그룹의 techs 가 빈 경우도 그 그룹은 hide.
+export default function AboutBrands({ groups = [] }) {
+	const visible = groups.filter((g) => g?.techs?.length);
+	if (!visible.length) return null;
+
+	const totalTechs = visible.reduce((sum, g) => sum + g.techs.length, 0);
 
 	return (
 		<section
@@ -42,44 +46,33 @@ export default function AboutBrands({ stacks = [] }) {
 						color: 'var(--paper-faint)',
 					}}
 				>
-					CORE · {String(stacks.length).padStart(2, '0')}
+					{visible.length} GROUPS · {String(totalTechs).padStart(2, '0')} TOOLS
 				</div>
 			</Reveal>
 
-			<div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3 lg:gap-4">
-				{stacks.map((label, idx) => (
-					<Reveal key={`${label}-${idx}`} delay={(idx % 4) * 0.06}>
+			<div className="flex flex-col gap-8 lg:gap-10">
+				{visible.map((group, idx) => (
+					<Reveal key={`${group.title}-${idx}`} delay={idx * 0.06}>
 						<div
-							className="bold-interactive grid place-items-center rounded-[12px] transition-all"
-							style={{
-								aspectRatio: '5 / 2',
-								border: '1px solid var(--line)',
-								transitionProperty: 'border-color, background',
-								transitionDuration: '0.3s',
-							}}
-							onMouseEnter={(e) => {
-								e.currentTarget.style.borderColor = 'var(--line-strong)';
-								e.currentTarget.style.background = 'rgba(255,255,255,0.02)';
-								const lbl = e.currentTarget.querySelector('span');
-								if (lbl) lbl.style.color = 'var(--paper)';
-							}}
-							onMouseLeave={(e) => {
-								e.currentTarget.style.borderColor = 'var(--line)';
-								e.currentTarget.style.background = 'transparent';
-								const lbl = e.currentTarget.querySelector('span');
-								if (lbl) lbl.style.color = 'var(--paper-faint)';
-							}}
+							className="pt-6"
+							style={{ borderTop: '1px solid var(--line-strong)' }}
 						>
-							<span
-								className="font-general-semibold transition-colors"
-								style={{
-									fontSize: 'clamp(1rem, 1.4vw, 1.4rem)',
-									letterSpacing: '0.04em',
-									color: 'var(--paper-faint)',
-								}}
-							>
-								{label}
-							</span>
+							<Eyebrow className="mb-4">{group.title}</Eyebrow>
+							<div className="flex flex-wrap gap-2 lg:gap-3">
+								{group.techs.map((tech) => (
+									<span
+										key={tech}
+										className="inline-flex items-center font-general-medium text-[13px] px-[1.1rem] py-[0.7rem] rounded-full"
+										style={{
+											border: '1px solid var(--line-strong)',
+											color: 'var(--paper)',
+											background: 'transparent',
+										}}
+									>
+										{tech}
+									</span>
+								))}
+							</div>
 						</div>
 					</Reveal>
 				))}

--- a/apps/web/pages/about.jsx
+++ b/apps/web/pages/about.jsx
@@ -36,7 +36,7 @@ function About({ about }) {
 			<AboutCounters stats={about.stats} />
 			<AboutPrinciples principles={about.principles} />
 			<AboutJourney journey={about.journey} />
-			<AboutBrands stacks={about.stacks} />
+			<AboutBrands groups={about.stacks} />
 			<AboutContactCTA />
 		</>
 	);

--- a/apps/web/pages/admin/about.jsx
+++ b/apps/web/pages/admin/about.jsx
@@ -45,9 +45,12 @@ function toFormState(about) {
 			role: j.role ?? '',
 			body: j.body ?? '',
 		})),
-		stacks: (about?.stacks ?? []).map((stack) => ({
+		// stacks: 그룹별 {title, techs[]} 배열. admin 폼에서는 techs 를 CSV 로
+		// 다루다가 submit 시점에 split (ProjectForm.technologies 와 동일 패턴).
+		stacks: (about?.stacks ?? []).map((group) => ({
 			_key: nextKey('stack'),
-			value: stack,
+			title: group.title ?? '',
+			techs: (group.techs ?? []).join(', '),
 		})),
 		socials: (about?.socials ?? []).map((s) => ({
 			_key: nextKey('social'),
@@ -110,8 +113,14 @@ function AdminAboutEditor({ initialAbout }) {
 						body: j.body.trim(),
 					})),
 				stacks: form.stacks
-					.map((s) => s.value.trim())
-					.filter((v) => v.length > 0),
+					.map((g) => ({
+						title: g.title.trim(),
+						techs: g.techs
+							.split(',')
+							.map((t) => t.trim())
+							.filter(Boolean),
+					}))
+					.filter((g) => g.title && g.techs.length > 0),
 				socials: form.socials
 					.filter((s) => s.label.trim() && s.url.trim())
 					.map((s) => ({ label: s.label.trim(), url: s.url.trim() })),
@@ -483,21 +492,35 @@ function AdminAboutEditor({ initialAbout }) {
 
 				<AdminFormSection
 					title="Tech Stack"
-					description="About 의 'Tech Stack' 그리드. 한 칸에 한 항목씩 입력. 비워둔 항목은 저장 시 자동 제거."
+					description="About 의 'Tech Stack' 섹션. 그룹 단위로 묶어 보여집니다. title 과 techs (콤마 구분) 둘 다 채워야 저장됩니다."
 				>
 					<DynamicList
 						items={form.stacks}
 						onChange={(next) => set('stacks', next)}
-						emptyItem={() => ({ _key: nextKey('stack'), value: '' })}
-						addLabel="스택 추가"
+						emptyItem={() => ({
+							_key: nextKey('stack'),
+							title: '',
+							techs: '',
+						})}
+						addLabel="스택 그룹 추가"
+						maxLength={20}
 						renderItem={(item, _idx, onItemChange) => (
-							<input
-								className={inputClass}
-								placeholder="예: NestJS"
-								aria-label="Tech stack"
-								value={item.value}
-								onChange={(e) => onItemChange({ value: e.target.value })}
-							/>
+							<div className="flex flex-col gap-2">
+								<input
+									className={inputClass}
+									placeholder="그룹 제목 (예: Backend, Databases)"
+									aria-label="Stack group title"
+									value={item.title}
+									onChange={(e) => onItemChange({ title: e.target.value })}
+								/>
+								<input
+									className={inputClass}
+									placeholder="기술 (콤마로 구분, 예: NestJS, Express, TypeScript)"
+									aria-label="Stack group techs"
+									value={item.techs}
+									onChange={(e) => onItemChange({ techs: e.target.value })}
+								/>
+							</div>
 						)}
 					/>
 				</AdminFormSection>


### PR DESCRIPTION
## Summary

\`/about\` 의 Tech Stack 섹션을 project detail 의 Stack 섹션과 동일한 그룹 + pill-chip 패턴으로 재구성.

- **api**: \`AboutProfile.stacks\` JSON 형상 \`string[]\` → \`{title, techs[]}[]\` (DTO/mapper 갱신, 컬럼 무변경)
- **admin**: About 폼 stacks 입력을 그룹 에디터로 (title + techs CSV)
- **public web**: \`AboutBrands\` 큰 타일 그리드 → 그룹별 Eyebrow + flex-wrap pill chips

## Data migration

기존 flat 16개를 단일 그룹 \`기술 스택\` 으로 wrap (1회 SQL 실행 필요, 후속 admin 에서 세분화). 마이그레이션 SQL 은 PR 본문 하단 + 첫 커밋 메시지에 포함.

\`\`\`sql
UPDATE ABOUT_PROFILE SET stacks =
  JSON_ARRAY(JSON_OBJECT('title', '기술 스택', 'techs', stacks))
WHERE stacks IS NOT NULL
  AND JSON_TYPE(stacks) = 'ARRAY'
  AND JSON_LENGTH(stacks) > 0
  AND JSON_TYPE(JSON_EXTRACT(stacks, '$[0]')) = 'STRING';
\`\`\`

## Test plan

- [x] \`npm --workspace apps/api test\` 27 suite / 128 test 그린
- [x] \`npm --workspace apps/api run build && lint\` 그린
- [x] \`npm --workspace apps/web run build && lint\` 그린
- [ ] dev-preview \`/about\` Tech Stack 영역이 그룹 + pill chip 으로 노출
- [ ] dev-preview admin \`/admin/about\` Tech Stack 섹션이 그룹 에디터 (title + techs CSV)
- [ ] dev-preview admin 에서 저장 → 공개 페이지 동기화 확인

Closes #123
Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)