### PR TITLE
[chore] release-please bump-patch-for-minor-pre-major 제거 (semver 정상 흐름)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,7 @@
       "release-type": "node",
       "component": "portfolio-project",
       "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
## Summary

\`release-please-config.json\` 에서 \`bump-patch-for-minor-pre-major: true\` 제거.

\`bump-minor-pre-major: true\` 와 함께 켜두면 0.x.x 범위의 \`feat:\` commit 이 patch 로 강등 (0.1.4 → 0.1.5) 됨. 169개 누적 PR (Bold 리디자인 / About 확장 / Phase 2 등) 이 \`feat:\` 인데도 PR #69 가 0.1.5 로만 산출되던 원인.

옵션 제거 후 흐름:
- \`feat:\` → minor (0.1.x → 0.2.0)
- \`fix:\` → patch
- \`BREAKING CHANGE\` → 1.0.0 (pre-major 라 1.0 으로 점프)

main 머지 시 release-please workflow 가 재실행 → **PR #69 의 버전이 0.2.0 으로 자동 갱신**.

## 직행 base=main 사유

런타임에 영향 없는 release tooling 설정. dev 환경 검증 의미 없음. 메모리 \`portfolio-pr-base-rule\` 의 hot-fix 예외 조항 적용.

## Test plan

- [x] 설정 파일 단순 변경 (1 줄 제거)
- [ ] main 머지 → release.yml workflow 그린
- [ ] PR #69 의 title 이 \`chore(main): release portfolio-project 0.2.0\` 으로 갱신

🤖 Generated with [Claude Code](https://claude.com/claude-code)