### PR TITLE
[feat] Project Hero Role/Client 별도 필드 분리

### DIFF
--- a/apps/api/src/database/migrations/1779870000000-AddProjectHeroRoleClient.ts
+++ b/apps/api/src/database/migrations/1779870000000-AddProjectHeroRoleClient.ts
@@ -16,10 +16,15 @@ export class AddProjectHeroRoleClient1779870000000
 
     // 기존 데이터 backfill — companyInfo 의 첫 매칭 row 의 details 를 사용 (web 의
     // buildHeroMeta 폴백 로직과 동일 키워드). sort_order asc 의 첫 매칭만.
+    //
+    // source (PROJECT_COMPANY_INFO.details) 는 varchar(500) 인데 신규 컬럼은
+    // varchar(100) (Hero meta strip 의 간결성 의도). 길이 초과 row 가 있으면 strict
+    // mode 에서 마이그가 실패하므로 LEFT(..., 100) 으로 의도적 truncate. truncate
+    // 발생 시 admin 에서 다듬으면 됨.
     await queryRunner.query(`
       UPDATE \`PROJECT\` p
       SET \`hero_role\` = (
-        SELECT ci.details FROM \`PROJECT_COMPANY_INFO\` ci
+        SELECT LEFT(ci.details, 100) FROM \`PROJECT_COMPANY_INFO\` ci
         WHERE ci.project_id = p.id
           AND (
             LOWER(ci.title) LIKE '%role%'
@@ -34,7 +39,7 @@ export class AddProjectHeroRoleClient1779870000000
     await queryRunner.query(`
       UPDATE \`PROJECT\` p
       SET \`hero_client\` = (
-        SELECT ci.details FROM \`PROJECT_COMPANY_INFO\` ci
+        SELECT LEFT(ci.details, 100) FROM \`PROJECT_COMPANY_INFO\` ci
         WHERE ci.project_id = p.id
           AND (
             LOWER(ci.title) LIKE '%client%'

--- a/apps/api/src/database/migrations/1779870000000-AddProjectHeroRoleClient.ts
+++ b/apps/api/src/database/migrations/1779870000000-AddProjectHeroRoleClient.ts
@@ -1,0 +1,56 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProjectHeroRoleClient1779870000000
+  implements MigrationInterface
+{
+  name = 'AddProjectHeroRoleClient1779870000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Hero meta strip 의 Role / Client 전용 컬럼 (#125). 이전엔 PROJECT_COMPANY_INFO
+    // 의 title 키워드 매칭으로 추출했지만 명명 의존 + admin 직관성 부족 문제로 분리.
+    await queryRunner.query(
+      `ALTER TABLE \`PROJECT\` ` +
+        `ADD COLUMN \`hero_role\` varchar(100) NULL, ` +
+        `ADD COLUMN \`hero_client\` varchar(100) NULL`,
+    );
+
+    // 기존 데이터 backfill — companyInfo 의 첫 매칭 row 의 details 를 사용 (web 의
+    // buildHeroMeta 폴백 로직과 동일 키워드). sort_order asc 의 첫 매칭만.
+    await queryRunner.query(`
+      UPDATE \`PROJECT\` p
+      SET \`hero_role\` = (
+        SELECT ci.details FROM \`PROJECT_COMPANY_INFO\` ci
+        WHERE ci.project_id = p.id
+          AND (
+            LOWER(ci.title) LIKE '%role%'
+            OR ci.title LIKE '%역할%'
+            OR ci.title LIKE '%담당%'
+          )
+        ORDER BY ci.sort_order ASC
+        LIMIT 1
+      )
+      WHERE \`hero_role\` IS NULL
+    `);
+    await queryRunner.query(`
+      UPDATE \`PROJECT\` p
+      SET \`hero_client\` = (
+        SELECT ci.details FROM \`PROJECT_COMPANY_INFO\` ci
+        WHERE ci.project_id = p.id
+          AND (
+            LOWER(ci.title) LIKE '%client%'
+            OR ci.title LIKE '%클라이언트%'
+            OR ci.title LIKE '%고객%'
+          )
+        ORDER BY ci.sort_order ASC
+        LIMIT 1
+      )
+      WHERE \`hero_client\` IS NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`PROJECT\` DROP COLUMN \`hero_client\`, DROP COLUMN \`hero_role\``,
+    );
+  }
+}

--- a/apps/api/src/modules/projects/admin-projects.service.ts
+++ b/apps/api/src/modules/projects/admin-projects.service.ts
@@ -194,6 +194,8 @@ function buildProject(dto: UpsertProjectDto): Project {
   project.heroAccentWord = dto.heroAccentWord?.trim()
     ? dto.heroAccentWord
     : null;
+  project.heroRole = dto.heroRole?.trim() ? dto.heroRole : null;
+  project.heroClient = dto.heroClient?.trim() ? dto.heroClient : null;
 
   project.images = dto.images.map((img, idx) => {
     const e = new ProjectImage();

--- a/apps/api/src/modules/projects/dto/project-detail.dto.ts
+++ b/apps/api/src/modules/projects/dto/project-detail.dto.ts
@@ -149,6 +149,13 @@ export class ProjectDetailDto {
   @ApiProperty({ required: false, nullable: true })
   heroAccentWord!: string | null;
 
+  // Hero meta strip 의 Role / Client. companyInfo 키워드 매칭 대체 (#125).
+  @ApiProperty({ required: false, nullable: true })
+  heroRole!: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  heroClient!: string | null;
+
   @ApiProperty({ type: ProjectHeaderDto })
   ProjectHeader!: ProjectHeaderDto;
 

--- a/apps/api/src/modules/projects/dto/upsert-project.dto.ts
+++ b/apps/api/src/modules/projects/dto/upsert-project.dto.ts
@@ -226,6 +226,21 @@ export class UpsertProjectDto {
   @MaxLength(100)
   heroAccentWord?: string | null;
 
+  // Hero meta strip 의 Role / Client 전용 필드 (#125).
+  @ApiProperty({ maxLength: 100, required: false, nullable: true, example: '백엔드 · 1인' })
+  @Transform(({ value }) => trimToNull(value))
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  heroRole?: string | null;
+
+  @ApiProperty({ maxLength: 100, required: false, nullable: true, example: '에버디그엠' })
+  @Transform(({ value }) => trimToNull(value))
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  heroClient?: string | null;
+
   @ApiProperty({ type: UpsertProjectQuoteDto, required: false, nullable: true })
   @IsOptional()
   @ValidateNested()

--- a/apps/api/src/modules/projects/entities/project.entity.ts
+++ b/apps/api/src/modules/projects/entities/project.entity.ts
@@ -62,6 +62,15 @@ export class Project {
   @Column({ name: 'hero_accent_word', type: 'varchar', length: 100, nullable: true })
   heroAccentWord!: string | null;
 
+  // Hero meta strip 의 Role / Client 전용 필드. 이전엔 companyInfo 의 title 키워드
+  // 매칭 (role/역할/담당, client/클라이언트/고객) 으로 추출했지만 명명 컨벤션 의존
+  // + 직관성 부족 문제로 dedicated column 으로 분리.
+  @Column({ name: 'hero_role', type: 'varchar', length: 100, nullable: true })
+  heroRole!: string | null;
+
+  @Column({ name: 'hero_client', type: 'varchar', length: 100, nullable: true })
+  heroClient!: string | null;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;
 

--- a/apps/api/src/modules/projects/mappers/project-detail.mapper.ts
+++ b/apps/api/src/modules/projects/mappers/project-detail.mapper.ts
@@ -20,6 +20,8 @@ export function toProjectDetailDto(project: Project): ProjectDetailDto {
     img: project.thumbnailImg,
     heroSubtitle: project.heroSubtitle ?? null,
     heroAccentWord: project.heroAccentWord ?? null,
+    heroRole: project.heroRole ?? null,
+    heroClient: project.heroClient ?? null,
     ProjectHeader: {
       title: project.title,
       publishDate: project.headerPublishDate,

--- a/apps/web/components/admin/ProjectForm.jsx
+++ b/apps/web/components/admin/ProjectForm.jsx
@@ -247,6 +247,7 @@ function ProjectForm({ initialValue, submitLabel = '저장', onSubmit }) {
 					placeholderText="여러 서비스 로그를 한 곳에 모으는 인프라."
 					value={form.heroSubtitle}
 					onChange={(e) => set('heroSubtitle', e.target.value)}
+					required={false}
 				/>
 				<FormInput
 					inputLabel="Hero Accent Word (강조할 단어, 미입력 시 타이틀 마지막 단어)"
@@ -258,6 +259,7 @@ function ProjectForm({ initialValue, submitLabel = '저장', onSubmit }) {
 					placeholderText="시스템"
 					value={form.heroAccentWord}
 					onChange={(e) => set('heroAccentWord', e.target.value)}
+					required={false}
 				/>
 				<FormInput
 					inputLabel="Hero Role (Hero meta strip 의 Role 칸, 비우면 미노출)"
@@ -269,6 +271,7 @@ function ProjectForm({ initialValue, submitLabel = '저장', onSubmit }) {
 					placeholderText="백엔드 · 1인"
 					value={form.heroRole}
 					onChange={(e) => set('heroRole', e.target.value)}
+					required={false}
 				/>
 				<FormInput
 					inputLabel="Hero Client (Hero meta strip 의 Client 칸, 비우면 미노출)"
@@ -280,6 +283,7 @@ function ProjectForm({ initialValue, submitLabel = '저장', onSubmit }) {
 					placeholderText="에버디그엠"
 					value={form.heroClient}
 					onChange={(e) => set('heroClient', e.target.value)}
+					required={false}
 				/>
 			</AdminFormSection>
 

--- a/apps/web/components/admin/ProjectForm.jsx
+++ b/apps/web/components/admin/ProjectForm.jsx
@@ -20,6 +20,9 @@ const DEFAULT_VALUES = {
 	// Phase 2 (선택) — Bold Hero / Impact / Quote 섹션.
 	heroSubtitle: '',
 	heroAccentWord: '',
+	// Hero meta strip 의 Role / Client 전용 필드 (#125). companyInfo 키워드 매칭 대체.
+	heroRole: '',
+	heroClient: '',
 	quote: { text: '', author: '' },
 	stats: [],
 	links: [],
@@ -41,6 +44,8 @@ function toFormState(initial) {
 		...merged,
 		heroSubtitle: merged.heroSubtitle ?? '',
 		heroAccentWord: merged.heroAccentWord ?? '',
+		heroRole: merged.heroRole ?? '',
+		heroClient: merged.heroClient ?? '',
 		quote: {
 			text: apiQuote?.text ?? '',
 			author: apiQuote?.author ?? '',
@@ -97,6 +102,8 @@ function toSubmitPayload(form) {
 		socialSharingHeading: form.socialSharingHeading.trim() || undefined,
 		heroSubtitle: form.heroSubtitle.trim() || null,
 		heroAccentWord: form.heroAccentWord.trim() || null,
+		heroRole: form.heroRole.trim() || null,
+		heroClient: form.heroClient.trim() || null,
 		// Phase 2: text 비면 quote 자체 미전송 (api 가 null 로 cascade delete).
 		quote: quoteText ? { text: quoteText, author: quoteAuthor || null } : null,
 		stats: form.stats
@@ -251,6 +258,28 @@ function ProjectForm({ initialValue, submitLabel = '저장', onSubmit }) {
 					placeholderText="시스템"
 					value={form.heroAccentWord}
 					onChange={(e) => set('heroAccentWord', e.target.value)}
+				/>
+				<FormInput
+					inputLabel="Hero Role (Hero meta strip 의 Role 칸, 비우면 미노출)"
+					labelFor="heroRole"
+					inputType="text"
+					inputId="heroRole"
+					inputName="heroRole"
+					ariaLabelName="Hero role"
+					placeholderText="백엔드 · 1인"
+					value={form.heroRole}
+					onChange={(e) => set('heroRole', e.target.value)}
+				/>
+				<FormInput
+					inputLabel="Hero Client (Hero meta strip 의 Client 칸, 비우면 미노출)"
+					labelFor="heroClient"
+					inputType="text"
+					inputId="heroClient"
+					inputName="heroClient"
+					ariaLabelName="Hero client"
+					placeholderText="에버디그엠"
+					value={form.heroClient}
+					onChange={(e) => set('heroClient', e.target.value)}
 				/>
 			</AdminFormSection>
 

--- a/apps/web/components/reusable/FormInput.jsx
+++ b/apps/web/components/reusable/FormInput.jsx
@@ -8,6 +8,9 @@ const FormInput = ({
 	ariaLabelName,
 	value,
 	onChange,
+	// 기본값 true 로 기존 사용처 (Contact 폼 등) 호환 유지. admin 의 선택 필드는
+	// required={false} 로 명시해서 빈 값 저장 허용.
+	required = true,
 }) => {
 	return (
 		<div className="font-general-regular mb-4">
@@ -28,7 +31,7 @@ const FormInput = ({
 				aria-label={ariaLabelName}
 				value={value}
 				onChange={onChange}
-				required
+				required={required}
 			/>
 		</div>
 	);

--- a/apps/web/pages/admin/projects/[id]/edit.jsx
+++ b/apps/web/pages/admin/projects/[id]/edit.jsx
@@ -22,6 +22,10 @@ function toFormInitial(project) {
 		// 기존 값을 반드시 form 에 적재해서 다른 필드만 편집해도 Phase 2 데이터가 보존되도록 한다.
 		heroSubtitle: project.heroSubtitle ?? '',
 		heroAccentWord: project.heroAccentWord ?? '',
+		// Hero Role / Client 전용 필드 (#125). 빠뜨리면 admin 빈 인풋 → 저장 시 null
+		// 로 덮어써져 백필 값 손실.
+		heroRole: project.heroRole ?? '',
+		heroClient: project.heroClient ?? '',
 		stats: (info.Impact ?? []).map((s) => ({
 			label: s.label,
 			value: s.value,
@@ -30,6 +34,11 @@ function toFormInitial(project) {
 		quote: info.Quote
 			? { text: info.Quote.text, author: info.Quote.author ?? '' }
 			: { text: '', author: '' },
+		// Project Links — 빠뜨리면 admin 빈 리스트 → 저장 시 cascade DELETE 로 손실.
+		links: (info.Links ?? []).map((l) => ({
+			label: l.label,
+			url: l.url,
+		})),
 		images: (project.ProjectImages ?? []).map((img) => ({
 			title: img.title,
 			img: img.img,
@@ -42,7 +51,13 @@ function toFormInitial(project) {
 			title: t.title,
 			techs: t.techs ?? [],
 		})),
-		details: (info.ProjectDetails ?? []).map((d) => ({ details: d.details })),
+		// kind / title 도 적재 — Phase 2 후속 admin 명시 필드. 빠뜨리면 빈 값으로
+		// 덮어써져 'NOTE/메모' 폴백 처리됨.
+		details: (info.ProjectDetails ?? []).map((d) => ({
+			kind: d.kind ?? '',
+			title: d.title ?? '',
+			details: d.details,
+		})),
 	};
 }
 

--- a/apps/web/pages/projects/[url].jsx
+++ b/apps/web/pages/projects/[url].jsx
@@ -123,23 +123,19 @@ function buildHeroEyebrow(project) {
 	return primary;
 }
 
-// CompanyInfo[] 의 title 매칭으로 Client/Role/Team/Status 폴백 + 항상 Timeline / Category 표시.
+// Hero meta strip: Client / Role 은 admin 의 전용 필드 (#125) 사용.
+// 이전엔 companyInfo 의 title 키워드 (role/역할/담당, client/...) 매칭 폴백이
+// 있었으나 명명 의존 + 직관성 부족으로 제거. 빈 값이면 해당 칸 미노출.
 function buildHeroMeta(project) {
-	const info = project.ProjectInfo?.CompanyInfo ?? [];
-	const findByKeywords = (keywords) =>
-		info.find((row) =>
-			keywords.some((k) =>
-				row.title?.toLowerCase().includes(k.toLowerCase()),
-			),
-		);
-
 	const meta = [];
 
-	const client = findByKeywords(['client', '클라이언트', '고객']);
-	if (client) meta.push({ label: 'Client', value: client.details });
+	if (project.heroClient) {
+		meta.push({ label: 'Client', value: project.heroClient });
+	}
 
-	const role = findByKeywords(['role', '역할', '담당']);
-	if (role) meta.push({ label: 'Role', value: role.details });
+	if (project.heroRole) {
+		meta.push({ label: 'Role', value: project.heroRole });
+	}
 
 	if (project.ProjectHeader?.publishDate) {
 		meta.push({ label: 'Timeline', value: project.ProjectHeader.publishDate });


### PR DESCRIPTION
## Summary

Hero meta strip 의 Role / Client 를 \`PROJECT_COMPANY_INFO\` title 키워드 매칭에서 PROJECT 의 dedicated 컬럼으로 분리.

- **api migration**: \`PROJECT\` 에 \`hero_role\` / \`hero_client\` 컬럼 추가 + 기존 companyInfo 매칭으로 backfill (\`role/역할/담당\`, \`client/클라이언트/고객\`)
- **api**: entity / upsert DTO / response DTO / mapper / admin service 반영
- **admin web**: ProjectForm 의 'Bold Hero (선택)' 섹션에 Hero Role / Hero Client 인풋 추가
- **public web**: \`buildHeroMeta\` 가 신규 필드 직접 사용, 키워드 매칭 폴백 제거

## Migration

부팅 시 typeorm migration 자동 적용 (\`migrationsRun: true\`). backfill SQL 도 포함 — 기존 6개 프로젝트의 Role/Client 매핑이 자동 이주.

## Test plan

- [x] \`npm --workspace apps/api test\` 27 suite / 128 test 그린
- [x] \`npm --workspace apps/api run build && lint\` 그린
- [x] \`npm --workspace apps/web run build && lint\` 그린
- [ ] dev-preview \`/admin/projects/{id}/edit\` Bold Hero 섹션에 Role / Client 인풋 노출
- [ ] dev-preview \`/projects/{slug}\` Hero meta strip 의 Client / Role 가 기존 companyInfo 매칭 결과와 동일하게 표시 (backfill 검증)
- [ ] admin 에서 Role 변경 → 저장 → 공개 페이지 즉시 반영

Closes #125
Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)