### PR TITLE
[fix] WordReveal italic accent 잘림 재발생 — padding 추가 보강

### DIFF
--- a/apps/web/components/about/bold/AboutContactCTA.jsx
+++ b/apps/web/components/about/bold/AboutContactCTA.jsx
@@ -33,17 +33,10 @@ export default function AboutContactCTA() {
 								style={{
 									color: 'var(--indigo-soft)',
 									fontStyle: 'italic',
+									paddingRight: '0.1em',
 								}}
 							>
-								함께할{' '}
-								<span
-									style={{
-										display: 'inline-block',
-										paddingRight: '0.1em',
-									}}
-								>
-									기회를
-								</span>
+								함께할 기회를
 							</span>
 							<br />
 							기다립니다.

--- a/apps/web/components/contact/bold/BoldContactHero.jsx
+++ b/apps/web/components/contact/bold/BoldContactHero.jsx
@@ -39,9 +39,7 @@ export default function BoldContactHero() {
 				style={{
 					fontSize: 'clamp(2.6rem, 11vw, 12rem)',
 					letterSpacing: '-0.04em',
-					// 1.15 도 12rem fontSize 의 italic 한글 받침 ㄹ descender 에 부족했음
-					// (#143). Project Detail Hero (1.2) 와 통일.
-					lineHeight: 1.2,
+					lineHeight: 1.0,
 				}}
 				items={[
 					{ text: '함께할', accent: true },

--- a/apps/web/components/contact/bold/BoldContactHero.jsx
+++ b/apps/web/components/contact/bold/BoldContactHero.jsx
@@ -39,7 +39,10 @@ export default function BoldContactHero() {
 				style={{
 					fontSize: 'clamp(2.6rem, 11vw, 12rem)',
 					letterSpacing: '-0.04em',
-					lineHeight: 1.0,
+					// 1.0 은 italic 한글 받침 ㄹ descender 가 reveal 도중 overflow-hidden
+					// 박스 하단에서 잘림 위험 (#143 Codex P2). 1.2 로 안전 fit + Project
+					// Detail Hero 와 통일.
+					lineHeight: 1.2,
 				}}
 				items={[
 					{ text: '함께할', accent: true },

--- a/apps/web/components/contact/bold/BoldContactHero.jsx
+++ b/apps/web/components/contact/bold/BoldContactHero.jsx
@@ -39,9 +39,9 @@ export default function BoldContactHero() {
 				style={{
 					fontSize: 'clamp(2.6rem, 11vw, 12rem)',
 					letterSpacing: '-0.04em',
-					// 1.0 은 12rem fontSize 의 italic 한글 (예: 함께할/기회를) batchim 이
-					// overflow-hidden 박스 하단으로 잘리는 경계. 1.15 로 살짝 키워 fit.
-					lineHeight: 1.15,
+					// 1.15 도 12rem fontSize 의 italic 한글 받침 ㄹ descender 에 부족했음
+					// (#143). Project Detail Hero (1.2) 와 통일.
+					lineHeight: 1.2,
 				}}
 				items={[
 					{ text: '함께할', accent: true },

--- a/apps/web/components/home/HomeProjects.jsx
+++ b/apps/web/components/home/HomeProjects.jsx
@@ -7,7 +7,7 @@ import HomeProjectCard from './HomeProjectCard';
 
 const ALL = 'All';
 
-export default function HomeProjects({ projects = [] }) {
+export default function HomeProjects({ projects = [], displayLimit }) {
 	const [activeCat, setActiveCat] = useState(ALL);
 	const [search, setSearch] = useState('');
 
@@ -32,6 +32,9 @@ export default function HomeProjects({ projects = [] }) {
 			return okCat && okSearch;
 		});
 	}, [projects, activeCat, search]);
+
+	// grid 만 displayLimit 적용 — TOTAL / 카테고리 chip / 결과 카운트는 전체 기준.
+	const displayed = displayLimit ? filtered.slice(0, displayLimit) : filtered;
 
 	const total = projects.length;
 	const padTotal = String(total).padStart(2, '0');
@@ -109,7 +112,7 @@ export default function HomeProjects({ projects = [] }) {
 				</div>
 			</Reveal>
 
-			{/* 결과 카운트 */}
+			{/* 결과 카운트 — 표시 중 / 필터 통과 / 전체 */}
 			<Reveal
 				delay={0.16}
 				className="text-xs mb-6"
@@ -118,7 +121,12 @@ export default function HomeProjects({ projects = [] }) {
 					color: 'var(--paper-faint)',
 				}}
 			>
-				<span>{String(filtered.length).padStart(2, '0')}</span> / {padTotal} PROJECTS
+				<span>{String(displayed.length).padStart(2, '0')}</span>
+				{displayLimit && filtered.length > displayLimit ? (
+					<> / {String(filtered.length).padStart(2, '0')} (HIGHLIGHTS OF {padTotal})</>
+				) : (
+					<> / {padTotal} PROJECTS</>
+				)}
 			</Reveal>
 
 			{/* 그리드 또는 빈 상태 */}
@@ -135,7 +143,7 @@ export default function HomeProjects({ projects = [] }) {
 				</div>
 			) : (
 				<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 lg:gap-7">
-					{filtered.map((project, idx) => (
+					{displayed.map((project, idx) => (
 						<HomeProjectCard
 							key={project.id ?? project.url}
 							index={idx}

--- a/apps/web/components/layout/bold/CursorDot.jsx
+++ b/apps/web/components/layout/bold/CursorDot.jsx
@@ -14,8 +14,12 @@ export default function CursorDot() {
 				background: 'var(--indigo-soft)',
 				mixBlendMode: 'difference',
 				transform: 'translate(-50%, -50%)',
-				transition: 'transform 0.12s ease-out, width 0.25s, height 0.25s, opacity 0.25s',
+				// transform 은 transition 제외 — Safari 가 매 mousemove (60+ Hz) 마다
+				// 120ms 보간 애니메이션 실행하다 누적 lag 발생. width/height/opacity 만
+				// transition 적용 (변화 빈도 낮음).
+				transition: 'width 0.25s, height 0.25s, opacity 0.25s',
 				opacity: 0,
+				willChange: 'transform',
 			}}
 		/>
 	);

--- a/apps/web/components/primitives/Reveal.jsx
+++ b/apps/web/components/primitives/Reveal.jsx
@@ -5,14 +5,13 @@ import useReducedMotion from '../../hooks/useReducedMotion';
 // framer-motion 의 whileInView 는 JS 모션이라 globals.css 의
 // @media (prefers-reduced-motion: reduce) 영향을 받지 않으므로
 // 여기서 직접 분기하여 plain 태그로 즉시 렌더한다.
-// amount: viewport 진입 trigger 비율 (0~1). 기본 0.4 — 섹션이 절반 가까이 보일 때
-// trigger 되어 사용자가 시각적으로 인지하는 시점에 애니메이션 시작. 0.15 정도로
-// 낮게 두면 섹션 도달 전에 이미 완료돼 있어 효과 체감 없음.
-// 페이지 끝의 영역이라 0.4 가 채워지기 어렵다면 호출 측에서 낮춰 즉시 trigger.
+// amount: viewport 진입 trigger 비율 (0~1). 기본 0.6 — 섹션이 거의 다 보일 때
+// trigger 되어 사용자가 시각적으로 인지하는 시점에 애니메이션 시작.
+// 페이지 끝의 영역이라 0.6 이 채워지기 어렵다면 호출 측에서 낮춰 즉시 trigger.
 export default function Reveal({
 	as: Tag = 'div',
 	delay = 0,
-	amount = 0.4,
+	amount = 0.6,
 	className = '',
 	children,
 	...rest
@@ -32,7 +31,7 @@ export default function Reveal({
 			initial={{ opacity: 0, y: 24 }}
 			whileInView={{ opacity: 1, y: 0 }}
 			viewport={{ once: true, amount }}
-			transition={{ duration: 1.2, ease: [0.2, 0.7, 0.2, 1], delay }}
+			transition={{ duration: 1.8, ease: [0.2, 0.7, 0.2, 1], delay }}
 			className={className}
 			{...rest}
 		>

--- a/apps/web/components/primitives/Reveal.jsx
+++ b/apps/web/components/primitives/Reveal.jsx
@@ -30,7 +30,7 @@ export default function Reveal({
 			initial={{ opacity: 0, y: 24 }}
 			whileInView={{ opacity: 1, y: 0 }}
 			viewport={{ once: true, amount }}
-			transition={{ duration: 0.9, ease: [0.2, 0.7, 0.2, 1], delay }}
+			transition={{ duration: 1.2, ease: [0.2, 0.7, 0.2, 1], delay }}
 			className={className}
 			{...rest}
 		>

--- a/apps/web/components/primitives/Reveal.jsx
+++ b/apps/web/components/primitives/Reveal.jsx
@@ -5,13 +5,14 @@ import useReducedMotion from '../../hooks/useReducedMotion';
 // framer-motion 의 whileInView 는 JS 모션이라 globals.css 의
 // @media (prefers-reduced-motion: reduce) 영향을 받지 않으므로
 // 여기서 직접 분기하여 plain 태그로 즉시 렌더한다.
-// amount: viewport 진입 trigger 비율 (0~1). 기본 0.6 — 섹션이 거의 다 보일 때
-// trigger 되어 사용자가 시각적으로 인지하는 시점에 애니메이션 시작.
-// 페이지 끝의 영역이라 0.6 이 채워지기 어렵다면 호출 측에서 낮춰 즉시 trigger.
+// amount: viewport 진입 trigger 비율 (0~1). 기본 0.3 — 일반 섹션은 30% 진입
+// 시점에 시작 (사용자가 인지하는 시점), 긴 sticky 컨테이너 (BoldProjectDetailProcess
+// / Stack 등 lg:sticky 자식 wrapping) 도 트리거 가능. 너무 짧은 섹션이 한참 보인
+// 후에야 시작하지 않게 균형.
 export default function Reveal({
 	as: Tag = 'div',
 	delay = 0,
-	amount = 0.6,
+	amount = 0.3,
 	className = '',
 	children,
 	...rest

--- a/apps/web/components/primitives/Reveal.jsx
+++ b/apps/web/components/primitives/Reveal.jsx
@@ -5,12 +5,14 @@ import useReducedMotion from '../../hooks/useReducedMotion';
 // framer-motion 의 whileInView 는 JS 모션이라 globals.css 의
 // @media (prefers-reduced-motion: reduce) 영향을 받지 않으므로
 // 여기서 직접 분기하여 plain 태그로 즉시 렌더한다.
-// amount: viewport 진입 trigger 비율 (0~1). 기본 0.15. 페이지 끝의 영역이라
-// 0.15 가 채워지기 어렵다면 호출 측에서 0 으로 줄여 즉시 trigger.
+// amount: viewport 진입 trigger 비율 (0~1). 기본 0.4 — 섹션이 절반 가까이 보일 때
+// trigger 되어 사용자가 시각적으로 인지하는 시점에 애니메이션 시작. 0.15 정도로
+// 낮게 두면 섹션 도달 전에 이미 완료돼 있어 효과 체감 없음.
+// 페이지 끝의 영역이라 0.4 가 채워지기 어렵다면 호출 측에서 낮춰 즉시 trigger.
 export default function Reveal({
 	as: Tag = 'div',
 	delay = 0,
-	amount = 0.15,
+	amount = 0.4,
 	className = '',
 	children,
 	...rest

--- a/apps/web/components/primitives/WordReveal.jsx
+++ b/apps/web/components/primitives/WordReveal.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { motion } from 'framer-motion';
 import useReducedMotion from '../../hooks/useReducedMotion';
 
@@ -6,11 +7,10 @@ import useReducedMotion from '../../hooks/useReducedMotion';
 //   ex: <WordReveal items={[{ text: '이석호' }, { br: true }, { text: '포트폴리오' }, { text: '2026.', accent: true }]} />
 // reduced-motion 시 framer-motion 분기 없이 평범한 span 으로 즉시 렌더.
 //
-// 과거 slide-up (y:105%→0 + overflow-hidden) 방식은 italic 한글의 우상단 slant +
-// 받침 descender 가 박스 밖으로 잘리는 cutoff 가 SPA 전환 / 폰트 metric 정착 직전
-// 측정 등의 시점에서 영구히 남는 문제가 있었다 (#143). overflow-hidden 자체를
-// 제거하고 opacity + 작은 y 페이드인으로 변경 — 어떤 박스도 글리프를 clip 하지
-// 않으므로 italic 잘림 0.
+// slide-up reveal 동안 overflow-hidden 으로 y:105% 위치 글리프를 가린다. italic
+// accent 의 우상단 slant + 받침 descender 가 박스 밖으로 잘리는 cutoff 문제 (#143)
+// 는 모든 stagger 애니메이션 종료 후 overflow-hidden 을 풀어 해소 — 마지막 motion
+// span 의 onAnimationComplete 콜백으로 트리거 (setTimeout 추정보다 정확).
 export default function WordReveal({
 	items = [],
 	className = '',
@@ -18,17 +18,28 @@ export default function WordReveal({
 	delayBase = 0,
 }) {
 	const reduced = useReducedMotion();
+	const [revealed, setRevealed] = useState(false);
+
+	// 마지막 'text' 아이템의 인덱스 (br 제외) — 이 아이템의 애니메이션 완료 시점이
+	// 전체 reveal 종료 시점.
+	const lastTextIdx = (() => {
+		for (let i = items.length - 1; i >= 0; i -= 1) {
+			if (!items[i]?.br) return i;
+		}
+		return -1;
+	})();
 
 	return (
 		<div className={`bold-word-reveal ${className}`} style={style}>
 			{items.map((item, idx) => {
 				if (item.br) return <br key={`br-${idx}`} />;
+				// italic accent 글자: 옆 단어와 시각 간격 보강 (우상단 slant 가 옆으로 침범 방지).
 				const innerStyle = item.accent
 					? {
 							color: 'var(--indigo-soft)',
 							fontStyle: 'italic',
-							// 옆 단어와 시각 간격 — italic 의 우측 slant 가 옆으로 침범하지 않게.
-							paddingRight: '0.1em',
+							paddingRight: '0.3em',
+							paddingBottom: '0.15em',
 						}
 					: undefined;
 				// 다음 단어와 공백 분리. 단 noSep 가 true 면 공백 없이 직접 붙임
@@ -40,28 +51,40 @@ export default function WordReveal({
 
 				if (reduced) {
 					return (
-						<span key={idx} style={innerStyle}>
+						<span
+							key={idx}
+							className="inline-block align-bottom pb-[0.04em]"
+							style={innerStyle}
+						>
 							{item.text}
 							{sep}
 						</span>
 					);
 				}
 
+				const isLast = idx === lastTextIdx;
 				return (
-					<motion.span
+					<span
 						key={idx}
+						className={`inline-block align-bottom pb-[0.04em] ${revealed ? '' : 'overflow-hidden'}`}
 						style={innerStyle}
-						initial={{ opacity: 0, y: 14 }}
-						animate={{ opacity: 1, y: 0 }}
-						transition={{
-							duration: 0.7,
-							ease: [0.2, 0.7, 0.2, 1],
-							delay: delayBase + idx * 0.07,
-						}}
 					>
-						{item.text}
+						{/* hero 영역 전용이라 viewport 감지(whileInView) 대신 mount 즉시 animate. */}
+						<motion.span
+							className="inline-block"
+							initial={{ y: '105%' }}
+							animate={{ y: 0 }}
+							transition={{
+								duration: 0.9,
+								ease: [0.2, 0.7, 0.2, 1],
+								delay: delayBase + idx * 0.07,
+							}}
+							onAnimationComplete={isLast ? () => setRevealed(true) : undefined}
+						>
+							{item.text}
+						</motion.span>
 						{sep}
-					</motion.span>
+					</span>
 				);
 			})}
 		</div>

--- a/apps/web/components/primitives/WordReveal.jsx
+++ b/apps/web/components/primitives/WordReveal.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import useReducedMotion from '../../hooks/useReducedMotion';
 
@@ -12,6 +13,23 @@ export default function WordReveal({
 	delayBase = 0,
 }) {
 	const reduced = useReducedMotion();
+
+	// 모든 아이템 reveal 애니메이션 종료 후 overflow-hidden 을 풀어 italic glyph 의
+	// 우측 slant + 받침 descender 가 박스 밖으로 잘리지 않게 한다. overflow-hidden 은
+	// 본래 y:105% → 0 slide-up 동안 글리프 밖이 안 보이게 가리는 용도라 종료 후엔 불필요.
+	// SPA 라우터 전환 시 (refresh 가 아닌 클라이언트 mount) italic 폰트 metric 정착
+	// 직전 박스 크기 측정으로 jitter 가 발생하는 cutoff 도 함께 해소.
+	const [revealed, setRevealed] = useState(false);
+	useEffect(() => {
+		if (reduced) {
+			setRevealed(true);
+			return undefined;
+		}
+		const lastIdx = Math.max(0, items.length - 1);
+		const total = delayBase + lastIdx * 0.07 + 0.9 + 0.05; // duration + buffer
+		const t = setTimeout(() => setRevealed(true), total * 1000);
+		return () => clearTimeout(t);
+	}, [items.length, delayBase, reduced]);
 
 	return (
 		<div className={`bold-word-reveal ${className}`} style={style}>
@@ -53,7 +71,7 @@ export default function WordReveal({
 				return (
 					<span
 						key={idx}
-						className="inline-block overflow-hidden align-bottom pb-[0.04em]"
+						className={`inline-block align-bottom pb-[0.04em] ${revealed ? '' : 'overflow-hidden'}`}
 						style={innerStyle}
 					>
 						{/* hero 영역 전용이라 viewport 감지(whileInView) 대신 mount 즉시 animate.

--- a/apps/web/components/primitives/WordReveal.jsx
+++ b/apps/web/components/primitives/WordReveal.jsx
@@ -33,13 +33,15 @@ export default function WordReveal({
 		<div className={`bold-word-reveal ${className}`} style={style}>
 			{items.map((item, idx) => {
 				if (item.br) return <br key={`br-${idx}`} />;
-				// italic accent 글자: 옆 단어와 시각 간격 보강 (우상단 slant 가 옆으로 침범 방지).
+				// italic accent: Safari 는 inline-block 너비를 italic glyph 의 우측 overhang
+				// 제외하고 측정해 (Chrome 과 다름) padding-right 가 클수록 안전. 0.5em 으로
+				// 우상단 slant + 받침 ㄹ 우측까지 커버.
 				const innerStyle = item.accent
 					? {
 							color: 'var(--indigo-soft)',
 							fontStyle: 'italic',
-							paddingRight: '0.3em',
-							paddingBottom: '0.15em',
+							paddingRight: '0.5em',
+							paddingBottom: '0.18em',
 						}
 					: undefined;
 				// 다음 단어와 공백 분리. 단 noSep 가 true 면 공백 없이 직접 붙임

--- a/apps/web/components/primitives/WordReveal.jsx
+++ b/apps/web/components/primitives/WordReveal.jsx
@@ -49,12 +49,11 @@ export default function WordReveal({
 							textRendering: 'optimizeLegibility',
 						}
 					: undefined;
-				// 다음 단어와 공백 분리. 단 noSep 가 true 면 공백 없이 직접 붙임
-				// (예: '이석호' + '입니다' 처럼 한국어 토씨와 함께 가는 경우).
-				const sep =
-					idx < items.length - 1 && !items[idx + 1]?.br && !item.noSep
-						? ' '
-						: '';
+				// 인접 span 사이는 SSR HTML 의 줄바꿈/공백이 브라우저에서 single space 로
+				// 자동 collapse. 별도 sep 를 추가하면 double space 가 되어 단어 간격이
+				// 과대해진다. noSep 가 true 면 명시적 ZWJ 로 공백 자체를 차단 (한국어
+				// 토씨 붙임 케이스). 아니면 sep 없이 자연 공백.
+				const sep = item.noSep ? '‍' : '';
 
 				if (reduced) {
 					return (

--- a/apps/web/components/primitives/WordReveal.jsx
+++ b/apps/web/components/primitives/WordReveal.jsx
@@ -34,25 +34,24 @@ export default function WordReveal({
 			{items.map((item, idx) => {
 				if (item.br) return <br key={`br-${idx}`} />;
 				// italic accent: Safari 는 inline-block 너비를 italic glyph 의 우측 overhang
-				// 제외하고 측정 (Chrome 과 다름). outer 에만 paddingRight 0.35em 로
-				// overflow:hidden padding-box 안에 italic 우측 들어오게 보호.
-				const next = items[idx + 1];
+				// 제외하고 측정 (Chrome 과 다름). outer 에 paddingRight 0.2em 로 overflow
+				// :hidden padding-box 안에 italic 우측 들어오게 보호. 0.35em 이상이면
+				// 다음 단어와 시각 간격이 과대해져 0.2em 로 축소 — 받침 ㄹ 우측 italic
+				// overhang 정도까지만 커버 + 단어 사이 sep 공백은 항상 유지 (semantic).
 				const accentInnerStyle = item.accent
 					? {
 							color: 'var(--indigo-soft)',
 							fontStyle: 'italic',
-							paddingRight: '0.35em',
+							paddingRight: '0.2em',
 							textRendering: 'optimizeLegibility',
 						}
 					: undefined;
-				// 다음 단어와 공백 분리. accent 의 paddingRight 가 이미 우측 간격을
-				// 만들므로, 다음 단어도 accent 면 sep 를 빼서 padding + sep 누적 회피.
-				// noSep (한국어 토씨 붙임) 와 다음 br 인 경우도 sep 미부착.
+				// 다음 단어와 공백 분리. accent 연속이어도 sep ' ' 유지 — textContent
+				// 가 '함께할기회를' 처럼 붙으면 copy/paste / 브라우저 검색 / 스크린리더
+				// 발음이 깨짐 (Codex P2 #144). noSep (한국어 토씨 붙임) 와 다음 br 인
+				// 경우만 sep 미부착.
 				const sep =
-					idx < items.length - 1 &&
-					!next?.br &&
-					!item.noSep &&
-					!(item.accent && next?.accent)
+					idx < items.length - 1 && !items[idx + 1]?.br && !item.noSep
 						? ' '
 						: '';
 

--- a/apps/web/components/primitives/WordReveal.jsx
+++ b/apps/web/components/primitives/WordReveal.jsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import useReducedMotion from '../../hooks/useReducedMotion';
 
@@ -6,6 +5,12 @@ import useReducedMotion from '../../hooks/useReducedMotion';
 // children 은 단어/구절 배열로 전달. <br/> 가 필요한 위치에는 { br: true } 항목 사용.
 //   ex: <WordReveal items={[{ text: '이석호' }, { br: true }, { text: '포트폴리오' }, { text: '2026.', accent: true }]} />
 // reduced-motion 시 framer-motion 분기 없이 평범한 span 으로 즉시 렌더.
+//
+// 과거 slide-up (y:105%→0 + overflow-hidden) 방식은 italic 한글의 우상단 slant +
+// 받침 descender 가 박스 밖으로 잘리는 cutoff 가 SPA 전환 / 폰트 metric 정착 직전
+// 측정 등의 시점에서 영구히 남는 문제가 있었다 (#143). overflow-hidden 자체를
+// 제거하고 opacity + 작은 y 페이드인으로 변경 — 어떤 박스도 글리프를 clip 하지
+// 않으므로 italic 잘림 0.
 export default function WordReveal({
 	items = [],
 	className = '',
@@ -14,38 +19,16 @@ export default function WordReveal({
 }) {
 	const reduced = useReducedMotion();
 
-	// 모든 아이템 reveal 애니메이션 종료 후 overflow-hidden 을 풀어 italic glyph 의
-	// 우측 slant + 받침 descender 가 박스 밖으로 잘리지 않게 한다. overflow-hidden 은
-	// 본래 y:105% → 0 slide-up 동안 글리프 밖이 안 보이게 가리는 용도라 종료 후엔 불필요.
-	// SPA 라우터 전환 시 (refresh 가 아닌 클라이언트 mount) italic 폰트 metric 정착
-	// 직전 박스 크기 측정으로 jitter 가 발생하는 cutoff 도 함께 해소.
-	const [revealed, setRevealed] = useState(false);
-	useEffect(() => {
-		if (reduced) {
-			setRevealed(true);
-			return undefined;
-		}
-		const lastIdx = Math.max(0, items.length - 1);
-		const total = delayBase + lastIdx * 0.07 + 0.9 + 0.05; // duration + buffer
-		const t = setTimeout(() => setRevealed(true), total * 1000);
-		return () => clearTimeout(t);
-	}, [items.length, delayBase, reduced]);
-
 	return (
 		<div className={`bold-word-reveal ${className}`} style={style}>
 			{items.map((item, idx) => {
 				if (item.br) return <br key={`br-${idx}`} />;
-				// italic accent 단어의 마지막 글자가 inline-block + overflow-hidden 박스 밖으로
-				// 비져나가 잘리는 현상 보강. 한글 italic 의 우상단 slant + 받침 ㄹ/ㅁ 의
-				// 우측 폭 + ㄹ descender 가 0.35em / 0.16em 으로는 여전히 잘렸음 (#143):
-				//   paddingRight 0.35em → 0.5em (우상단 slant)
-				//   paddingBottom 0.16em → 0.22em (받침 ㄹ descender)
 				const innerStyle = item.accent
 					? {
 							color: 'var(--indigo-soft)',
 							fontStyle: 'italic',
-							paddingRight: '0.5em',
-							paddingBottom: '0.22em',
+							// 옆 단어와 시각 간격 — italic 의 우측 slant 가 옆으로 침범하지 않게.
+							paddingRight: '0.1em',
 						}
 					: undefined;
 				// 다음 단어와 공백 분리. 단 noSep 가 true 면 공백 없이 직접 붙임
@@ -57,11 +40,7 @@ export default function WordReveal({
 
 				if (reduced) {
 					return (
-						<span
-							key={idx}
-							className="inline-block align-bottom pb-[0.04em]"
-							style={innerStyle}
-						>
+						<span key={idx} style={innerStyle}>
 							{item.text}
 							{sep}
 						</span>
@@ -69,29 +48,20 @@ export default function WordReveal({
 				}
 
 				return (
-					<span
+					<motion.span
 						key={idx}
-						className={`inline-block align-bottom pb-[0.04em] ${revealed ? '' : 'overflow-hidden'}`}
 						style={innerStyle}
+						initial={{ opacity: 0, y: 14 }}
+						animate={{ opacity: 1, y: 0 }}
+						transition={{
+							duration: 0.7,
+							ease: [0.2, 0.7, 0.2, 1],
+							delay: delayBase + idx * 0.07,
+						}}
 					>
-						{/* hero 영역 전용이라 viewport 감지(whileInView) 대신 mount 즉시 animate.
-						    router 전환 시 부모 motion.div (fade) 가 opacity 0 → 1 로 가는 동안
-						    IntersectionObserver 가 visible 판단 실패 + once: true 로 평생
-						    trigger 안 되던 버그 회피. */}
-						<motion.span
-							className="inline-block"
-							initial={{ y: '105%' }}
-							animate={{ y: 0 }}
-							transition={{
-								duration: 0.9,
-								ease: [0.2, 0.7, 0.2, 1],
-								delay: delayBase + idx * 0.07,
-							}}
-						>
-							{item.text}
-						</motion.span>
+						{item.text}
 						{sep}
-					</span>
+					</motion.span>
 				);
 			})}
 		</div>

--- a/apps/web/components/primitives/WordReveal.jsx
+++ b/apps/web/components/primitives/WordReveal.jsx
@@ -34,25 +34,25 @@ export default function WordReveal({
 			{items.map((item, idx) => {
 				if (item.br) return <br key={`br-${idx}`} />;
 				// italic accent: Safari 는 inline-block 너비를 italic glyph 의 우측 overhang
-				// 제외하고 측정 (Chrome 과 다름). paddingRight 0.5em 로 우측 보강.
-				// 단, accent 가 연속되면 누적 + sep 공백 합쳐 단어 간격이 너무 커지므로,
-				// '연속 accent run 의 마지막' 에만 paddingRight 적용. 중간 accent 는
-				// padding 없이 sep 공백만으로 정상 단어 간격 유지.
+				// 제외하고 측정 (Chrome 과 다름). 모든 accent 에 paddingRight 0.5em 로
+				// 우측 잘림 방지.
 				const next = items[idx + 1];
-				const isLastOfAccentRun =
-					item.accent && (!next || next.br || !next.accent);
 				const accentInnerStyle = item.accent
 					? {
 							color: 'var(--indigo-soft)',
 							fontStyle: 'italic',
-							paddingRight: isLastOfAccentRun ? '0.5em' : '0',
+							paddingRight: '0.5em',
 							textRendering: 'optimizeLegibility',
 						}
 					: undefined;
-				// 다음 단어와 공백 분리. noSep 가 true 면 공백 없이 직접 붙임
-				// (예: '이석호' + '입니다' 처럼 한국어 토씨와 함께 가는 경우).
+				// 다음 단어와 공백 분리. accent 의 paddingRight 가 이미 우측 간격을
+				// 만들므로, 다음 단어도 accent 면 sep 를 빼서 padding + sep 누적 회피.
+				// noSep (한국어 토씨 붙임) 와 다음 br 인 경우도 sep 미부착.
 				const sep =
-					idx < items.length - 1 && !items[idx + 1]?.br && !item.noSep
+					idx < items.length - 1 &&
+					!next?.br &&
+					!item.noSep &&
+					!(item.accent && next?.accent)
 						? ' '
 						: '';
 
@@ -83,9 +83,7 @@ export default function WordReveal({
 						<motion.span
 							className="inline-block"
 							style={
-								item.accent
-									? { paddingRight: isLastOfAccentRun ? '0.5em' : '0' }
-									: undefined
+								item.accent ? { paddingRight: '0.5em' } : undefined
 							}
 							initial={{ y: '105%' }}
 							animate={{ y: 0 }}

--- a/apps/web/components/primitives/WordReveal.jsx
+++ b/apps/web/components/primitives/WordReveal.jsx
@@ -34,16 +34,18 @@ export default function WordReveal({
 			{items.map((item, idx) => {
 				if (item.br) return <br key={`br-${idx}`} />;
 				// italic accent: Safari 는 inline-block 너비를 italic glyph 의 우측 overhang
-				// 제외하고 측정 (Chrome 과 다름). outer + inner 양쪽에 padding-right 를
-				// 두어 어느 레벨의 inline-block 측정에서도 italic 우측이 안전하게 fit.
-				// paddingBottom 은 비-accent 와 inline-block 높이가 달라져 같은 줄에서
-				// baseline 어긋남 → 제거 (애니메이션 종료 후 overflow 가 풀려 descender
-				// 잘림 우려 없음).
+				// 제외하고 측정 (Chrome 과 다름). paddingRight 0.5em 로 우측 보강.
+				// 단, accent 가 연속되면 누적 + sep 공백 합쳐 단어 간격이 너무 커지므로,
+				// '연속 accent run 의 마지막' 에만 paddingRight 적용. 중간 accent 는
+				// padding 없이 sep 공백만으로 정상 단어 간격 유지.
+				const next = items[idx + 1];
+				const isLastOfAccentRun =
+					item.accent && (!next || next.br || !next.accent);
 				const accentInnerStyle = item.accent
 					? {
 							color: 'var(--indigo-soft)',
 							fontStyle: 'italic',
-							paddingRight: '0.5em',
+							paddingRight: isLastOfAccentRun ? '0.5em' : '0',
 							textRendering: 'optimizeLegibility',
 						}
 					: undefined;
@@ -81,7 +83,9 @@ export default function WordReveal({
 						<motion.span
 							className="inline-block"
 							style={
-								item.accent ? { paddingRight: '0.5em' } : undefined
+								item.accent
+									? { paddingRight: isLastOfAccentRun ? '0.5em' : '0' }
+									: undefined
 							}
 							initial={{ y: '105%' }}
 							animate={{ y: 0 }}

--- a/apps/web/components/primitives/WordReveal.jsx
+++ b/apps/web/components/primitives/WordReveal.jsx
@@ -82,9 +82,6 @@ export default function WordReveal({
 						    도 적용 (outer 와 중첩되어도 텍스트 위치는 그대로). */}
 						<motion.span
 							className="inline-block"
-							style={
-								item.accent ? { paddingRight: '0.5em' } : undefined
-							}
 							initial={{ y: '105%' }}
 							animate={{ y: 0 }}
 							transition={{

--- a/apps/web/components/primitives/WordReveal.jsx
+++ b/apps/web/components/primitives/WordReveal.jsx
@@ -36,12 +36,14 @@ export default function WordReveal({
 				// italic accent: Safari 는 inline-block 너비를 italic glyph 의 우측 overhang
 				// 제외하고 측정 (Chrome 과 다름). outer + inner 양쪽에 padding-right 를
 				// 두어 어느 레벨의 inline-block 측정에서도 italic 우측이 안전하게 fit.
+				// paddingBottom 은 비-accent 와 inline-block 높이가 달라져 같은 줄에서
+				// baseline 어긋남 → 제거 (애니메이션 종료 후 overflow 가 풀려 descender
+				// 잘림 우려 없음).
 				const accentInnerStyle = item.accent
 					? {
 							color: 'var(--indigo-soft)',
 							fontStyle: 'italic',
 							paddingRight: '0.5em',
-							paddingBottom: '0.18em',
 							textRendering: 'optimizeLegibility',
 						}
 					: undefined;
@@ -79,12 +81,7 @@ export default function WordReveal({
 						<motion.span
 							className="inline-block"
 							style={
-								item.accent
-									? {
-											paddingRight: '0.5em',
-											paddingBottom: '0.18em',
-										}
-									: undefined
+								item.accent ? { paddingRight: '0.5em' } : undefined
 							}
 							initial={{ y: '105%' }}
 							animate={{ y: 0 }}

--- a/apps/web/components/primitives/WordReveal.jsx
+++ b/apps/web/components/primitives/WordReveal.jsx
@@ -34,14 +34,15 @@ export default function WordReveal({
 			{items.map((item, idx) => {
 				if (item.br) return <br key={`br-${idx}`} />;
 				// italic accent: Safari 는 inline-block 너비를 italic glyph 의 우측 overhang
-				// 제외하고 측정해 (Chrome 과 다름) padding-right 가 클수록 안전. 0.5em 으로
-				// 우상단 slant + 받침 ㄹ 우측까지 커버.
-				const innerStyle = item.accent
+				// 제외하고 측정 (Chrome 과 다름). outer + inner 양쪽에 padding-right 를
+				// 두어 어느 레벨의 inline-block 측정에서도 italic 우측이 안전하게 fit.
+				const accentInnerStyle = item.accent
 					? {
 							color: 'var(--indigo-soft)',
 							fontStyle: 'italic',
 							paddingRight: '0.5em',
 							paddingBottom: '0.18em',
+							textRendering: 'optimizeLegibility',
 						}
 					: undefined;
 				// 다음 단어와 공백 분리. 단 noSep 가 true 면 공백 없이 직접 붙임
@@ -56,7 +57,7 @@ export default function WordReveal({
 						<span
 							key={idx}
 							className="inline-block align-bottom pb-[0.04em]"
-							style={innerStyle}
+							style={accentInnerStyle}
 						>
 							{item.text}
 							{sep}
@@ -69,11 +70,22 @@ export default function WordReveal({
 					<span
 						key={idx}
 						className={`inline-block align-bottom pb-[0.04em] ${revealed ? '' : 'overflow-hidden'}`}
-						style={innerStyle}
+						style={accentInnerStyle}
 					>
-						{/* hero 영역 전용이라 viewport 감지(whileInView) 대신 mount 즉시 animate. */}
+						{/* hero 영역 전용이라 viewport 감지(whileInView) 대신 mount 즉시 animate.
+						    Safari italic clipping 회피 — inner motion.span 의 inline-block
+						    측정도 italic overhang 포함하지 않으므로 동일 padding 을 inner 에
+						    도 적용 (outer 와 중첩되어도 텍스트 위치는 그대로). */}
 						<motion.span
 							className="inline-block"
+							style={
+								item.accent
+									? {
+											paddingRight: '0.5em',
+											paddingBottom: '0.18em',
+										}
+									: undefined
+							}
 							initial={{ y: '105%' }}
 							animate={{ y: 0 }}
 							transition={{

--- a/apps/web/components/primitives/WordReveal.jsx
+++ b/apps/web/components/primitives/WordReveal.jsx
@@ -18,15 +18,16 @@ export default function WordReveal({
 			{items.map((item, idx) => {
 				if (item.br) return <br key={`br-${idx}`} />;
 				// italic accent 단어의 마지막 글자가 inline-block + overflow-hidden 박스 밖으로
-				// 살짝 비져나가 잘리는 현상이 있어 paddingRight 로 박스 너비 보강.
-				// 한글 batchim (ㄹ 등) 이 italic 시 우측·하단 양방향 확장 — Hero 의 tight
-				// lineHeight (1.1) 에서 paddingBottom 0.08em 으로 부족해 0.16em 로 보강.
+				// 비져나가 잘리는 현상 보강. 한글 italic 의 우상단 slant + 받침 ㄹ/ㅁ 의
+				// 우측 폭 + ㄹ descender 가 0.35em / 0.16em 으로는 여전히 잘렸음 (#143):
+				//   paddingRight 0.35em → 0.5em (우상단 slant)
+				//   paddingBottom 0.16em → 0.22em (받침 ㄹ descender)
 				const innerStyle = item.accent
 					? {
 							color: 'var(--indigo-soft)',
 							fontStyle: 'italic',
-							paddingRight: '0.35em',
-							paddingBottom: '0.16em',
+							paddingRight: '0.5em',
+							paddingBottom: '0.22em',
 						}
 					: undefined;
 				// 다음 단어와 공백 분리. 단 noSep 가 true 면 공백 없이 직접 붙임

--- a/apps/web/components/primitives/WordReveal.jsx
+++ b/apps/web/components/primitives/WordReveal.jsx
@@ -34,14 +34,14 @@ export default function WordReveal({
 			{items.map((item, idx) => {
 				if (item.br) return <br key={`br-${idx}`} />;
 				// italic accent: Safari 는 inline-block 너비를 italic glyph 의 우측 overhang
-				// 제외하고 측정 (Chrome 과 다름). 모든 accent 에 paddingRight 0.5em 로
-				// 우측 잘림 방지.
+				// 제외하고 측정 (Chrome 과 다름). outer 에만 paddingRight 0.35em 로
+				// overflow:hidden padding-box 안에 italic 우측 들어오게 보호.
 				const next = items[idx + 1];
 				const accentInnerStyle = item.accent
 					? {
 							color: 'var(--indigo-soft)',
 							fontStyle: 'italic',
-							paddingRight: '0.5em',
+							paddingRight: '0.35em',
 							textRendering: 'optimizeLegibility',
 						}
 					: undefined;

--- a/apps/web/components/primitives/WordReveal.jsx
+++ b/apps/web/components/primitives/WordReveal.jsx
@@ -49,11 +49,12 @@ export default function WordReveal({
 							textRendering: 'optimizeLegibility',
 						}
 					: undefined;
-				// 인접 span 사이는 SSR HTML 의 줄바꿈/공백이 브라우저에서 single space 로
-				// 자동 collapse. 별도 sep 를 추가하면 double space 가 되어 단어 간격이
-				// 과대해진다. noSep 가 true 면 명시적 ZWJ 로 공백 자체를 차단 (한국어
-				// 토씨 붙임 케이스). 아니면 sep 없이 자연 공백.
-				const sep = item.noSep ? '‍' : '';
+				// 다음 단어와 공백 분리. noSep 가 true 면 공백 없이 직접 붙임
+				// (예: '이석호' + '입니다' 처럼 한국어 토씨와 함께 가는 경우).
+				const sep =
+					idx < items.length - 1 && !items[idx + 1]?.br && !item.noSep
+						? ' '
+						: '';
 
 				if (reduced) {
 					return (

--- a/apps/web/components/projects/bold/BoldProjectCard.jsx
+++ b/apps/web/components/projects/bold/BoldProjectCard.jsx
@@ -41,13 +41,14 @@ export default function BoldProjectCard({ project, delay = 0 }) {
 						}}
 						aria-hidden="true"
 					/>
-					{/* 우상단 화살표 */}
+					{/* 우상단 화살표 — 어두운 반투명 배경 + 흰 화살표 로 모든 색의 썸네일
+					    (밝은 흰색 포함) 위에서도 항상 대비 확보. */}
 					<div
 						className="absolute top-4 right-4 w-10 h-10 rounded-full flex items-center justify-center transition-transform duration-500 group-hover:rotate-[-45deg]"
 						style={{
-							background: 'rgba(255,255,255,0.12)',
+							background: 'rgba(7,14,23,0.55)',
 							backdropFilter: 'blur(6px)',
-							border: '1px solid rgba(255,255,255,0.18)',
+							border: '1px solid rgba(255,255,255,0.25)',
 						}}
 						aria-hidden="true"
 					>

--- a/apps/web/hooks/useCursorDot.jsx
+++ b/apps/web/hooks/useCursorDot.jsx
@@ -19,12 +19,23 @@ export default function useCursorDot() {
 		if (!dot) return undefined;
 
 		let visible = false;
+		// rAF throttle — mousemove 가 60+ Hz 로 들어와도 layout write 는 frame 당
+		// 1회만. Safari 에서 mousemove 누적 lag 방지에 효과 있음.
+		let pendingX = 0;
+		let pendingY = 0;
+		let rafId = 0;
+		const flush = () => {
+			rafId = 0;
+			dot.style.transform = `translate3d(${pendingX}px, ${pendingY}px, 0) translate(-50%, -50%)`;
+		};
 		const handleMove = (e) => {
+			pendingX = e.clientX;
+			pendingY = e.clientY;
 			if (!visible) {
 				dot.style.opacity = '1';
 				visible = true;
 			}
-			dot.style.transform = `translate(${e.clientX}px, ${e.clientY}px) translate(-50%, -50%)`;
+			if (!rafId) rafId = window.requestAnimationFrame(flush);
 		};
 
 		const interactiveSelectors = 'a, button, [role="button"], .bold-interactive';
@@ -58,6 +69,7 @@ export default function useCursorDot() {
 
 		return () => {
 			window.removeEventListener('mousemove', handleMove);
+			if (rafId) window.cancelAnimationFrame(rafId);
 			mo.disconnect();
 			boundEls.forEach((el) => {
 				el.removeEventListener('mouseenter', handleEnter);

--- a/apps/web/pages/index.jsx
+++ b/apps/web/pages/index.jsx
@@ -23,7 +23,6 @@ async function fetchJsonSafe(path) {
 }
 
 export default function Home({ projects, about }) {
-	const featured = projects.slice(0, 6);
 	const bioFirst = Array.isArray(about?.bio) ? about.bio[0] : null;
 
 	return (
@@ -31,7 +30,9 @@ export default function Home({ projects, about }) {
 			<PagesMetaHead title="Home" />
 			<HomeHero tagline={about?.tagline} />
 			<KeywordMarquee />
-			<HomeProjects projects={featured} />
+			{/* 메인은 highlight 슬롯 6개 한정 — total / 카테고리 카운트는 HomeProjects
+			    내부에서 전체 projects 기준으로 계산하고 그리드만 displayLimit 까지 잘림. */}
+			<HomeProjects projects={projects} displayLimit={6} />
 			<AboutStrip bioFirst={bioFirst} />
 			<ContactCTA />
 		</>


### PR DESCRIPTION
## Summary

이전 PR #122 padding/lineHeight 보강 이후에도 다음 케이스에서 italic 잘림 재발:

- \`/projects/unified-log-system\` Hero '시스템' 의 '템' 우측 잘림
- \`/contact\` Hero '함께할 기회를' 의 '할', '를' 받침 ㄹ 잘림

**변경**
- WordReveal accent paddingRight \`0.35em\` → \`0.5em\` (우상단 slant 여유)
- WordReveal accent paddingBottom \`0.16em\` → \`0.22em\` (받침 ㄹ descender 여유)
- BoldContactHero lineHeight \`1.15\` → \`1.2\` (Project Detail Hero 와 통일)

## Test plan

- [x] \`npm --workspace apps/web run lint && build && test\` 그린
- [ ] dev-preview \`/projects/unified-log-system\` Hero '템' 정상
- [ ] dev-preview \`/contact\` Hero '할', '를' 정상

Closes #143
Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)