### PR TITLE
[fix] Projects 페이지 카피 다듬기 (Hero / Marquee / CTA)

### DIFF
--- a/apps/web/components/projects/bold/BoldProjectsCTA.jsx
+++ b/apps/web/components/projects/bold/BoldProjectsCTA.jsx
@@ -31,7 +31,7 @@ export default function BoldProjectsCTA() {
 
 			<Reveal delay={0.16} className="mt-12">
 				<PillButton href="/contact" variant="cta" ariaLabel="문의하기로 이동">
-					<span>메일로 시작하기</span>
+					<span>메일로 연락하기</span>
 					<svg
 						className="w-4 h-4"
 						viewBox="0 0 24 24"

--- a/apps/web/components/projects/bold/BoldProjectsCTA.jsx
+++ b/apps/web/components/projects/bold/BoldProjectsCTA.jsx
@@ -11,7 +11,7 @@ export default function BoldProjectsCTA() {
 			style={{ borderColor: 'var(--line)' }}
 		>
 			<Reveal className="mb-6">
-				<Eyebrow>— Have a project?</Eyebrow>
+				<Eyebrow>— Let&apos;s work together</Eyebrow>
 			</Reveal>
 
 			<WordReveal
@@ -21,7 +21,12 @@ export default function BoldProjectsCTA() {
 					letterSpacing: '-0.04em',
 					lineHeight: 1.0,
 				}}
-				items={[{ text: '같이' }, { text: '만들어요.', accent: true }]}
+				items={[
+					{ text: '함께할', accent: true },
+					{ text: '기회를', accent: true },
+					{ br: true },
+					{ text: '기다립니다.' },
+				]}
 			/>
 
 			<Reveal delay={0.16} className="mt-12">

--- a/apps/web/components/projects/bold/BoldProjectsHero.jsx
+++ b/apps/web/components/projects/bold/BoldProjectsHero.jsx
@@ -42,7 +42,7 @@ export default function BoldProjectsHero({ totalCount, categoryCount, yearCount 
 					letterSpacing: '-0.04em',
 					lineHeight: 1.0,
 				}}
-				items={[{ text: '모든' }, { br: true }, { text: '프로젝트들.', accent: true }]}
+				items={[{ text: '전체' }, { br: true }, { text: '프로젝트.', accent: true }]}
 			/>
 
 			{/* tagline */}
@@ -56,7 +56,7 @@ export default function BoldProjectsHero({ totalCount, categoryCount, yearCount 
 					letterSpacing: '-0.02em',
 				}}
 			>
-				직접 만들고 함께 완성한 프로젝트들.
+				만들고 개선하며,
 				<br />
 				문제를 해결해 온 기록입니다.
 			</Reveal>

--- a/apps/web/components/projects/bold/BoldProjectsMarquee.jsx
+++ b/apps/web/components/projects/bold/BoldProjectsMarquee.jsx
@@ -16,7 +16,7 @@ const DEFAULT_KEYWORDS = [
 	'Docker',
 	'AWS',
 	'CI/CD',
-	'AI · LLM',
+	'AI/LLM',
 ];
 
 export default function BoldProjectsMarquee({ items = DEFAULT_KEYWORDS }) {


### PR DESCRIPTION
## Summary

\`/projects\` 페이지 카피 일괄 다듬기:

- Hero 타이틀: \`모든 / 프로젝트들.\` → \`전체 / 프로젝트.\`
- Hero 설명: 압축 — \`만들고 개선하며, / 문제를 해결해 온 기록입니다.\`
- Marquee 키워드: \`AI · LLM\` → \`AI/LLM\`
- CTA Eyebrow: \`— Have a project?\` → \`— Let's work together\`
- CTA 타이틀: \`같이 만들어요.\` → \`함께할 기회를 / 기다립니다.\` (Contact 페이지 통일)
- CTA 버튼: \`메일로 시작하기\` → \`메일로 연락하기\`

## Test plan

- [x] web lint + build 그린
- [ ] dev-preview \`/projects\` Hero / Marquee / CTA 시각 확인

Closes #148
Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)