### PR TITLE
[refactor] DirectRow + deriveLinkLabel 를 primitives/DirectLinkRow 로 lift

### DIFF
--- a/apps/web/components/contact/bold/BoldContactSidebar.jsx
+++ b/apps/web/components/contact/bold/BoldContactSidebar.jsx
@@ -1,5 +1,6 @@
 import Reveal from '../../primitives/Reveal';
 import Eyebrow from '../../primitives/Eyebrow';
+import DirectLinkRow, { deriveLinkLabel } from '../../primitives/DirectLinkRow';
 
 // socials 는 admin About 입력으로 동적. EMAIL 행은 about.email 우선. 빈 배열이면 EMAIL 만 노출.
 export default function BoldContactSidebar({
@@ -60,19 +61,18 @@ export default function BoldContactSidebar({
 					}}
 				>
 					{email && (
-						<DirectRow label="EMAIL" href={`mailto:${email}`}>
+						<DirectLinkRow label="EMAIL" href={`mailto:${email}`} external={false}>
 							{email}
-						</DirectRow>
+						</DirectLinkRow>
 					)}
 					{socials.map((s) => (
-						<DirectRow
+						<DirectLinkRow
 							key={`${s.label}-${s.url}`}
-							label={deriveDirectLabel(s)}
+							label={deriveLinkLabel(s.url)}
 							href={s.url}
-							external
 						>
 							{s.label}
-						</DirectRow>
+						</DirectLinkRow>
 					))}
 				</div>
 			</Reveal>
@@ -91,31 +91,3 @@ export default function BoldContactSidebar({
 	);
 }
 
-// 좌측 라벨은 url 의 host 에서 추출. 예: github.com/... → GITHUB. 알 수 없으면 'LINK'.
-function deriveDirectLabel(social) {
-	try {
-		const host = new URL(social.url).host.toLowerCase();
-		const dotParts = host.split('.');
-		const root = dotParts.length >= 2 ? dotParts[dotParts.length - 2] : host;
-		return root.toUpperCase().slice(0, 10);
-	} catch {
-		return 'LINK';
-	}
-}
-
-function DirectRow({ label, href, external, children }) {
-	return (
-		<div className="flex items-center justify-between">
-			<span>{label}</span>
-			<a
-				href={href}
-				target={external ? '_blank' : undefined}
-				rel={external ? 'noopener noreferrer' : undefined}
-				className="bold-interactive transition-colors hover:text-[color:var(--paper)]"
-				style={{ color: 'var(--paper-dim)' }}
-			>
-				{children}
-			</a>
-		</div>
-	);
-}

--- a/apps/web/components/primitives/DirectLinkRow.jsx
+++ b/apps/web/components/primitives/DirectLinkRow.jsx
@@ -1,0 +1,37 @@
+// 좌측 host-라벨 + 우측 링크 한 줄. BoldContactSidebar (Direct 섹션) 와
+// BoldProjectDetailHero (Links 섹션) 두 곳에 거의 동일한 구현이 복사돼 있던
+// 것을 단일 primitive 로 통합.
+export default function DirectLinkRow({
+	label,
+	href,
+	external = true,
+	children,
+}) {
+	return (
+		<div className="flex items-center justify-between gap-3">
+			<span>{label}</span>
+			<a
+				href={href}
+				target={external ? '_blank' : undefined}
+				rel={external ? 'noopener noreferrer' : undefined}
+				className="bold-interactive transition-colors hover:text-[color:var(--paper)] truncate"
+				style={{ color: 'var(--paper-dim)' }}
+			>
+				{children}
+			</a>
+		</div>
+	);
+}
+
+// URL host 에서 root 도메인 추출 → 대문자 10자 cap. 예: github.com → GITHUB.
+// 파싱 실패 시 'LINK' 폴백.
+export function deriveLinkLabel(url) {
+	try {
+		const host = new URL(url).host.toLowerCase();
+		const parts = host.split('.');
+		const root = parts.length >= 2 ? parts[parts.length - 2] : host;
+		return root.toUpperCase().slice(0, 10);
+	} catch {
+		return 'LINK';
+	}
+}

--- a/apps/web/components/projects/bold/detail/BoldProjectDetailHero.jsx
+++ b/apps/web/components/projects/bold/detail/BoldProjectDetailHero.jsx
@@ -3,6 +3,9 @@ import Link from 'next/link';
 import Reveal from '../../../primitives/Reveal';
 import WordReveal from '../../../primitives/WordReveal';
 import Eyebrow from '../../../primitives/Eyebrow';
+import DirectLinkRow, {
+	deriveLinkLabel,
+} from '../../../primitives/DirectLinkRow';
 
 export default function BoldProjectDetailHero({
 	title,
@@ -118,8 +121,7 @@ export default function BoldProjectDetailHero({
 				</Reveal>
 			)}
 
-			{/* Links — admin 입력 외부 링크 (GitHub / Notion / Demo 등). 빈 배열이면 미렌더.
-			    Contact Sidebar 의 DirectRow 패턴 복사 (후속에 primitive lift 검토). */}
+			{/* Links — admin 입력 외부 링크 (GitHub / Notion / Demo 등). 빈 배열이면 미렌더. */}
 			{links.length > 0 && (
 				<Reveal
 					delay={0.28}
@@ -130,13 +132,13 @@ export default function BoldProjectDetailHero({
 					}}
 				>
 					{links.map((link) => (
-						<DirectRow
+						<DirectLinkRow
 							key={link.id ?? link.url}
 							label={deriveLinkLabel(link.url)}
 							href={link.url}
 						>
 							{link.label}
-						</DirectRow>
+						</DirectLinkRow>
 					))}
 				</Reveal>
 			)}
@@ -175,36 +177,6 @@ export default function BoldProjectDetailHero({
 // - accentWord 가 title 첫 토큰: accent / tail (2-line)
 // - accentWord 가 title 중간 토큰: head / accent / tail (3-line) — 시안 패턴
 // - accentWord 가 title 에 없거나 미지정: 마지막 토큰을 accent 로 폴백 (안전)
-// Contact Sidebar 의 DirectRow / deriveDirectLabel 패턴 그대로 복사 — 좌측 host
-// 라벨 자동 추출. 후속에 primitives/DirectLinkRow.jsx 로 lift 검토.
-function DirectRow({ label, href, children }) {
-	return (
-		<div className="flex items-center justify-between gap-3">
-			<span>{label}</span>
-			<a
-				href={href}
-				target="_blank"
-				rel="noopener noreferrer"
-				className="bold-interactive transition-colors hover:text-[color:var(--paper)] truncate"
-				style={{ color: 'var(--paper-dim)' }}
-			>
-				{children}
-			</a>
-		</div>
-	);
-}
-
-function deriveLinkLabel(url) {
-	try {
-		const host = new URL(url).host.toLowerCase();
-		const parts = host.split('.');
-		const root = parts.length >= 2 ? parts[parts.length - 2] : host;
-		return root.toUpperCase().slice(0, 10);
-	} catch {
-		return 'LINK';
-	}
-}
-
 function buildHeroItems(title, accentWord) {
 	const trimmed = (title ?? '').trim();
 	if (!trimmed) return [{ text: '' }];


### PR DESCRIPTION
## Summary

- \`apps/web/components/primitives/DirectLinkRow.jsx\` 신설 — \`DirectLinkRow\` + \`deriveLinkLabel\` named export
- \`BoldContactSidebar\` (Direct 섹션) / \`BoldProjectDetailHero\` (Links 섹션) 의 로컬 복사본 제거 → primitive import
- 스타일 통합: \`gap-3\` + \`truncate\` (Project 버전이 더 안전)

두 파일 모두 코멘트에 lift 검토 메모 존재했음.

## Test plan

- [x] \`npm --workspace apps/web run lint && build\` 그린
- [ ] dev-preview \`/contact\` sidebar Direct 섹션 EMAIL + socials 회귀
- [ ] dev-preview \`/projects/{slug}\` Hero links 행 회귀

Closes #130
Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)