### PR TITLE
[refactor] api transform 헬퍼 common lift + about mapper bySortOrder 추출

### DIFF
--- a/apps/api/src/common/dto/transforms.ts
+++ b/apps/api/src/common/dto/transforms.ts
@@ -1,0 +1,18 @@
+// class-transformer @Transform 헬퍼 공용 — 모듈별 DTO 파일에서 복사돼 있던 것을 lift.
+// (이전: apps/api/src/modules/projects/dto/upsert-project.dto.ts:14-24,
+//       apps/api/src/modules/about/dto/upsert-about.dto.ts:14-25)
+
+// 입력이 string 이면 trim, 아니면 그대로.
+export const trimIfString = (value: unknown): unknown =>
+  typeof value === 'string' ? value.trim() : value;
+
+// 입력이 배열이면 각 요소에 trimIfString 적용, 아니면 그대로.
+export const trimArray = (value: unknown): unknown =>
+  Array.isArray(value) ? value.map(trimIfString) : value;
+
+// 빈 문자열·공백-only 는 null 로 정규화 (선택 필드 공통 규칙).
+export const trimToNull = (value: unknown): unknown => {
+  if (typeof value !== 'string') return value;
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+};

--- a/apps/api/src/modules/about/dto/upsert-about.dto.ts
+++ b/apps/api/src/modules/about/dto/upsert-about.dto.ts
@@ -10,19 +10,11 @@ import {
   MaxLength,
   ValidateNested,
 } from 'class-validator';
-
-const trimIfString = (value: unknown): unknown =>
-  typeof value === 'string' ? value.trim() : value;
-
-const trimArray = (value: unknown): unknown =>
-  Array.isArray(value) ? value.map(trimIfString) : value;
-
-// 빈 문자열·공백-only 는 null 로 정규화 (선택 필드 공통 규칙).
-const trimToNull = (value: unknown): unknown => {
-  if (typeof value !== 'string') return value;
-  const trimmed = value.trim();
-  return trimmed.length === 0 ? null : trimmed;
-};
+import {
+  trimArray,
+  trimIfString,
+  trimToNull,
+} from '../../../common/dto/transforms';
 
 // Bold 리디자인 후속 — 신규 nested DTO 4개.
 

--- a/apps/api/src/modules/about/mappers/about.mapper.ts
+++ b/apps/api/src/modules/about/mappers/about.mapper.ts
@@ -1,25 +1,16 @@
 import { AboutProfile } from '../entities/about-profile.entity';
 import { AboutResponseDto } from '../dto/about-response.dto';
 
+const bySortOrder = <T extends { sortOrder: number }>(a: T, b: T): number =>
+  a.sortOrder - b.sortOrder;
+
 export function toAboutResponseDto(profile: AboutProfile): AboutResponseDto {
-  const sortedBios = [...(profile.bios ?? [])].sort(
-    (a, b) => a.sortOrder - b.sortOrder,
-  );
-  const sortedStats = [...(profile.stats ?? [])].sort(
-    (a, b) => a.sortOrder - b.sortOrder,
-  );
-  const sortedPrinciples = [...(profile.principles ?? [])].sort(
-    (a, b) => a.sortOrder - b.sortOrder,
-  );
-  const sortedJourneys = [...(profile.journeys ?? [])].sort(
-    (a, b) => a.sortOrder - b.sortOrder,
-  );
-  const sortedSocials = [...(profile.socials ?? [])].sort(
-    (a, b) => a.sortOrder - b.sortOrder,
-  );
-  const sortedFaqs = [...(profile.faqs ?? [])].sort(
-    (a, b) => a.sortOrder - b.sortOrder,
-  );
+  const sortedBios = [...(profile.bios ?? [])].sort(bySortOrder);
+  const sortedStats = [...(profile.stats ?? [])].sort(bySortOrder);
+  const sortedPrinciples = [...(profile.principles ?? [])].sort(bySortOrder);
+  const sortedJourneys = [...(profile.journeys ?? [])].sort(bySortOrder);
+  const sortedSocials = [...(profile.socials ?? [])].sort(bySortOrder);
+  const sortedFaqs = [...(profile.faqs ?? [])].sort(bySortOrder);
 
   return {
     name: profile.name,

--- a/apps/api/src/modules/projects/dto/upsert-project.dto.ts
+++ b/apps/api/src/modules/projects/dto/upsert-project.dto.ts
@@ -10,18 +10,7 @@ import {
   MaxLength,
   ValidateNested,
 } from 'class-validator';
-
-// About 의 trim helper 와 동일 패턴 (apps/api/src/modules/about/dto/upsert-about.dto.ts:14-25).
-// 후속에 apps/api/src/common/dto/transforms.ts 같은 공용 위치로 lift 검토.
-const trimIfString = (value: unknown): unknown =>
-  typeof value === 'string' ? value.trim() : value;
-
-// 빈 문자열·공백-only 는 null 로 정규화 (선택 필드 공통 규칙).
-const trimToNull = (value: unknown): unknown => {
-  if (typeof value !== 'string') return value;
-  const trimmed = value.trim();
-  return trimmed.length === 0 ? null : trimmed;
-};
+import { trimIfString, trimToNull } from '../../../common/dto/transforms';
 
 export class UpsertImageDto {
   @ApiProperty({ maxLength: 200 })


### PR DESCRIPTION
## Summary

- \`apps/api/src/common/dto/transforms.ts\` 신설 — \`trimIfString\` / \`trimArray\` / \`trimToNull\` lift
- projects + about DTO 가 import (중복 구현 제거)
- about mapper 에 \`bySortOrder<T>\` 추출 (project-detail mapper 동일 패턴) + 6 곳 lambda 교체

## Test plan

- [x] api 27 suite / 128 test 그린
- [x] \`npm --workspace apps/api run lint && build\` 그린
- [ ] dev-preview \`/about\` + \`/projects/{slug}\` 회귀 (정렬 / DTO 동작 동일성)

Closes #127
Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)