### PR TITLE
[fix] admin-projects buildProject trim 중복 제거 (DTO transform 신뢰)

### DIFF
--- a/apps/api/src/modules/projects/admin-projects.service.spec.ts
+++ b/apps/api/src/modules/projects/admin-projects.service.spec.ts
@@ -145,6 +145,81 @@ describe('AdminProjectsService', () => {
       expect(dto.url).toBe('new-slug');
       expect(dto.id).toBe(10);
     });
+
+    it('buildProject: nullable 필드 (heroXxx / detail.kind|title / stat.sub / quote.author / quote 자체) 가 미입력이면 entity 에 null 저장', async () => {
+      projectRepo.findOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(baseProject({ id: 11, url: 'new-slug' }));
+
+      let captured: Project | undefined;
+      txManager.save.mockImplementation(async (_entity, project: Project) => {
+        captured = project;
+        return { ...project, id: 11 };
+      });
+
+      // ValidationPipe 의 @Transform(trimToNull) 가 이미 null 로 정규화한 상태를
+      // 모사 — 각 nullable 필드를 명시적 null 로 전달.
+      await service.create(
+        baseDto({
+          heroSubtitle: null,
+          heroAccentWord: null,
+          heroRole: null,
+          heroClient: null,
+          quote: null,
+          stats: [{ label: 'L', value: '1', sub: null }],
+          details: [{ kind: null, title: null, details: '본문' }],
+        }),
+      );
+
+      expect(captured).toBeDefined();
+      expect(captured!.heroSubtitle).toBeNull();
+      expect(captured!.heroAccentWord).toBeNull();
+      expect(captured!.heroRole).toBeNull();
+      expect(captured!.heroClient).toBeNull();
+      expect(captured!.quote).toBeNull();
+      expect(captured!.stats[0].sub).toBeNull();
+      expect(captured!.details[0].kind).toBeNull();
+      expect(captured!.details[0].title).toBeNull();
+    });
+
+    it('buildProject: 값이 있으면 그대로 entity 에 매핑 (DTO trim 신뢰)', async () => {
+      projectRepo.findOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(baseProject({ id: 12, url: 'new-slug' }));
+
+      let captured: Project | undefined;
+      txManager.save.mockImplementation(async (_entity, project: Project) => {
+        captured = project;
+        return { ...project, id: 12 };
+      });
+
+      await service.create(
+        baseDto({
+          heroSubtitle: '서브타이틀',
+          heroAccentWord: '시스템',
+          heroRole: '백엔드',
+          heroClient: 'ACME',
+          quote: { text: '인용', author: '저자' },
+          stats: [{ label: 'Latency', value: '170ms', sub: '단축' }],
+          details: [
+            { kind: 'DECISION', title: '결정사항', details: '본문' },
+          ],
+          links: [{ label: '@me', url: 'https://github.com/me' }],
+        }),
+      );
+
+      expect(captured!.heroSubtitle).toBe('서브타이틀');
+      expect(captured!.heroAccentWord).toBe('시스템');
+      expect(captured!.heroRole).toBe('백엔드');
+      expect(captured!.heroClient).toBe('ACME');
+      expect(captured!.quote?.text).toBe('인용');
+      expect(captured!.quote?.author).toBe('저자');
+      expect(captured!.stats[0].sub).toBe('단축');
+      expect(captured!.details[0].kind).toBe('DECISION');
+      expect(captured!.details[0].title).toBe('결정사항');
+      expect(captured!.links[0].label).toBe('@me');
+      expect(captured!.links[0].url).toBe('https://github.com/me');
+    });
   });
 
   describe('update', () => {

--- a/apps/api/src/modules/projects/admin-projects.service.ts
+++ b/apps/api/src/modules/projects/admin-projects.service.ts
@@ -176,6 +176,9 @@ export class AdminProjectsService {
   }
 }
 
+// DTO 의 @Transform(trimIfString / trimToNull) + class-validator 가 ValidationPipe
+// 단계에서 이미 trim + 빈 문자열 → null + IsNotEmpty 검증을 수행한다. buildProject
+// 는 이를 신뢰하고 단순 매핑만 — 중복 trim/truthy 체크 제거.
 function buildProject(dto: UpsertProjectDto): Project {
   const project = new Project();
   project.url = dto.url;
@@ -189,13 +192,10 @@ function buildProject(dto: UpsertProjectDto): Project {
   project.objectivesDetails = dto.objectivesDetails;
   project.projectDetailsHeading = dto.projectDetailsHeading;
   project.socialSharingHeading = dto.socialSharingHeading ?? '';
-  // Phase 2: 빈 문자열은 null 로 정규화 (DB nullable).
-  project.heroSubtitle = dto.heroSubtitle?.trim() ? dto.heroSubtitle : null;
-  project.heroAccentWord = dto.heroAccentWord?.trim()
-    ? dto.heroAccentWord
-    : null;
-  project.heroRole = dto.heroRole?.trim() ? dto.heroRole : null;
-  project.heroClient = dto.heroClient?.trim() ? dto.heroClient : null;
+  project.heroSubtitle = dto.heroSubtitle ?? null;
+  project.heroAccentWord = dto.heroAccentWord ?? null;
+  project.heroRole = dto.heroRole ?? null;
+  project.heroClient = dto.heroClient ?? null;
 
   project.images = dto.images.map((img, idx) => {
     const e = new ProjectImage();
@@ -228,45 +228,38 @@ function buildProject(dto: UpsertProjectDto): Project {
 
   project.details = dto.details.map((detail, idx) => {
     const e = new ProjectDetail();
-    // Phase 2 후속 — admin 명시 kind/title 은 trim 후 null 정규화. 미입력 entry 는
-    // web 의 parseProcessSteps 가 markdown h2 split 폴백으로 처리.
-    e.kind = detail.kind?.trim() ? detail.kind : null;
-    e.title = detail.title?.trim() ? detail.title : null;
+    e.kind = detail.kind ?? null;
+    e.title = detail.title ?? null;
     e.details = detail.details;
     e.sortOrder = idx;
     return e;
   });
 
-  // Phase 2: stats (OneToMany) — 입력 순서대로 sort_order 부여.
   project.stats = (dto.stats ?? []).map((stat, idx) => {
     const e = new ProjectStat();
     e.label = stat.label;
     e.value = stat.value;
-    e.sub = stat.sub?.trim() ? stat.sub : null;
+    e.sub = stat.sub ?? null;
     e.sortOrder = idx;
     return e;
   });
 
-  // Phase 2: quote (OneToOne) — text 비면 null.
-  if (dto.quote && dto.quote.text?.trim()) {
+  if (dto.quote) {
     const q = new ProjectQuote();
     q.text = dto.quote.text;
-    q.author = dto.quote.author?.trim() ? dto.quote.author : null;
+    q.author = dto.quote.author ?? null;
     project.quote = q;
   } else {
     project.quote = null;
   }
 
-  // Links (OneToMany) — label/url 둘 다 있어야 살림. 입력 순서대로 sortOrder.
-  project.links = (dto.links ?? [])
-    .filter((l) => l.label?.trim() && l.url?.trim())
-    .map((link, idx) => {
-      const e = new ProjectLink();
-      e.label = link.label.trim();
-      e.url = link.url.trim();
-      e.sortOrder = idx;
-      return e;
-    });
+  project.links = (dto.links ?? []).map((link, idx) => {
+    const e = new ProjectLink();
+    e.label = link.label;
+    e.url = link.url;
+    e.sortOrder = idx;
+    return e;
+  });
 
   return project;
 }


### PR DESCRIPTION
## Summary

\`UpsertProjectDto\` 의 \`@Transform(trimIfString / trimToNull)\` + class-validator \`@IsNotEmpty\` 가 ValidationPipe 단계에서 이미 trim + 빈 문자열 → null + required 검증을 끝낸다. \`buildProject\` 의 redundant truthy check / 재 trim / filter 제거.

- heroSubtitle / AccentWord / Role / Client: \`?? null\`
- ProjectDetail.kind / title: \`?? null\`
- ProjectStat.sub / ProjectQuote.author: \`?? null\`
- ProjectQuote: \`text\` 가 \`@IsNotEmpty\` 라 \`dto.quote\` 존재만 체크
- ProjectLink: 양쪽 \`@IsNotEmpty\` 라 filter + 재 trim 제거

spec 시나리오 2건 추가 (15 → 17 test):
- nullable 필드 전부 null 입력 → entity null 매핑
- 정상 값 입력 → entity 그대로 매핑

## Test plan

- [x] api 27 suite / 130 test 그린 (15 → 17 보강)
- [x] \`npm --workspace apps/api run lint && build\` 그린
- [ ] dev-preview admin 에서 프로젝트 한 번 저장 → DB 동일성 확인 (null 정규화 회귀 없음)

Closes #129
Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)